### PR TITLE
browserWindow: option to autohide cursor on OSX

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -125,6 +125,9 @@ class NativeWindowMac : public NativeWindow {
   // used in custom drag to compute the window movement.
   NSPoint last_mouse_offset_;
 
+  // Enable hiding cursor during keyboard event until mouse moves.
+  bool auto_hide_cursor_;
+
   DISALLOW_COPY_AND_ASSIGN(NativeWindowMac);
 };
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -365,6 +365,9 @@ NativeWindowMac::NativeWindowMac(content::WebContents* web_contents,
     [window_ setCollectionBehavior:collectionBehavior];
   }
 
+  // AutoHideCursor when is specified to true
+  options.Get(switches::kAutoHideCursor, &auto_hide_cursor_);
+
   NSView* view = inspectable_web_contents()->GetView()->GetNativeView();
   [view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
 
@@ -738,6 +741,8 @@ void NativeWindowMac::HandleKeyboardEvent(
   if (event.skip_in_browser ||
       event.type == content::NativeWebKeyboardEvent::Char)
     return;
+
+  [NSCursor setHiddenUntilMouseMoves:auto_hide_cursor_];
 
   if (event.os_event.window == window_.get()) {
     EventProcessingWindow* event_window =

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -39,6 +39,9 @@ const char kNodeIntegration[] = "node-integration";
 // Enable the NSView to accept first mouse event.
 const char kAcceptFirstMouse[] = "accept-first-mouse";
 
+// Enable NSCursor to hide until mouse moves.
+const char kAutoHideCursor[] = "auto-hide-cursor";
+
 // Whether window size should include window frame.
 const char kUseContentSize[] = "use-content-size";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -24,6 +24,7 @@ extern const char kMaxWidth[];
 extern const char kMaxHeight[];
 extern const char kResizable[];
 extern const char kFullscreen[];
+extern const char kAutoHideCursor[];
 extern const char kSkipTaskbar[];
 extern const char kKiosk[];
 extern const char kAlwaysOnTop[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -43,6 +43,8 @@ You can also create a window without chrome by using
      other windows
   * `fullscreen` Boolean - Whether the window should show in fullscreen, when
     set to `false` the fullscreen button would also be hidden on OS X
+  * `auto-hide-cursor` Boolean - Whether the cursor should be hidden during
+    keyboard events on **OSX**
   * `skip-taskbar` Boolean - Do not show window in Taskbar
   * `zoom-factor` Number - The default zoom factor of the page, zoom factor is
     zoom percent / 100, so `3.0` represents `300%`


### PR DESCRIPTION
fixes #995 , not sure of the purpose for enabling this unless,  the developer can specify keycodes as options array. any thoughts ? 