### PR TITLE
renderer: implementing HTML5 fullscreen api

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -699,10 +699,22 @@ bool NativeWindow::OnMessageReceived(const IPC::Message& message) {
   IPC_BEGIN_MESSAGE_MAP(NativeWindow, message)
     IPC_MESSAGE_HANDLER(AtomViewHostMsg_UpdateDraggableRegions,
                         UpdateDraggableRegions)
+    IPC_MESSAGE_HANDLER(AtomViewHostMsg_ToggleFullscreen,
+                        ToggleFullscreen)
     IPC_MESSAGE_UNHANDLED(handled = false)
   IPC_END_MESSAGE_MAP()
 
   return handled;
+}
+
+void NativeWindow::ToggleFullscreen(bool enter_fullscreen) {
+  content::WebContents* contents = GetWebContents();
+  RenderWidgetHostView* const view = contents->GetRenderWidgetHostView();
+  RenderWidgetHost* const host = view ? view->GetRenderWidgetHost() : nullptr;
+  if (!host)
+    return;
+  SetFullScreen(enter_fullscreen);
+  host->WasResized();
 }
 
 void NativeWindow::Observe(int type,

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -96,6 +96,9 @@ class NativeWindow : public brightray::DefaultWebContentsDelegate,
 
   void InitFromOptions(const mate::Dictionary& options);
 
+  // renderer triggered fullscreen mode
+  void ToggleFullscreen(bool enter_fullscreen);
+
   virtual void Close() = 0;
   virtual void CloseImmediately() = 0;
   virtual void Move(const gfx::Rect& pos) = 0;

--- a/atom/common/api/api_messages.h
+++ b/atom/common/api/api_messages.h
@@ -37,3 +37,7 @@ IPC_MESSAGE_ROUTED2(AtomViewMsg_Message,
 // Sent by the renderer when the draggable regions are updated.
 IPC_MESSAGE_ROUTED1(AtomViewHostMsg_UpdateDraggableRegions,
                     std::vector<atom::DraggableRegion> /* regions */)
+
+// Sent by the renderer when toggling fullscreen mode
+IPC_MESSAGE_ROUTED1(AtomViewHostMsg_ToggleFullscreen,
+                    bool /* enter_fullscreen */)

--- a/atom/renderer/atom_render_view_observer.cc
+++ b/atom/renderer/atom_render_view_observer.cc
@@ -91,6 +91,16 @@ void AtomRenderViewObserver::DraggableRegionsChanged(blink::WebFrame* frame) {
   Send(new AtomViewHostMsg_UpdateDraggableRegions(routing_id(), regions));
 }
 
+bool AtomRenderViewObserver::enterFullscreen() {
+  Send(new AtomViewHostMsg_ToggleFullscreen(routing_id(), true));
+  return true;
+}
+
+bool AtomRenderViewObserver::exitFullscreen() {
+  Send(new AtomViewHostMsg_ToggleFullscreen(routing_id(), false));
+  return true;
+}
+
 bool AtomRenderViewObserver::OnMessageReceived(const IPC::Message& message) {
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(AtomRenderViewObserver, message)

--- a/atom/renderer/atom_render_view_observer.h
+++ b/atom/renderer/atom_render_view_observer.h
@@ -7,6 +7,7 @@
 
 #include "base/strings/string16.h"
 #include "content/public/renderer/render_view_observer.h"
+#include "third_party/WebKit/public/web/WebFrameClient.h"
 
 namespace base {
 class ListValue;
@@ -16,7 +17,8 @@ namespace atom {
 
 class AtomRendererClient;
 
-class AtomRenderViewObserver : public content::RenderViewObserver {
+class AtomRenderViewObserver : public content::RenderViewObserver,
+                               public blink::WebFrameClient {
  public:
   explicit AtomRenderViewObserver(content::RenderView* render_view,
                                   AtomRendererClient* renderer_client);
@@ -32,6 +34,9 @@ class AtomRenderViewObserver : public content::RenderViewObserver {
 
   void OnBrowserMessage(const base::string16& channel,
                         const base::ListValue& args);
+  // blink::WebFrameClient implementation.
+  bool enterFullscreen() override;
+  bool exitFullscreen() override;
 
   // Weak reference to renderer client.
   AtomRendererClient* renderer_client_;


### PR DESCRIPTION
initial work for #1314 based on the process described [here](https://code.google.com/p/chromium/issues/detail?id=466854&q=enterfullscreenmodefortab&colspec=ID%20Pri%20M%20Week%20ReleaseBlock%20Cr%20Status%20Owner%20Summary%20OS%20Modified) doesnt work yet. 

/cc @zcbenz 