### PR TITLE
pm: throw when initialising module before ready event

### DIFF
--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -4,6 +4,7 @@
 
 #include "atom/browser/api/atom_api_power_monitor.h"
 
+#include "atom/browser/browser.h"
 #include "base/power_monitor/power_monitor.h"
 #include "base/power_monitor/power_monitor_device_source.h"
 #include "native_mate/dictionary.h"
@@ -38,8 +39,14 @@ void PowerMonitor::OnResume() {
 }
 
 // static
-mate::Handle<PowerMonitor> PowerMonitor::Create(v8::Isolate* isolate) {
-  return CreateHandle(isolate, new PowerMonitor);
+v8::Handle<v8::Value> PowerMonitor::Create(v8::Isolate* isolate) {
+  if (!Browser::Get()->is_ready()) {
+    node::ThrowError("Cannot initialize \"power-monitor\" module"
+                      "before app is ready");
+    return v8::Null(isolate);
+  }
+
+  return CreateHandle(isolate, new PowerMonitor).ToV8();
 }
 
 }  // namespace api
@@ -57,9 +64,8 @@ void Initialize(v8::Handle<v8::Object> exports, v8::Handle<v8::Value> unused,
 
   using atom::api::PowerMonitor;
   v8::Isolate* isolate = context->GetIsolate();
-  mate::Handle<PowerMonitor> power_monitor = PowerMonitor::Create(isolate);
   mate::Dictionary dict(isolate, exports);
-  dict.Set("powerMonitor", power_monitor);
+  dict.Set("powerMonitor", PowerMonitor::Create(isolate));
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_power_monitor.h
+++ b/atom/browser/api/atom_api_power_monitor.h
@@ -17,7 +17,7 @@ namespace api {
 class PowerMonitor : public mate::EventEmitter,
                      public base::PowerObserver {
  public:
-  static mate::Handle<PowerMonitor> Create(v8::Isolate* isolate);
+  static v8::Handle<v8::Value> Create(v8::Isolate* isolate);
 
  protected:
   PowerMonitor();


### PR DESCRIPTION
related #1421 , weird doesnt throw but continues to initialise as `undefined` .