### PR TITLE
Add electron-prebuilt npm instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ editor](https://github.com/atom/atom).
 Prebuilt binaries and debug symbols of Electron for Linux, Windows and Mac can
 be found on the [releases](https://github.com/atom/electron/releases) page.
 
+You can also use [`npm`](https://docs.npmjs.com/) to install prebuilt electron
+binaries:
+
+```
+# Install the `electron` command globally in your $PATH
+npm install electron-prebuilt -g
+
+# Install as a development dependency
+npm install electron-prebuilt --save-dev
+```
+
 ### Mirrors
 
 - [China](https://npm.taobao.org/mirrors/atom-shell)


### PR DESCRIPTION
We updated the name of our `atom-shell` module on npm to `electron-prebuilt`. It installs a binary called `electron`. Published 0.24.0 to npm here https://www.npmjs.com/package/electron-prebuilt and added @zcbenz as a npm owner just in case