### PR TITLE
webview: page-favicon-updated navigation event and getFavicon api

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -4,6 +4,8 @@
 
 #include "atom/browser/api/atom_api_web_contents.h"
 
+#include <set>
+
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/native_window.h"
 #include "atom/browser/web_dialog_helper.h"

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -310,8 +310,6 @@ void WebContents::WebContentsDestroyed() {
 
 void WebContents::NavigationEntryCommitted(
     const content::LoadCommittedDetails& load_details) {
-  if (load_details.is_navigation_to_different_page())
-    Emit("did-navigate");
   auto entry = web_contents()->GetController().GetLastCommittedEntry();
   entry->SetVirtualURL(load_details.entry->GetOriginalRequestURL());
 }
@@ -400,8 +398,7 @@ gfx::Image WebContents::GetFavicon() const {
   auto entry = web_contents()->GetController().GetLastCommittedEntry();
   if (!entry)
     return gfx::Image();
-  auto favicon_status = entry->GetFavicon();
-  return favicon_status.image;
+  return entry->GetFavicon().image;
 }
 
 bool WebContents::IsLoading() const {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -256,6 +256,19 @@ void WebContents::TitleWasSet(content::NavigationEntry* entry,
   Emit("page-title-set", entry->GetTitle(), explicit_set);
 }
 
+void WebContents::DidUpdateFaviconURL(
+    const std::vector<content::FaviconURL>& urls) {
+  std::set<GURL> unique_urls;
+  for (auto iter = urls.begin(); iter != urls.end(); ++iter) {
+    if (iter->icon_type != content::FaviconURL::FAVICON)
+      continue;
+    const GURL& url = iter->icon_url;
+    if (url.is_valid())
+      unique_urls.insert(url);
+  }
+  Emit("page-favicon-set", unique_urls);
+}
+
 bool WebContents::OnMessageReceived(const IPC::Message& message) {
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(WebContents, message)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -6,10 +6,13 @@
 #define ATOM_BROWSER_API_ATOM_API_WEB_CONTENTS_H_
 
 #include <string>
+#include <vector>
+#include <set>
 
 #include "atom/browser/api/event_emitter.h"
 #include "brightray/browser/default_web_contents_delegate.h"
 #include "content/public/browser/browser_plugin_guest_delegate.h"
+#include "content/public/common/favicon_url.h"
 #include "content/public/browser/web_contents_delegate.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "native_mate/handle.h"
@@ -175,6 +178,8 @@ class WebContents : public mate::EventEmitter,
   void NavigationEntryCommitted(
       const content::LoadCommittedDetails& load_details) override;
   void TitleWasSet(content::NavigationEntry* entry, bool explicit_set) override;
+  void DidUpdateFaviconURL(
+      const std::vector<content::FaviconURL>& urls) override;
 
   // content::BrowserPluginGuestDelegate:
   void DidAttach(int guest_proxy_routing_id) final;

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <vector>
+#include <set>
 
 #include "atom/browser/api/event_emitter.h"
 #include "brightray/browser/default_web_contents_delegate.h"

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -16,6 +16,7 @@
 #include "content/public/browser/web_contents_delegate.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "native_mate/handle.h"
+#include "ui/gfx/image/image.h"
 
 namespace brightray {
 class InspectableWebContents;
@@ -49,6 +50,7 @@ class WebContents : public mate::EventEmitter,
   void LoadURL(const GURL& url, const mate::Dictionary& options);
   GURL GetURL() const;
   base::string16 GetTitle() const;
+  gfx::Image GetFavicon() const;
   bool IsLoading() const;
   bool IsWaitingForResponse() const;
   void Stop();

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -7,7 +7,6 @@
 
 #include <string>
 #include <vector>
-#include <set>
 
 #include "atom/browser/api/event_emitter.h"
 #include "brightray/browser/default_web_contents_delegate.h"

--- a/atom/browser/lib/guest-view-manager.coffee
+++ b/atom/browser/lib/guest-view-manager.coffee
@@ -6,6 +6,7 @@ supportedWebViewEvents = [
   'did-finish-load'
   'did-fail-load'
   'did-frame-finish-load'
+  'did-navigate'
   'did-start-loading'
   'did-stop-loading'
   'did-get-response-details'
@@ -16,7 +17,7 @@ supportedWebViewEvents = [
   'crashed'
   'destroyed'
   'page-title-set'
-  'page-favicon-set'
+  'page-favicon-updated'
 ]
 
 nextInstanceId = 0

--- a/atom/browser/lib/guest-view-manager.coffee
+++ b/atom/browser/lib/guest-view-manager.coffee
@@ -6,7 +6,6 @@ supportedWebViewEvents = [
   'did-finish-load'
   'did-fail-load'
   'did-frame-finish-load'
-  'did-navigate'
   'did-start-loading'
   'did-stop-loading'
   'did-get-response-details'

--- a/atom/browser/lib/guest-view-manager.coffee
+++ b/atom/browser/lib/guest-view-manager.coffee
@@ -16,6 +16,7 @@ supportedWebViewEvents = [
   'crashed'
   'destroyed'
   'page-title-set'
+  'page-favicon-set'
 ]
 
 nextInstanceId = 0

--- a/atom/renderer/lib/web-view/guest-view-internal.coffee
+++ b/atom/renderer/lib/web-view/guest-view-internal.coffee
@@ -7,6 +7,7 @@ WEB_VIEW_EVENTS =
   'did-finish-load': []
   'did-fail-load': ['errorCode', 'errorDescription']
   'did-frame-finish-load': ['isMainFrame']
+  'did-navigate': []
   'did-start-loading': []
   'did-stop-loading': []
   'did-get-response-details': ['status', 'newUrl', 'originalUrl',
@@ -18,7 +19,7 @@ WEB_VIEW_EVENTS =
   'crashed': []
   'destroyed': []
   'page-title-set': ['title', 'explicitSet']
-  'page-favicon-set': ['favicons']
+  'page-favicon-updated': ['favicons']
 
 dispatchEvent = (webView, event, args...) ->
   throw new Error("Unkown event #{event}") unless WEB_VIEW_EVENTS[event]?

--- a/atom/renderer/lib/web-view/guest-view-internal.coffee
+++ b/atom/renderer/lib/web-view/guest-view-internal.coffee
@@ -18,6 +18,7 @@ WEB_VIEW_EVENTS =
   'crashed': []
   'destroyed': []
   'page-title-set': ['title', 'explicitSet']
+  'page-favicon-set': ['favicons']
 
 dispatchEvent = (webView, event, args...) ->
   throw new Error("Unkown event #{event}") unless WEB_VIEW_EVENTS[event]?

--- a/atom/renderer/lib/web-view/guest-view-internal.coffee
+++ b/atom/renderer/lib/web-view/guest-view-internal.coffee
@@ -7,7 +7,6 @@ WEB_VIEW_EVENTS =
   'did-finish-load': []
   'did-fail-load': ['errorCode', 'errorDescription']
   'did-frame-finish-load': ['isMainFrame']
-  'did-navigate': []
   'did-start-loading': []
   'did-stop-loading': []
   'did-get-response-details': ['status', 'newUrl', 'originalUrl',

--- a/atom/renderer/lib/web-view/web-view-attributes.coffee
+++ b/atom/renderer/lib/web-view/web-view-attributes.coffee
@@ -154,6 +154,14 @@ class SrcAttribute extends WebViewAttribute
        not @.getValue()
       return
 
+    domEvent = new Event('will-navigate')
+    domEvent['url'] = @getValue()
+    domEvent.cancelable = true
+    self = @
+    domEvent.preventDefault = () ->
+      self.setValueIgnoreMutation ''
+    @webViewImpl.webviewNode.dispatchEvent domEvent
+
     unless @webViewImpl.guestInstanceId?
       if @webViewImpl.beforeFirstNavigation
         @webViewImpl.beforeFirstNavigation = false
@@ -161,9 +169,10 @@ class SrcAttribute extends WebViewAttribute
       return
 
     # Navigate to |this.src|.
-    httpreferrer = @webViewImpl.attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER].getValue()
-    urlOptions = if httpreferrer then {httpreferrer} else {}
-    remote.getGuestWebContents(@webViewImpl.guestInstanceId).loadUrl @getValue(), urlOptions
+    if @getValue()
+      httpreferrer = @webViewImpl.attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER].getValue()
+      urlOptions = if httpreferrer then {httpreferrer} else {}
+      remote.getGuestWebContents(@webViewImpl.guestInstanceId).loadUrl @getValue(), urlOptions
 
 # Attribute specifies HTTP referrer.
 class HttpReferrerAttribute extends WebViewAttribute

--- a/atom/renderer/lib/web-view/web-view-attributes.coffee
+++ b/atom/renderer/lib/web-view/web-view-attributes.coffee
@@ -154,6 +154,7 @@ class SrcAttribute extends WebViewAttribute
        not @.getValue()
       return
 
+    # Allow users to cancel webview navigation.
     domEvent = new Event('will-navigate')
     domEvent['url'] = @getValue()
     domEvent.cancelable = true

--- a/atom/renderer/lib/web-view/web-view-attributes.coffee
+++ b/atom/renderer/lib/web-view/web-view-attributes.coffee
@@ -154,14 +154,6 @@ class SrcAttribute extends WebViewAttribute
        not @.getValue()
       return
 
-    # Allow users to cancel webview navigation.
-    domEvent = new Event('will-navigate')
-    domEvent['url'] = @getValue()
-    domEvent.cancelable = true
-    domEvent.preventDefault = () =>
-      @setValueIgnoreMutation ''
-    @webViewImpl.webviewNode.dispatchEvent domEvent
-
     unless @webViewImpl.guestInstanceId?
       if @webViewImpl.beforeFirstNavigation
         @webViewImpl.beforeFirstNavigation = false
@@ -169,10 +161,9 @@ class SrcAttribute extends WebViewAttribute
       return
 
     # Navigate to |this.src|.
-    if @getValue()
-      httpreferrer = @webViewImpl.attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER].getValue()
-      urlOptions = if httpreferrer then {httpreferrer} else {}
-      remote.getGuestWebContents(@webViewImpl.guestInstanceId).loadUrl @getValue(), urlOptions
+    httpreferrer = @webViewImpl.attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER].getValue()
+    urlOptions = if httpreferrer then {httpreferrer} else {}
+    remote.getGuestWebContents(@webViewImpl.guestInstanceId).loadUrl @getValue(), urlOptions
 
 # Attribute specifies HTTP referrer.
 class HttpReferrerAttribute extends WebViewAttribute

--- a/atom/renderer/lib/web-view/web-view-attributes.coffee
+++ b/atom/renderer/lib/web-view/web-view-attributes.coffee
@@ -158,9 +158,8 @@ class SrcAttribute extends WebViewAttribute
     domEvent = new Event('will-navigate')
     domEvent['url'] = @getValue()
     domEvent.cancelable = true
-    self = @
-    domEvent.preventDefault = () ->
-      self.setValueIgnoreMutation ''
+    domEvent.preventDefault = () =>
+      @setValueIgnoreMutation ''
     @webViewImpl.webviewNode.dispatchEvent domEvent
 
     unless @webViewImpl.guestInstanceId?

--- a/atom/renderer/lib/web-view/web-view.coffee
+++ b/atom/renderer/lib/web-view/web-view.coffee
@@ -236,7 +236,6 @@ registerWebViewElement = ->
   methods = [
     "getUrl"
     "getTitle"
-    "getFavicon"
     "isLoading"
     "isWaitingForResponse"
     "stop"
@@ -276,6 +275,13 @@ registerWebViewElement = ->
       internal = v8Util.getHiddenValue this, 'internal'
       remote.getGuestWebContents(internal.guestInstanceId)[m]  args...
   proto[m] = createHandler m for m in methods
+
+  # Return dataUrl instead of nativeImage.
+  proto.getFavicon = (args...) ->
+    internal = v8Util.getHiddenValue this, 'internal'
+    return unless internal
+    favicon = remote.getGuestWebContents(internal.guestInstanceId)['getFavicon'] args...
+    favicon.toDataUrl()
 
   window.WebView = webFrame.registerEmbedderCustomElement 'webview',
     prototype: proto

--- a/atom/renderer/lib/web-view/web-view.coffee
+++ b/atom/renderer/lib/web-view/web-view.coffee
@@ -236,6 +236,7 @@ registerWebViewElement = ->
   methods = [
     "getUrl"
     "getTitle"
+    "getFavicon"
     "isLoading"
     "isWaitingForResponse"
     "stop"

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -671,7 +671,7 @@ Emitted when a redirect was received while requesting a resource.
 ### Event: 'page-favicon-updated'
 
 * `event` Event
-* `favicons` [String]
+* `favicons` Array - Array of Urls
 
 Emitted when page receives favicon urls.
 
@@ -728,7 +728,7 @@ Returns the title of web page.
 
 ### WebContents.getFavicon()
 
-Returns the favicon of web page as `nativeImage`.
+Returns the favicon of web page as [NativeImage](native-image.md).
 
 ### WebContents.isLoading()
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -632,6 +632,12 @@ cancelled, e.g. `window.stop()` is invoked.
 
 Emitted when a frame has done navigation.
 
+### Event: 'did-navigate'
+
+* `event` Event
+
+Emitted when a frame navigation has been committed to history.
+
 ### Event: 'did-start-loading'
 
 Corresponds to the points in time when the spinner of the tab starts spinning.
@@ -662,7 +668,7 @@ Emitted when details regarding a requested resource is available.
 
 Emitted when a redirect was received while requesting a resource.
 
-### Event: 'page-favicon-set'
+### Event: 'page-favicon-updated'
 
 * `event` Event
 * `favicons` [String]
@@ -719,6 +725,10 @@ Returns URL of current web page.
 ### WebContents.getTitle()
 
 Returns the title of web page.
+
+### WebContents.getFavicon()
+
+Returns the favicon of web page as `nativeImage`.
 
 ### WebContents.isLoading()
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -632,12 +632,6 @@ cancelled, e.g. `window.stop()` is invoked.
 
 Emitted when a frame has done navigation.
 
-### Event: 'did-navigate'
-
-* `event` Event
-
-Emitted when a frame navigation has been committed to history.
-
 ### Event: 'did-start-loading'
 
 Corresponds to the points in time when the spinner of the tab starts spinning.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -662,6 +662,13 @@ Emitted when details regarding a requested resource is available.
 
 Emitted when a redirect was received while requesting a resource.
 
+### Event: 'page-favicon-set'
+
+* `event` Event
+* `favicons` [String]
+
+Emitted when page receives favicon urls.
+
 ### Event: 'new-window'
 
 * `event` Event

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -279,13 +279,6 @@ examples.
 
 ## DOM events
 
-### will-navigate
-
-* `url` String
-
-Fired when view is about to navigate , calling `event.preventDefault()` will
-cancel the navigation.
-
 ### did-finish-load
 
 Fired when the navigation is done, i.e. the spinner of the tab will stop
@@ -304,10 +297,6 @@ cancelled, e.g. `window.stop()` is invoked.
 * `isMainFrame` Boolean
 
 Fired when a frame has done navigation.
-
-### did-navigate
-
-Fired when a frame navigation has been committed to history.
 
 ### did-start-loading
 

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -275,6 +275,13 @@ examples.
 
 ## DOM events
 
+### will-navigate
+
+* `url` String
+
+Fired when view is about to navigate , calling `event.preventDefault()` will
+cancel the navigation.
+
 ### did-finish-load
 
 Fired when the navigation is done, i.e. the spinner of the tab will stop
@@ -329,6 +336,12 @@ Fired when a redirect was received while requesting a resource.
 
 Fired when page title is set during navigation. `explicitSet` is false when title is synthesised from file
 url.
+
+### page-favicon-set
+
+* `favicons` [String]
+
+Fired when page receives favicon urls.
 
 ### console-message
 

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -132,7 +132,7 @@ Returns the title of guest page.
 
 ### `<webview>`.getFavicon()
 
-Returns the favicon of guest page as `nativeImage`.
+Returns the favicon of guest page as dataUrl.
 
 ### `<webview>`.isLoading()
 
@@ -347,7 +347,7 @@ url.
 
 ### page-favicon-updated
 
-* `favicons` [String]
+* `favicons` Array - Array of Urls
 
 Fired when page receives favicon urls.
 

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -130,6 +130,10 @@ Returns URL of guest page.
 
 Returns the title of guest page.
 
+### `<webview>`.getFavicon()
+
+Returns the favicon of guest page as `nativeImage`.
+
 ### `<webview>`.isLoading()
 
 Returns whether guest page is still loading resources.
@@ -301,6 +305,10 @@ cancelled, e.g. `window.stop()` is invoked.
 
 Fired when a frame has done navigation.
 
+### did-navigate
+
+Fired when a frame navigation has been committed to history.
+
 ### did-start-loading
 
 Corresponds to the points in time when the spinner of the tab starts spinning.
@@ -337,7 +345,7 @@ Fired when a redirect was received while requesting a resource.
 Fired when page title is set during navigation. `explicitSet` is false when title is synthesised from file
 url.
 
-### page-favicon-set
+### page-favicon-updated
 
 * `favicons` [String]
 

--- a/spec/fixtures/pages/a.html
+++ b/spec/fixtures/pages/a.html
@@ -1,4 +1,6 @@
 <html>
+<link rel="icon" type="image/png" href="/favicon.png"/>
+<link rel="icon" type="image/png" href="http://test.com/favicon.png"/>
 <body>
 <script type="text/javascript" charset="utf-8">
   console.log('a');

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -152,19 +152,6 @@ describe '<webview> tag', ->
       webview.src = "file://#{fixtures}/pages/a.html"
       document.body.appendChild webview
 
-  describe 'will-navigate event', ->
-    it 'is emitted before navigation', (done) ->
-      view = new WebView
-      view.addEventListener 'will-navigate', (e) ->
-        e.preventDefault()
-        assert.equal webview.src, ''
-      view.addEventListener 'did-navigate', (e) ->
-        document.body.removeChild view
-        done()
-      view.src = "file://#{fixtures}/pages/a.html"
-      document.body.appendChild view
-      document.body.appendChild webview
-
   describe 'page-favicon-updated event', ->
     it 'emits when favicon urls are received', (done) ->
       webview.addEventListener 'page-favicon-updated', (e) ->

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -151,3 +151,21 @@ describe '<webview> tag', ->
         done()
       webview.src = "file://#{fixtures}/pages/a.html"
       document.body.appendChild webview
+
+  describe 'will-navigate event', ->
+    it 'is emitted before navigation', (done) ->
+      webview.addEventListener 'will-navigate', (e) ->
+        e.preventDefault()
+        assert.equal webview.src, ''
+        done()
+      webview.src = "file://#{fixtures}/pages/a.html"
+      document.body.appendChild webview
+
+  describe 'page-favicon-set event', ->
+    it 'emits when favicon is set', (done) ->
+      webview.addEventListener 'page-favicon-set', (e) ->
+        assert.equal e.favicons.length, 2
+        assert.equal e.favicons[0], 'file:///favicon.png'
+        done()
+      webview.src = "file://#{fixtures}/pages/a.html"
+      document.body.appendChild webview

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -154,16 +154,20 @@ describe '<webview> tag', ->
 
   describe 'will-navigate event', ->
     it 'is emitted before navigation', (done) ->
-      webview.addEventListener 'will-navigate', (e) ->
+      view = new WebView
+      view.addEventListener 'will-navigate', (e) ->
         e.preventDefault()
         assert.equal webview.src, ''
+      view.addEventListener 'did-navigate', (e) ->
+        document.body.removeChild view
         done()
-      webview.src = "file://#{fixtures}/pages/a.html"
+      view.src = "file://#{fixtures}/pages/a.html"
+      document.body.appendChild view
       document.body.appendChild webview
 
-  describe 'page-favicon-set event', ->
-    it 'emits when favicon is set', (done) ->
-      webview.addEventListener 'page-favicon-set', (e) ->
+  describe 'page-favicon-updated event', ->
+    it 'emits when favicon urls are received', (done) ->
+      webview.addEventListener 'page-favicon-updated', (e) ->
         assert.equal e.favicons.length, 2
         assert.equal e.favicons[0], 'file:///favicon.png'
         done()


### PR DESCRIPTION
Related #1378 and #1079 , not quite sure on how to achieve the various mutations for `page-url-set`. @zcbenz any clue on why the test for `will-navigate` gets called for `spec/index.html` too ?

Depends on https://github.com/zcbenz/native-mate/pull/1