### PR TITLE
updated bash path to ./Electron.app/Contents/MacOS/Electron

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -149,7 +149,7 @@ $ ./electron/electron your-app/
 On OS X:
 
 ```bash
-$ ./Electron.app/Contents/MacOS/Atom your-app/
+$ ./Electron.app/Contents/MacOS/Electron your-app/
 ```
 
 `Electron.app` here is part of the Electron's release package, you can download


### PR DESCRIPTION
it had the trailing /Atom which no longer exists