### PR TITLE
Provide an optional way to explicitly set the AppUserModelID

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -229,7 +229,7 @@ mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(
       .SetMethod("setPath", &App::SetPath)
       .SetMethod("getPath", &App::GetPath)
       .SetMethod("resolveProxy", &App::ResolveProxy)
-      .SetMethod("setDesktopName", &App::SetDesktopName);
+      .SetMethod("setDesktopName", &App::SetDesktopName)
       .SetMethod("setAppUserModelId", &App::SetAppUserModelId);
 }
 

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -200,6 +200,13 @@ void App::SetDesktopName(const std::string& desktop_name) {
 #endif
 }
 
+void App::SetAppUserModelId(const std::string& app_id) {
+#if defined(OS_WIN)
+  base::string16 app_id_utf16 = base::UTF8ToUTF16(app_id);
+  SetCurrentProcessExplicitAppUserModelID(app_id_utf16.c_str());
+#endif
+}
+
 mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
   auto browser = base::Unretained(Browser::Get());
@@ -223,6 +230,7 @@ mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(
       .SetMethod("getPath", &App::GetPath)
       .SetMethod("resolveProxy", &App::ResolveProxy)
       .SetMethod("setDesktopName", &App::SetDesktopName);
+      .SetMethod("setAppUserModelId", &App::SetAppUserModelId);
 }
 
 // static

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -61,6 +61,7 @@ class App : public mate::EventEmitter,
 
   void ResolveProxy(const GURL& url, ResolveProxyCallback callback);
   void SetDesktopName(const std::string& desktop_name);
+  void SetAppUserModelId(const std::string& app_id);
 
   DISALLOW_COPY_AND_ASSIGN(App);
 };


### PR DESCRIPTION
When Squirrel sets up shortcuts, it creates them with an explicit AppUserModelID based on the app's package name. Since Electron sets up a _different_ AppUserModelID, this results in Weirdness - most notably, it means that in the tray visibility settings, we start seeing >1 entry for apps:

![](http://cl.ly/image/1f2H072Y1s3W/content#png)

We set the original prefix in the init.coffee so that apps that don't explicitly override `setName` don't see any changes:

## TODO

- [x] Make sure this actually work