### PR TITLE
Add help menu to default app

### DIFF
--- a/atom/browser/default_app/default_app.js
+++ b/atom/browser/default_app/default_app.js
@@ -149,6 +149,10 @@ app.on('ready', function() {
         label: 'Help',
         submenu: [
           {
+            label: 'Learn More',
+            click: function() { require('shell').openExternal('http://electron.atom.io') }
+          },
+          {
             label: 'Documentation',
             click: function() { require('shell').openExternal('https://github.com/atom/electron/tree/master/docs#readme') }
           },
@@ -205,6 +209,10 @@ app.on('ready', function() {
       {
         label: 'Help',
         submenu: [
+          {
+            label: 'Learn More',
+            click: function() { require('shell').openExternal('http://electron.atom.io') }
+          },
           {
             label: 'Documentation',
             click: function() { require('shell').openExternal('https://github.com/atom/electron/tree/master/docs#readme') }

--- a/atom/browser/default_app/default_app.js
+++ b/atom/browser/default_app/default_app.js
@@ -112,11 +112,12 @@ app.on('ready', function() {
             click: function() { mainWindow.restart(); }
           },
           {
-            label: 'Enter Fullscreen',
-            click: function() { mainWindow.setFullScreen(true); }
+            label: 'Toggle Full Screen',
+            accelerator: 'Ctrl+Command+F',
+            click: function() { mainWindow.setFullScreen(!mainWindow.isFullScreen()); }
           },
           {
-            label: 'Toggle DevTools',
+            label: 'Toggle Developer Tools',
             accelerator: 'Alt+Command+I',
             click: function() { mainWindow.toggleDevTools(); }
           },
@@ -173,11 +174,12 @@ app.on('ready', function() {
             click: function() { mainWindow.restart(); }
           },
           {
-            label: '&Enter Fullscreen',
-            click: function() { mainWindow.setFullScreen(true); }
+            label: 'Toggle &Full Screen',
+            accelerator: 'F11',
+            click: function() { mainWindow.setFullScreen(!mainWindow.isFullScreen()); }
           },
           {
-            label: '&Toggle DevTools',
+            label: 'Toggle &Developer Tools',
             accelerator: 'Alt+Ctrl+I',
             click: function() { mainWindow.toggleDevTools(); }
           },

--- a/atom/browser/default_app/default_app.js
+++ b/atom/browser/default_app/default_app.js
@@ -145,6 +145,23 @@ app.on('ready', function() {
           },
         ]
       },
+      {
+        label: 'Help',
+        submenu: [
+          {
+            label: 'Documentation',
+            click: function() { require('shell').openExternal('https://github.com/atom/electron/tree/master/docs#readme') }
+          },
+          {
+            label: 'Community Discussions',
+            click: function() { require('shell').openExternal('https://discuss.atom.io/c/electron') }
+          },
+          {
+            label: 'Search Issues',
+            click: function() { require('shell').openExternal('https://github.com/atom/electron/issues') }
+          }
+        ]
+      }
     ];
 
     menu = Menu.buildFromTemplate(template);
@@ -185,6 +202,23 @@ app.on('ready', function() {
           },
         ]
       },
+      {
+        label: 'Help',
+        submenu: [
+          {
+            label: 'Documentation',
+            click: function() { require('shell').openExternal('https://github.com/atom/electron/tree/master/docs#readme') }
+          },
+          {
+            label: 'Community Discussions',
+            click: function() { require('shell').openExternal('https://discuss.atom.io/c/electron') }
+          },
+          {
+            label: 'Search Issues',
+            click: function() { require('shell').openExternal('https://github.com/atom/electron/issues') }
+          }
+        ]
+      }
     ];
 
     menu = Menu.buildFromTemplate(template);

--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -66,7 +66,8 @@ if (option.file && !option.webdriver) {
 } else if (option.help) {
   var helpMessage = "Electron v" + process.versions.electron + " - Cross Platform Desktop Application Shell\n\n";
   helpMessage    += "Usage: electron [options] [path]\n\n";
-  helpMessage    += "Specify a path to the Electron app to open\n\n";
+  helpMessage    += "A path to an Electron application may be specified. The path must be to \n";
+  helpMessage    += "an index.js file or to a folder containing a package.json or index.js file.\n\n";
   helpMessage    += "Options:\n";
   helpMessage    += "  -h, --help            Print this usage message.\n";
   helpMessage    += "  -v, --version         Print the version.";

--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -11,10 +11,13 @@ app.on('window-all-closed', function() {
 
 // Parse command line options.
 var argv = process.argv.slice(1);
-var option = { file: null, version: null, webdriver: null };
+var option = { file: null, help: null, version: null, webdriver: null };
 for (var i in argv) {
   if (argv[i] == '--version' || argv[i] == '-v') {
     option.version = true;
+    break;
+  } else if (argv[i] == '--help' || argv[i] == '-h') {
+    option.help = true;
     break;
   } else if (argv[i] == '--test-type=webdriver') {
     option.webdriver = true;
@@ -58,7 +61,16 @@ if (option.file && !option.webdriver) {
     }
   }
 } else if (option.version) {
-  console.log('v' + process.versions['electron']);
+  console.log('v' + process.versions.electron);
+  process.exit(0);
+} else if (option.help) {
+  var helpMessage = "Electron v" + process.versions.electron + " - Cross Platform Desktop Application Shell\n\n";
+  helpMessage    += "Usage: electron [options] [path]\n\n";
+  helpMessage    += "Specify a path to the Electron app to open\n\n";
+  helpMessage    += "Options:\n";
+  helpMessage    += "  -h, --help            Print this usage message.\n";
+  helpMessage    += "  -v, --version         Print the version.";
+  console.log(helpMessage);
   process.exit(0);
 } else {
   require('./default_app.js');


### PR DESCRIPTION
Also adds `-h/--help` to the command line.

The goal here it just to doc things a bit more and provide some useful links typically found in Help menus.