### PR TITLE
Add `Super` key support in global-shortcut API.

### DIFF
--- a/atom/browser/ui/accelerator_util.cc
+++ b/atom/browser/ui/accelerator_util.cc
@@ -109,8 +109,12 @@ bool StringToAccelerator(const std::string& description,
         modifiers |= ui::EF_SHIFT_DOWN;
     } else if (tokens[i] == "ctrl" || tokens[i] == "control") {
       modifiers |= ui::EF_CONTROL_DOWN;
+    } else if (tokens[i] == "super") {
+      modifiers |= ui::EF_COMMAND_DOWN;
+#if defined(OS_MACOSX)
     } else if (tokens[i] == "cmd" || tokens[i] == "command") {
       modifiers |= ui::EF_COMMAND_DOWN;
+#endif
     } else if (tokens[i] == "commandorcontrol" || tokens[i] == "cmdorctrl") {
 #if defined(OS_MACOSX)
       modifiers |= ui::EF_COMMAND_DOWN;

--- a/chromium_src/chrome/browser/extensions/global_shortcut_listener_win.cc
+++ b/chromium_src/chrome/browser/extensions/global_shortcut_listener_win.cc
@@ -58,6 +58,8 @@ void GlobalShortcutListenerWin::OnWndProc(HWND hwnd,
   modifiers |= (LOWORD(lparam) & MOD_SHIFT) ? ui::EF_SHIFT_DOWN : 0;
   modifiers |= (LOWORD(lparam) & MOD_ALT) ? ui::EF_ALT_DOWN : 0;
   modifiers |= (LOWORD(lparam) & MOD_CONTROL) ? ui::EF_CONTROL_DOWN : 0;
+  modifiers |= (LOWORD(lparam) & MOD_WIN) ? ui::EF_COMMAND_DOWN : 0;
+
   ui::Accelerator accelerator(
       ui::KeyboardCodeForWindowsKeyCode(key_code), modifiers);
 
@@ -72,6 +74,8 @@ bool GlobalShortcutListenerWin::RegisterAcceleratorImpl(
   modifiers |= accelerator.IsShiftDown() ? MOD_SHIFT : 0;
   modifiers |= accelerator.IsCtrlDown() ? MOD_CONTROL : 0;
   modifiers |= accelerator.IsAltDown() ? MOD_ALT : 0;
+  modifiers |= accelerator.IsCmdDown() ? MOD_WIN : 0;
+
   static int hotkey_id = 0;
   bool success = !!RegisterHotKey(
       gfx::SingletonHwnd::GetInstance()->hwnd(),

--- a/chromium_src/chrome/browser/extensions/global_shortcut_listener_x11.cc
+++ b/chromium_src/chrome/browser/extensions/global_shortcut_listener_x11.cc
@@ -35,6 +35,7 @@ int GetNativeModifiers(const ui::Accelerator& accelerator) {
   modifiers |= accelerator.IsShiftDown() ? ShiftMask : 0;
   modifiers |= accelerator.IsCtrlDown() ? ControlMask : 0;
   modifiers |= accelerator.IsAltDown() ? Mod1Mask : 0;
+  modifiers |= accelerator.IsCmdDown() ? Mod4Mask : 0;
 
   return modifiers;
 }
@@ -148,6 +149,8 @@ void GlobalShortcutListenerX11::OnXKeyPressEvent(::XEvent* x_event) {
   modifiers |= (x_event->xkey.state & ShiftMask) ? ui::EF_SHIFT_DOWN : 0;
   modifiers |= (x_event->xkey.state & ControlMask) ? ui::EF_CONTROL_DOWN : 0;
   modifiers |= (x_event->xkey.state & Mod1Mask) ? ui::EF_ALT_DOWN : 0;
+  // For Windows key
+  modifiers |= (x_event->xkey.state & Mod4Mask) ? ui::EF_COMMAND_DOWN: 0;
 
   ui::Accelerator accelerator(
       ui::KeyboardCodeFromXKeyEvent(x_event), modifiers);

--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -14,6 +14,9 @@ On Linux and Windows, the `Command` key would not have any effect, you can
 use `CommandOrControl` which represents `Command` on OS X and `Control` on
 Linux and Windows to define some accelerators.
 
+The `Super` key is mapped to the `Windows` key on Windows and Linux and
+`Cmd` on OS X.
+
 ## Available modifiers
 
 * `Command` (or `Cmd` for short)
@@ -21,6 +24,7 @@ Linux and Windows to define some accelerators.
 * `CommandOrControl` (or `CmdOrCtrl` for short)
 * `Alt`
 * `Shift`
+* `Super`
 
 ## Available key codes
 


### PR DESCRIPTION
Fixes #1395 .  

To simplify the implementation code, this patch reuses the `command` constant defined in ui namespace on Windows, rather than introducing a new constant.

@zcbenz  PTAL.