### PR TITLE
Reenable NPAPI by setting optional flag

### DIFF
--- a/atom/browser/lib/init.coffee
+++ b/atom/browser/lib/init.coffee
@@ -81,6 +81,9 @@ if packageJson.desktopName?
 else
   app.setDesktopName "#{app.getName()}.desktop"
 
+# Chrome 42 disables NPAPI plugins by default, reenable them here
+app.commandLine.appendSwitch 'enable-npapi'
+
 # Set the user path according to application's name.
 app.setPath 'userData', path.join(app.getPath('appData'), app.getName())
 app.setPath 'userCache', path.join(app.getPath('cache'), app.getName())


### PR DESCRIPTION
In Chrome 42, NPAPI is now gated by an `--enable-npapi` flag. This PR sets this flag if plugins are enabled, at least until we can port PPAPI over (this flag still exists as of Chrome 44 today, but at some point the entire NPAPI infrastructure will be :fire:).

## TODO:

- [ ] Make sure I'm not completely full of it
- [ ] Make sure this works
- [ ] Code Review