### PR TITLE
Typo and missing comma in Desktop Integration doc page

### DIFF
--- a/docs/tutorial/desktop-environment-integration.md
+++ b/docs/tutorial/desktop-environment-integration.md
@@ -118,8 +118,8 @@ app.setUserTasks([
     arguments: '--new-window',
     iconPath: process.execPath,
     iconIndex: 0,
-    title: 'New Window'
-    description: 'Create a new winodw',
+    title: 'New Window',
+    description: 'Create a new window',
   }
 ]);
 ```


### PR DESCRIPTION
Missing comma in the 'setUserTasks' as well as a typo in the description under "User tasks (Windows)"