### PR TITLE
Log errors in preload script instead of rethrowing

### DIFF
--- a/atom/renderer/lib/init.coffee
+++ b/atom/renderer/lib/init.coffee
@@ -103,5 +103,8 @@ if preloadScript
   try
     require preloadScript
   catch error
-    throw error unless error.code is 'MODULE_NOT_FOUND'
-    console.error "Unable to load preload script #{preloadScript}"
+    if error.code is 'MODULE_NOT_FOUND'
+      console.error "Unable to load preload script #{preloadScript}"
+    else
+      console.error(error)
+      console.error(error.stack)


### PR DESCRIPTION
At some point, unhandled errors in preload scripts stopped being logged to console, meaning that preload scripts were very difficult to debug. Instead, print the error to console (which is what we wanted to have happen anyways)

To repro the bug:

1. Create a page with a WebView that has a preload script
1. In the preload script, throw an error for whatever reason (syntax error, etc)
1. Script silently stops and the page loads but the script didn't execute