### PR TITLE
webContents: removing getFavicon api

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -426,13 +426,6 @@ base::string16 WebContents::GetTitle() const {
   return web_contents()->GetTitle();
 }
 
-gfx::Image WebContents::GetFavicon() const {
-  auto entry = web_contents()->GetController().GetLastCommittedEntry();
-  if (!entry)
-    return gfx::Image();
-  return entry->GetFavicon().image;
-}
-
 bool WebContents::IsLoading() const {
   return web_contents()->IsLoading();
 }
@@ -613,7 +606,6 @@ mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
         .SetMethod("isAlive", &WebContents::IsAlive)
         .SetMethod("_loadUrl", &WebContents::LoadURL)
         .SetMethod("getTitle", &WebContents::GetTitle)
-        .SetMethod("getFavicon", &WebContents::GetFavicon)
         .SetMethod("isLoading", &WebContents::IsLoading)
         .SetMethod("isWaitingForResponse", &WebContents::IsWaitingForResponse)
         .SetMethod("_stop", &WebContents::Stop)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -49,7 +49,6 @@ class WebContents : public mate::EventEmitter,
   bool IsAlive() const;
   void LoadURL(const GURL& url, const mate::Dictionary& options);
   base::string16 GetTitle() const;
-  gfx::Image GetFavicon() const;
   bool IsLoading() const;
   bool IsWaitingForResponse() const;
   void Stop();

--- a/atom/renderer/lib/web-view/web-view.coffee
+++ b/atom/renderer/lib/web-view/web-view.coffee
@@ -277,13 +277,6 @@ registerWebViewElement = ->
       remote.getGuestWebContents(internal.guestInstanceId)[m]  args...
   proto[m] = createHandler m for m in methods
 
-  # Return dataUrl instead of nativeImage.
-  proto.getFavicon = (args...) ->
-    internal = v8Util.getHiddenValue this, 'internal'
-    return unless internal
-    favicon = remote.getGuestWebContents(internal.guestInstanceId)['getFavicon'] args...
-    favicon.toDataUrl()
-
   window.WebView = webFrame.registerEmbedderCustomElement 'webview',
     prototype: proto
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -741,10 +741,6 @@ Returns URL of current web page.
 
 Returns the title of web page.
 
-### WebContents.getFavicon()
-
-Returns the favicon of web page as [NativeImage](native-image.md).
-
 ### WebContents.isLoading()
 
 Returns whether web page is still loading resources.

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -130,10 +130,6 @@ Returns URL of guest page.
 
 Returns the title of guest page.
 
-### `<webview>`.getFavicon()
-
-Returns the favicon of guest page as dataUrl.
-
 ### `<webview>`.isLoading()
 
 Returns whether guest page is still loading resources.


### PR DESCRIPTION
Related #1546 

Currently the `getfavicon` api relies on navigation entry's `GetFavicon` api which at most times returns default empty favicon. So now when page favicon urls availablity are notified, their bitmaps are downloded and stored. I didnt yet find a way to detect whats the icon url used currently in a page, so user has to pass in the url for which they want favicon image, which is ofcourse available during `page-favicon-updated` event. 