### PR TITLE
Pass bounds instead of position in "clicked" event of "tray"

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -40,8 +40,8 @@ mate::Wrappable* Tray::New(const gfx::Image& image) {
   return new Tray(image);
 }
 
-void Tray::OnClicked(const gfx::Point& pos) {
-  Emit("clicked", pos);
+void Tray::OnClicked(const gfx::Rect& bounds) {
+  Emit("clicked", bounds);
 }
 
 void Tray::OnDoubleClicked() {

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -41,7 +41,7 @@ class Tray : public mate::EventEmitter,
   virtual ~Tray();
 
   // TrayIconObserver:
-  void OnClicked(const gfx::Point&) override;
+  void OnClicked(const gfx::Rect&) override;
   void OnDoubleClicked() override;
   void OnBalloonShow() override;
   void OnBalloonClicked() override;

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -237,6 +237,22 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
     Show();
 }
 
+void NativeWindow::SetSize(const gfx::Size& size) {
+  SetBounds(gfx::Rect(GetPosition(), size));
+}
+
+gfx::Size NativeWindow::GetSize() {
+  return GetBounds().size();
+}
+
+void NativeWindow::SetPosition(const gfx::Point& position) {
+  SetBounds(gfx::Rect(position, GetSize()));
+}
+
+gfx::Point NativeWindow::GetPosition() {
+  return GetBounds().origin();
+}
+
 void NativeWindow::SetRepresentedFilename(const std::string& filename) {
 }
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -114,8 +114,10 @@ class NativeWindow : public brightray::DefaultWebContentsDelegate,
   virtual bool IsFullscreen() const = 0;
   virtual void SetBounds(const gfx::Rect& bounds) = 0;
   virtual gfx::Rect GetBounds() = 0;
-  virtual void SetSize(const gfx::Size& size) = 0;
-  virtual gfx::Size GetSize() = 0;
+  virtual void SetSize(const gfx::Size& size);
+  virtual gfx::Size GetSize();
+  virtual void SetPosition(const gfx::Point& position);
+  virtual gfx::Point GetPosition();
   virtual void SetContentSize(const gfx::Size& size) = 0;
   virtual gfx::Size GetContentSize() = 0;
   virtual void SetMinimumSize(const gfx::Size& size) = 0;
@@ -127,8 +129,6 @@ class NativeWindow : public brightray::DefaultWebContentsDelegate,
   virtual void SetAlwaysOnTop(bool top) = 0;
   virtual bool IsAlwaysOnTop() = 0;
   virtual void Center() = 0;
-  virtual void SetPosition(const gfx::Point& position) = 0;
-  virtual gfx::Point GetPosition() = 0;
   virtual void SetTitle(const std::string& title) = 0;
   virtual std::string GetTitle() = 0;
   virtual void FlashFrame(bool flash) = 0;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -46,8 +46,6 @@ class NativeWindowMac : public NativeWindow {
   bool IsFullscreen() const override;
   void SetBounds(const gfx::Rect& bounds) override;
   gfx::Rect GetBounds() override;
-  void SetSize(const gfx::Size& size) override;
-  gfx::Size GetSize() override;
   void SetContentSize(const gfx::Size& size) override;
   gfx::Size GetContentSize() override;
   void SetMinimumSize(const gfx::Size& size) override;
@@ -59,8 +57,6 @@ class NativeWindowMac : public NativeWindow {
   void SetAlwaysOnTop(bool top) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
-  void SetPosition(const gfx::Point& position) override;
-  gfx::Point GetPosition() override;
   void SetTitle(const std::string& title) override;
   std::string GetTitle() override;
   void FlashFrame(bool flash) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -11,14 +11,14 @@
 #include "atom/common/options_switches.h"
 #include "base/mac/mac_util.h"
 #include "base/strings/sys_string_conversions.h"
+#include "brightray/browser/inspectable_web_contents.h"
+#include "brightray/browser/inspectable_web_contents_view.h"
 #include "content/public/browser/browser_accessibility_state.h"
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/render_widget_host_view.h"
 #include "native_mate/dictionary.h"
-#include "vendor/brightray/browser/inspectable_web_contents.h"
-#include "vendor/brightray/browser/inspectable_web_contents_view.h"
 
 static const CGFloat kAtomWindowCornerRadius = 4.0;
 
@@ -303,7 +303,7 @@ NativeWindowMac::NativeWindowMac(content::WebContents* web_contents,
   options.Get(switches::kWidth, &width);
   options.Get(switches::kHeight, &height);
 
-  NSRect main_screen_rect = [[[NSScreen screens] objectAtIndex:0] frame];
+  NSRect main_screen_rect = [[NSScreen mainScreen] frame];
   NSRect cocoa_bounds = NSMakeRect(
       round((NSWidth(main_screen_rect) - width) / 2) ,
       round((NSHeight(main_screen_rect) - height) / 2),
@@ -463,7 +463,7 @@ void NativeWindowMac::SetBounds(const gfx::Rect& bounds) {
                                    bounds.width(),
                                    bounds.height());
   // Flip coordinates based on the primary screen.
-  NSScreen* screen = [[NSScreen screens] objectAtIndex:0];
+  NSScreen* screen = [NSScreen mainScreen];
   cocoa_bounds.origin.y =
       NSHeight([screen frame]) - bounds.height() - bounds.y();
 
@@ -472,13 +472,10 @@ void NativeWindowMac::SetBounds(const gfx::Rect& bounds) {
 
 gfx::Rect NativeWindowMac::GetBounds() {
   NSRect frame = [window_ frame];
-  NSScreen* screen = [[NSScreen screens] objectAtIndex:0];
-
-  gfx::Point pos(frame.origin.x,
-      NSHeight([screen frame]) - frame.origin.y - frame.size.height);
-  gfx::Size size(frame.size.width, frame.size.height);
-
-  return gfx::Rect(pos, size);
+  gfx::Rect bounds(frame.origin.x, 0, NSWidth(frame), NSHeight(frame));
+  NSScreen* screen = [NSScreen mainScreen];
+  bounds.set_y(NSHeight([screen frame]) - NSMaxY(frame));
+  return bounds;
 }
 
 void NativeWindowMac::SetSize(const gfx::Size& size) {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -478,19 +478,6 @@ gfx::Rect NativeWindowMac::GetBounds() {
   return bounds;
 }
 
-void NativeWindowMac::SetSize(const gfx::Size& size) {
-  NSRect frame = [window_ frame];
-  frame.origin.y -= size.height() - frame.size.height;
-  frame.size.width = size.width();
-  frame.size.height = size.height();
-
-  [window_ setFrame:frame display:YES];
-}
-
-gfx::Size NativeWindowMac::GetSize() {
-  return GetBounds().size();
-}
-
 void NativeWindowMac::SetContentSize(const gfx::Size& size) {
   NSRect frame_nsrect = [window_ frame];
   NSSize frame = frame_nsrect.size;
@@ -559,14 +546,6 @@ bool NativeWindowMac::IsAlwaysOnTop() {
 
 void NativeWindowMac::Center() {
   [window_ center];
-}
-
-void NativeWindowMac::SetPosition(const gfx::Point& position) {
-  SetBounds(gfx::Rect(position, GetSize()));
-}
-
-gfx::Point NativeWindowMac::GetPosition() {
-  return GetBounds().origin();
 }
 
 void NativeWindowMac::SetTitle(const std::string& title) {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -391,31 +391,15 @@ gfx::Rect NativeWindowViews::GetBounds() {
   return window_->GetWindowBoundsInScreen();
 }
 
-void NativeWindowViews::SetSize(const gfx::Size& size) {
-#if defined(USE_X11)
-  // On Linux the minimum and maximum size should be updated with window size
-  // when window is not resizable.
-  if (!resizable_) {
-    SetMaximumSize(size);
-    SetMinimumSize(size);
-  }
-#endif
-
-  window_->SetSize(size);
-}
-
-gfx::Size NativeWindowViews::GetSize() {
-  return GetBounds().size();
-}
-
 void NativeWindowViews::SetContentSize(const gfx::Size& size) {
   if (!has_frame_) {
-    SetSize(size);
+    NativeWindow::SetSize(size);
     return;
   }
 
   gfx::Rect bounds = window_->GetWindowBoundsInScreen();
-  SetSize(ContentBoundsToWindowBounds(gfx::Rect(bounds.origin(), size)).size());
+  bounds.set_size(size);
+  SetBounds(ContentBoundsToWindowBounds(bounds));
 }
 
 gfx::Size NativeWindowViews::GetContentSize() {
@@ -503,19 +487,6 @@ bool NativeWindowViews::IsAlwaysOnTop() {
 
 void NativeWindowViews::Center() {
   window_->CenterWindow(GetSize());
-}
-
-void NativeWindowViews::SetPosition(const gfx::Point& position) {
-  window_->SetBounds(gfx::Rect(position, GetSize()));
-}
-
-gfx::Point NativeWindowViews::GetPosition() {
-#if defined(OS_WIN)
-  if (IsMinimized())
-    return window_->GetRestoredBounds().origin();
-#endif
-
-  return window_->GetWindowBoundsInScreen().origin();
 }
 
 void NativeWindowViews::SetTitle(const std::string& title) {

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -51,8 +51,6 @@ class NativeWindowViews : public NativeWindow,
   bool IsFullscreen() const override;
   void SetBounds(const gfx::Rect& bounds) override;
   gfx::Rect GetBounds() override;
-  void SetSize(const gfx::Size& size) override;
-  gfx::Size GetSize() override;
   void SetContentSize(const gfx::Size& size) override;
   gfx::Size GetContentSize() override;
   void SetMinimumSize(const gfx::Size& size) override;
@@ -64,8 +62,6 @@ class NativeWindowViews : public NativeWindow,
   void SetAlwaysOnTop(bool top) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
-  void SetPosition(const gfx::Point& position) override;
-  gfx::Point GetPosition() override;
   void SetTitle(const std::string& title) override;
   std::string GetTitle() override;
   void FlashFrame(bool flash) override;

--- a/atom/browser/ui/tray_icon.cc
+++ b/atom/browser/ui/tray_icon.cc
@@ -26,8 +26,8 @@ void TrayIcon::DisplayBalloon(const gfx::Image& icon,
                               const base::string16& contents) {
 }
 
-void TrayIcon::NotifyClicked(const gfx::Point& pos) {
-  FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnClicked(pos));
+void TrayIcon::NotifyClicked(const gfx::Rect& bounds) {
+  FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnClicked(bounds));
 }
 
 void TrayIcon::NotifyDoubleClicked() {

--- a/atom/browser/ui/tray_icon.h
+++ b/atom/browser/ui/tray_icon.h
@@ -10,6 +10,7 @@
 #include "atom/browser/ui/tray_icon_observer.h"
 #include "base/observer_list.h"
 #include "ui/base/models/simple_menu_model.h"
+#include "ui/gfx/geometry/rect.h"
 
 namespace atom {
 
@@ -50,7 +51,7 @@ class TrayIcon {
 
   void AddObserver(TrayIconObserver* obs) { observers_.AddObserver(obs); }
   void RemoveObserver(TrayIconObserver* obs) { observers_.RemoveObserver(obs); }
-  void NotifyClicked(const gfx::Point&);
+  void NotifyClicked(const gfx::Rect& = gfx::Rect());
   void NotifyDoubleClicked();
   void NotifyBalloonShow();
   void NotifyBalloonClicked();

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -26,13 +26,14 @@
 }
 
 - (void)handleClick:(id)sender {
-  // Get the position of the frame of the NSStatusItem.
-  NSPoint pos = [NSApp currentEvent].window.frame.origin;
+  // Get the frame of the NSStatusItem.
+  NSRect frame = [NSApp currentEvent].window.frame;
+  gfx::Rect bounds(frame.origin.x, 0, NSWidth(frame), NSHeight(frame));
   // Flip coordinates to gfx (0,0 in top-left corner) using current screen.
   NSScreen* screen = [NSScreen mainScreen];
-  pos.y = NSMaxY([screen frame]) - pos.y;
+  bounds.set_y(NSHeight([screen frame]) - NSMaxY(frame));
 
-  trayIcon_->NotifyClicked(gfx::Point(pos.x, pos.y));
+  trayIcon_->NotifyClicked(bounds);
 }
 
 - (void)handleDoubleClick:(id)sender {

--- a/atom/browser/ui/tray_icon_observer.h
+++ b/atom/browser/ui/tray_icon_observer.h
@@ -6,14 +6,14 @@
 #define ATOM_BROWSER_UI_TRAY_ICON_OBSERVER_H_
 
 namespace gfx {
-class Point;
+class Rect;
 }
 
 namespace atom {
 
 class TrayIconObserver {
  public:
-  virtual void OnClicked(const gfx::Point&) {}
+  virtual void OnClicked(const gfx::Rect&) {}
   virtual void OnDoubleClicked() {}
   virtual void OnBalloonShow() {}
   virtual void OnBalloonClicked() {}

--- a/atom/browser/ui/win/notify_icon.cc
+++ b/atom/browser/ui/win/notify_icon.cc
@@ -49,7 +49,7 @@ void NotifyIcon::HandleClickEvent(const gfx::Point& cursor_pos,
                                   bool left_mouse_click) {
   // Pass to the observer if appropriate.
   if (left_mouse_click) {
-    NotifyClicked(cursor_pos);
+    NotifyClicked();
     return;
   }
 

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -47,11 +47,15 @@ Creates a new tray icon associated with the `image`.
 ### Event: 'clicked'
 
 * `event`
-* `point` Object
+* `bounds` Object - the bounds of tray icon
   * `x` Integer
   * `y` Integer
+  * `width` Integer
+  * `height` Integer
 
 Emitted when the tray icon is clicked.
+
+__NOte:__ The `bounds` payload is only implemented on OS X.
 
 ### Event: 'double-clicked'
 
@@ -106,7 +110,7 @@ Sets the hover text for this tray icon.
 
 Sets the title displayed aside of the tray icon in the status bar.
 
-This is only implemented on OS X.
+__Note:__ This is only implemented on OS X.
 
 ### Tray.setHighlightMode(highlight)
 
@@ -114,7 +118,7 @@ This is only implemented on OS X.
 
 Sets whether the tray icon is highlighted when it is clicked.
 
-This is only implmented on OS X.
+__Note:__ This is only implemented on OS X.
 
 ### Tray.displayBalloon(options)
 
@@ -123,10 +127,14 @@ This is only implmented on OS X.
   * `title` String
   * `content` String
 
+Displays a tray balloon.
+
+__Note:__ This is only implemented on Windows.
+
 ### Tray.setContextMenu(menu)
 
 * `menu` Menu
 
-Set the context menu for this icon.
+Sets the context menu for this icon.
 
 [event-emitter]: http://nodejs.org/api/events.html#events_class_events_eventemitter

--- a/spec/api-browser-window-spec.coffee
+++ b/spec/api-browser-window-spec.coffee
@@ -227,6 +227,7 @@ describe 'browser-window module', ->
 
   describe 'dom-ready event', ->
     it 'emits when document is loaded', (done) ->
+      ipc = remote.require 'ipc'
       server = http.createServer (req, res) ->
         action = url.parse(req.url, true).pathname
         if action == '/logo.png'
@@ -237,7 +238,8 @@ describe 'browser-window module', ->
           , 2000
           server.close()
       server.listen 62542, '127.0.0.1'
-      remote.require('ipc').on 'dom-ready', (e, state) ->
+      ipc.on 'dom-ready', (e, state) ->
+        ipc.removeAllListeners 'dom-ready'
         assert.equal state, 'interactive'
         done()
       w.webContents.on 'did-finish-load', ->

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -181,15 +181,15 @@ describe '<webview> tag', ->
 
   describe '<webview>.reload()', ->
     it 'should emit beforeunload handler', (done) ->
-      webview.addEventListener 'did-finish-load', (e) ->
-        webview.reload()
       listener = (e) ->
         assert.equal e.channel, 'onbeforeunload'
         webview.removeEventListener 'ipc-message', listener
         done()
-      webview.addEventListener 'console-message', (e) ->
-        console.log(e)
+      listener2 = (e) ->
+        webview.reload()
+        webview.removeEventListener 'did-finish-load', listener2
       webview.addEventListener 'ipc-message', listener
+      webview.addEventListener 'did-finish-load', listener2
       webview.setAttribute 'nodeintegration', 'on'
       webview.src = "file://#{fixtures}/pages/beforeunload-false.html"
       document.body.appendChild webview


### PR DESCRIPTION
Only position is not enough to decide where to show custom view, fixes #1500.