### PR TITLE
spec: add test for basic authentication

### DIFF
--- a/spec/fixtures/pages/basic-auth.html
+++ b/spec/fixtures/pages/basic-auth.html
@@ -1,0 +1,17 @@
+<html>
+<body>
+<script src='http://127.0.0.1:62342/jquery.js'></script>
+<script type="text/javascript" charset="utf-8">
+  $.ajax({
+    type: "GET",
+    url: "http://127.0.0.1:62342",
+    headers: {
+      "Authorization": "Basic " + btoa("test:test")
+    },
+    success: function (result){
+      require('ipc').send('console-message', result);
+    }
+  });
+</script>
+</body>
+</html>

--- a/spec/package.json
+++ b/spec/package.json
@@ -4,6 +4,7 @@
   "main": "static/main.js",
   "version": "0.1.0",
   "devDependencies": {
+    "basic-auth": "^1.0.0",
     "formidable": "1.0.16",
     "graceful-fs": "3.0.5",
     "mocha": "2.1.0",


### PR DESCRIPTION
Checking on #1362 , the [`HttpAuthHandlerFactory::CreateDefault`](https://code.google.com/p/chromium/codesearch#chromium/src/net/http/http_auth_handler_factory.cc&sq=package:chromium&rcl=1430724764&l=46) does create handlers for `basic, negotiate, ntlm and digest` . As for #1318 we probably need to pass `URLSecurityManager` using this [method](https://code.google.com/p/chromium/codesearch#chromium/src/net/http/http_auth_handler_factory.cc&sq=package:chromium&rcl=1430724764&l=129) , anyone working on windows can use this as [example](https://code.google.com/p/chromium/codesearch#chromium/src/chrome/browser/io_thread.cc&sq=package:chromium&rcl=1430739881&l=1118) and implement on brightray side. 

/cc @zcbenz , @paulcbetts thoughts ? 