### PR TITLE
Use the standard window background

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -310,10 +310,18 @@ NativeWindowMac::NativeWindowMac(content::WebContents* web_contents,
       width,
       height);
 
+  bool useFrame = true;
+  options.Get(switches::kFrame, &useFrame);
+
+  NSUInteger styleMask = NSTitledWindowMask | NSClosableWindowMask |
+                         NSMiniaturizableWindowMask | NSResizableWindowMask;
+  if (!useFrame) {
+    styleMask |= NSTexturedBackgroundWindowMask;
+  }
+
   window_.reset([[AtomNSWindow alloc]
       initWithContentRect:cocoa_bounds
-                styleMask:NSTitledWindowMask | NSClosableWindowMask |
-                          NSMiniaturizableWindowMask | NSResizableWindowMask
+                styleMask:styleMask
                   backing:NSBackingStoreBuffered
                     defer:YES]);
   [window_ setShell:this];

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -313,8 +313,7 @@ NativeWindowMac::NativeWindowMac(content::WebContents* web_contents,
   window_.reset([[AtomNSWindow alloc]
       initWithContentRect:cocoa_bounds
                 styleMask:NSTitledWindowMask | NSClosableWindowMask |
-                          NSMiniaturizableWindowMask | NSResizableWindowMask |
-                          NSTexturedBackgroundWindowMask
+                          NSMiniaturizableWindowMask | NSResizableWindowMask
                   backing:NSBackingStoreBuffered
                     defer:YES]);
   [window_ setShell:this];

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -310,12 +310,12 @@ NativeWindowMac::NativeWindowMac(content::WebContents* web_contents,
       width,
       height);
 
-  bool useFrame = true;
-  options.Get(switches::kFrame, &useFrame);
+  bool useStandardWindow = false;
+  options.Get(switches::kStandardWindow, &useStandardWindow);
 
   NSUInteger styleMask = NSTitledWindowMask | NSClosableWindowMask |
                          NSMiniaturizableWindowMask | NSResizableWindowMask;
-  if (!useFrame) {
+  if (!useStandardWindow) {
     styleMask |= NSTexturedBackgroundWindowMask;
   }
 

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -78,6 +78,9 @@ const char kType[] = "type";
 // Disable auto-hiding cursor.
 const char kDisableAutoHideCursor[] = "disable-auto-hide-cursor";
 
+// Use the OS X's standard window instead of the textured window.
+const char kStandardWindow[] = "standard-window";
+
 // Web runtime features.
 const char kExperimentalFeatures[]       = "experimental-features";
 const char kExperimentalCanvasFeatures[] = "experimental-canvas-features";

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -42,6 +42,7 @@ extern const char kPreloadScript[];
 extern const char kTransparent[];
 extern const char kType[];
 extern const char kDisableAutoHideCursor[];
+extern const char kStandardWindow[];
 
 extern const char kExperimentalFeatures[];
 extern const char kExperimentalCanvasFeatures[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -72,6 +72,8 @@ You can also create a window without chrome by using
   * `type` String - Specifies the type of the window, possible types are
     `desktop`, `dock`, `toolbar`, `splash`, `notification`. This only works on
     Linux.
+  * `standard-window` Boolean - Use the OS X's standard window instead of the
+    textured window. Defaults to `false`.
   * `web-preferences` Object - Settings of web page's features
     * `javascript` Boolean
     * `web-security` Boolean


### PR DESCRIPTION
I was playing around with making an Electron app the other day and noticed something that bothered my native developer eyes: the window was missing the divider line between the title bar and the content.

![before](https://cloud.githubusercontent.com/assets/13760/7485833/7de6fe0e-f369-11e4-8d2f-340de8874433.jpg)

It turns out it's because we're using the textured window background. Remove that flag and we're :sparkles::cool::

![after](https://cloud.githubusercontent.com/assets/13760/7485843/af7de450-f369-11e4-8615-abc57f0ff6b3.jpg)

It's entirely possible there's a good reason that I'm unaware of to use the textured window background. Also I know that the line can be recreated using CSS, but then you see a flash when you load the app before it's there.