### PR TITLE
Allow User Agent on WebView to be set as an attribute

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -418,6 +418,10 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
     params.referrer = content::Referrer(http_referrer.GetAsReferrer(),
                                         blink::WebReferrerPolicyDefault);
 
+  std::string user_agent;
+  if (options.Get("useragent", &user_agent))
+    this->SetUserAgent(user_agent);
+
   params.transition_type = ui::PAGE_TRANSITION_TYPED;
   params.should_clear_history_list = true;
   params.override_user_agent = content::NavigationController::UA_OVERRIDE_TRUE;

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -420,7 +420,7 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
 
   std::string user_agent;
   if (options.Get("useragent", &user_agent))
-    this->SetUserAgent(user_agent);
+    SetUserAgent(user_agent);
 
   params.transition_type = ui::PAGE_TRANSITION_TYPED;
   params.should_clear_history_list = true;

--- a/atom/browser/lib/guest-view-manager.coffee
+++ b/atom/browser/lib/guest-view-manager.coffee
@@ -57,14 +57,13 @@ createGuest = (embedder, params) ->
     min = width: params.minwidth, height: params.minheight
     max = width: params.maxwidth, height: params.maxheight
     @setAutoSize params.autosize, min, max
+
     if params.src
       opts = {}
       opts.httpreferrer = params.httpreferrer if params.httpreferrer
       opts.useragent = params.useragent if params.useragent
-      if params.httpreferrer or params.useragent
-        @loadUrl params.src, opts
-      else
-        @loadUrl params.src
+      @loadUrl params.src, opts
+
     if params.allowtransparency?
       @setAllowTransparency params.allowtransparency
 

--- a/atom/browser/lib/guest-view-manager.coffee
+++ b/atom/browser/lib/guest-view-manager.coffee
@@ -58,8 +58,11 @@ createGuest = (embedder, params) ->
     max = width: params.maxwidth, height: params.maxheight
     @setAutoSize params.autosize, min, max
     if params.src
-      if params.httpreferrer
-        @loadUrl params.src, {httpreferrer: params.httpreferrer}
+      opts = {}
+      opts.httpreferrer = params.httpreferrer if params.httpreferrer
+      opts.useragent = params.useragent if params.useragent
+      if params.httpreferrer or params.useragent
+        @loadUrl params.src, opts
       else
         @loadUrl params.src
     if params.allowtransparency?

--- a/atom/renderer/lib/web-view/web-view-attributes.coffee
+++ b/atom/renderer/lib/web-view/web-view-attributes.coffee
@@ -173,7 +173,7 @@ class HttpReferrerAttribute extends WebViewAttribute
   constructor: (webViewImpl) ->
     super webViewConstants.ATTRIBUTE_HTTPREFERRER, webViewImpl
 
-# Attribute specifies HTTP referrer.
+# Attribute specifies user agent
 class UserAgentAttribute extends WebViewAttribute
   constructor: (webViewImpl) ->
     super webViewConstants.ATTRIBUTE_USERAGENT, webViewImpl

--- a/atom/renderer/lib/web-view/web-view-attributes.coffee
+++ b/atom/renderer/lib/web-view/web-view-attributes.coffee
@@ -158,13 +158,14 @@ class SrcAttribute extends WebViewAttribute
       return
 
     # Navigate to |this.src|.
+    opts = {}
     httpreferrer = @webViewImpl.attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER].getValue()
-    urlOptions = if httpreferrer then {httpreferrer} else {}
+    if httpreferrer then opts.httpreferrer = httpreferrer
 
-    useragent = @webViewImpl.attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER].getValue()
+    useragent = @webViewImpl.attributes[webViewConstants.ATTRIBUTE_USERAGENT].getValue()
+    if useragent then opts.useragent = useragent
 
     guestContents = remote.getGuestWebContents(@webViewImpl.guestInstanceId)
-    guestContents.setUserAgent(guestContents) if guestContents
     guestContents.loadUrl @getValue(), urlOptions
 
 # Attribute specifies HTTP referrer.
@@ -175,7 +176,7 @@ class HttpReferrerAttribute extends WebViewAttribute
 # Attribute specifies HTTP referrer.
 class UserAgentAttribute extends WebViewAttribute
   constructor: (webViewImpl) ->
-    super webViewConstants.ATTRIBUTE_HTTPREFERRER, webViewImpl
+    super webViewConstants.ATTRIBUTE_USERAGENT, webViewImpl
 
 # Attribute that set preload script.
 class PreloadAttribute extends WebViewAttribute

--- a/atom/renderer/lib/web-view/web-view-attributes.coffee
+++ b/atom/renderer/lib/web-view/web-view-attributes.coffee
@@ -160,7 +160,12 @@ class SrcAttribute extends WebViewAttribute
     # Navigate to |this.src|.
     httpreferrer = @webViewImpl.attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER].getValue()
     urlOptions = if httpreferrer then {httpreferrer} else {}
-    remote.getGuestWebContents(@webViewImpl.guestInstanceId).loadUrl @getValue(), urlOptions
+
+    useragent = @webViewImpl.attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER].getValue()
+
+    guestContents = remote.getGuestWebContents(@webViewImpl.guestInstanceId)
+    guestContents.setUserAgent(guestContents) if guestContents
+    guestContents.loadUrl @getValue(), urlOptions
 
 # Attribute specifies HTTP referrer.
 class HttpReferrerAttribute extends WebViewAttribute

--- a/atom/renderer/lib/web-view/web-view-attributes.coffee
+++ b/atom/renderer/lib/web-view/web-view-attributes.coffee
@@ -190,6 +190,7 @@ WebViewImpl::setupWebViewAttributes = ->
   @attributes[webViewConstants.ATTRIBUTE_PARTITION] = new PartitionAttribute(this)
   @attributes[webViewConstants.ATTRIBUTE_SRC] = new SrcAttribute(this)
   @attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER] = new HttpReferrerAttribute(this)
+  @attributes[webViewConstants.ATTRIBUTE_USERAGENT] = new UserAgentAttribute(this)
   @attributes[webViewConstants.ATTRIBUTE_NODEINTEGRATION] = new BooleanAttribute(webViewConstants.ATTRIBUTE_NODEINTEGRATION, this)
   @attributes[webViewConstants.ATTRIBUTE_PLUGINS] = new BooleanAttribute(webViewConstants.ATTRIBUTE_PLUGINS, this)
   @attributes[webViewConstants.ATTRIBUTE_DISABLEWEBSECURITY] = new BooleanAttribute(webViewConstants.ATTRIBUTE_DISABLEWEBSECURITY, this)

--- a/atom/renderer/lib/web-view/web-view-attributes.coffee
+++ b/atom/renderer/lib/web-view/web-view-attributes.coffee
@@ -166,7 +166,7 @@ class SrcAttribute extends WebViewAttribute
     if useragent then opts.useragent = useragent
 
     guestContents = remote.getGuestWebContents(@webViewImpl.guestInstanceId)
-    guestContents.loadUrl @getValue(), urlOptions
+    guestContents.loadUrl @getValue(), opts
 
 # Attribute specifies HTTP referrer.
 class HttpReferrerAttribute extends WebViewAttribute

--- a/atom/renderer/lib/web-view/web-view-attributes.coffee
+++ b/atom/renderer/lib/web-view/web-view-attributes.coffee
@@ -167,6 +167,11 @@ class HttpReferrerAttribute extends WebViewAttribute
   constructor: (webViewImpl) ->
     super webViewConstants.ATTRIBUTE_HTTPREFERRER, webViewImpl
 
+# Attribute specifies HTTP referrer.
+class UserAgentAttribute extends WebViewAttribute
+  constructor: (webViewImpl) ->
+    super webViewConstants.ATTRIBUTE_HTTPREFERRER, webViewImpl
+
 # Attribute that set preload script.
 class PreloadAttribute extends WebViewAttribute
   constructor: (webViewImpl) ->

--- a/atom/renderer/lib/web-view/web-view-constants.coffee
+++ b/atom/renderer/lib/web-view/web-view-constants.coffee
@@ -14,6 +14,7 @@ module.exports =
   ATTRIBUTE_PLUGINS: 'plugins'
   ATTRIBUTE_DISABLEWEBSECURITY: 'disablewebsecurity'
   ATTRIBUTE_PRELOAD: 'preload'
+  ATTRIBUTE_USERAGENT: 'useragent'
 
   # Internal attribute.
   ATTRIBUTE_INTERNALINSTANCEID: 'internalinstanceid'

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -112,6 +112,14 @@ after this script has done execution.
 
 Sets the referrer URL for the guest page.
 
+### useragent
+
+```html
+<webview src="https://www.github.com/" useragent="Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko"></webview>
+```
+
+Sets the user agent for the guest page before the page is navigated to. Once the page is loaded, use the `setUserAgent` method to change the user agent.
+
 ### disablewebsecurity
 
 ```html

--- a/spec/fixtures/pages/useragent.html
+++ b/spec/fixtures/pages/useragent.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  console.log(navigator.userAgent);
+</script>
+</body>
+</html>

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -99,6 +99,18 @@ describe '<webview> tag', ->
       webview.src = "file://#{fixtures}/pages/referrer.html"
       document.body.appendChild webview
 
+  describe 'useragent attribute', ->
+    it 'sets the user agent', (done) ->
+      referrer = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko'
+      listener = (e) ->
+        assert.equal e.message, referrer
+        webview.removeEventListener 'console-message', listener
+        done()
+      webview.addEventListener 'console-message', listener
+      webview.setAttribute 'useragent', referrer
+      webview.src = "file://#{fixtures}/pages/useragent.html"
+      document.body.appendChild webview
+
   describe 'disablewebsecurity attribute', ->
     it 'does not disable web security when not set', (done) ->
       src = "


### PR DESCRIPTION
Using the `setUserAgent` method on WebView when you want to ensure that all requests get sent with your custom user agent is very difficult to get right - if you call it too early, the method throws, and calling it too late will result in the first few requests being sent with the default user agent.

This PR creates an additional way to set the user agent, via an HTML attribute:

```
<webview tabindex="-1" id="webView1" preload="myScript.js" src="https://google.com" useragent="Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko">
</webview>
```

This then guarantees that we'll apply the custom user agent right before navigation. This PR doesn't remove the existing method, nor does it attempt to catch mutations to `useragent` after the page has loaded - I can add these. 

## TODO:

- [x] Specs
- [x] Documentation
- [x] Code Review