### PR TITLE
protocol: wrapping HttpJobFactory with a default protocol handler to intercept

### DIFF
--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -61,7 +61,13 @@ net::URLRequestJobFactory* AtomBrowserContext::CreateURLRequestJobFactory(
           BrowserThread::GetBlockingPool()->GetTaskRunnerWithShutdownBehavior(
               base::SequencedWorkerPool::SKIP_ON_SHUTDOWN)));
   job_factory->SetProtocolHandler(
-      url::kHttpScheme, new HttpProtocolHandler());
+      url::kHttpScheme, new HttpProtocolHandler(url::kHttpScheme));
+  job_factory->SetProtocolHandler(
+      url::kHttpsScheme, new HttpProtocolHandler(url::kHttpsScheme));
+  job_factory->SetProtocolHandler(
+      url::kWsScheme, new HttpProtocolHandler(url::kWsScheme));
+  job_factory->SetProtocolHandler(
+      url::kWssScheme, new HttpProtocolHandler(url::kWssScheme));
 
   // Set up interceptors in the reverse order.
   scoped_ptr<net::URLRequestJobFactory> top_job_factory = job_factory.Pass();

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -7,6 +7,7 @@
 #include "atom/browser/atom_browser_main_parts.h"
 #include "atom/browser/net/atom_url_request_job_factory.h"
 #include "atom/browser/net/asar/asar_protocol_handler.h"
+#include "atom/browser/net/http_protocol_handler.h"
 #include "atom/browser/web_view_manager.h"
 #include "atom/common/options_switches.h"
 #include "base/command_line.h"
@@ -59,6 +60,8 @@ net::URLRequestJobFactory* AtomBrowserContext::CreateURLRequestJobFactory(
       url::kFileScheme, new asar::AsarProtocolHandler(
           BrowserThread::GetBlockingPool()->GetTaskRunnerWithShutdownBehavior(
               base::SequencedWorkerPool::SKIP_ON_SHUTDOWN)));
+  job_factory->SetProtocolHandler(
+      url::kHttpScheme, new HttpProtocolHandler());
 
   // Set up interceptors in the reverse order.
   scoped_ptr<net::URLRequestJobFactory> top_job_factory = job_factory.Pass();

--- a/atom/browser/net/http_protocol_handler.cc
+++ b/atom/browser/net/http_protocol_handler.cc
@@ -1,0 +1,25 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/net/http_protocol_handler.h"
+
+#include "net/url_request/url_request_http_job.h"
+
+namespace atom {
+
+HttpProtocolHandler::HttpProtocolHandler() {
+}
+
+HttpProtocolHandler::~HttpProtocolHandler() {
+}
+
+net::URLRequestJob* HttpProtocolHandler::MaybeCreateJob(
+    net::URLRequest* request,
+    net::NetworkDelegate* network_delegate) const {
+  return net::URLRequestHttpJob::Factory(request,
+                                         network_delegate,
+                                         "http");
+}
+
+}  // namespace atom

--- a/atom/browser/net/http_protocol_handler.cc
+++ b/atom/browser/net/http_protocol_handler.cc
@@ -8,7 +8,8 @@
 
 namespace atom {
 
-HttpProtocolHandler::HttpProtocolHandler() {
+HttpProtocolHandler::HttpProtocolHandler(const std::string& scheme)
+    : scheme_(scheme) {
 }
 
 HttpProtocolHandler::~HttpProtocolHandler() {
@@ -19,7 +20,7 @@ net::URLRequestJob* HttpProtocolHandler::MaybeCreateJob(
     net::NetworkDelegate* network_delegate) const {
   return net::URLRequestHttpJob::Factory(request,
                                          network_delegate,
-                                         "http");
+                                         scheme_);
 }
 
 }  // namespace atom

--- a/atom/browser/net/http_protocol_handler.h
+++ b/atom/browser/net/http_protocol_handler.h
@@ -5,19 +5,24 @@
 #ifndef ATOM_BROWSER_NET_HTTP_PROTOCOL_HANDLER_H_
 #define ATOM_BROWSER_NET_HTTP_PROTOCOL_HANDLER_H_
 
+#include <string>
+
 #include "net/url_request/url_request_job_factory.h"
 
 namespace atom {
 
 class HttpProtocolHandler : public net::URLRequestJobFactory::ProtocolHandler {
  public:
-  HttpProtocolHandler();
+  explicit HttpProtocolHandler(const std::string&);
   virtual ~HttpProtocolHandler();
 
   // net::URLRequestJobFactory::ProtocolHandler:
   net::URLRequestJob* MaybeCreateJob(
       net::URLRequest* request,
       net::NetworkDelegate* network_delegate) const override;
+
+ private:
+  std::string scheme_;
 };
 
 }  // namespace atom

--- a/atom/browser/net/http_protocol_handler.h
+++ b/atom/browser/net/http_protocol_handler.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_NET_HTTP_PROTOCOL_HANDLER_H_
+#define ATOM_BROWSER_NET_HTTP_PROTOCOL_HANDLER_H_
+
+#include "net/url_request/url_request_job_factory.h"
+
+namespace atom {
+
+class HttpProtocolHandler : public net::URLRequestJobFactory::ProtocolHandler {
+ public:
+  HttpProtocolHandler();
+  virtual ~HttpProtocolHandler();
+
+  // net::URLRequestJobFactory::ProtocolHandler:
+  net::URLRequestJob* MaybeCreateJob(
+      net::URLRequest* request,
+      net::NetworkDelegate* network_delegate) const override;
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_NET_HTTP_PROTOCOL_HANDLER_H_

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -145,6 +145,8 @@
       'atom/browser/net/asar/url_request_asar_job.h',
       'atom/browser/net/atom_url_request_job_factory.cc',
       'atom/browser/net/atom_url_request_job_factory.h',
+      'atom/browser/net/http_protocol_handler.cc',
+      'atom/browser/net/http_protocol_handler.h',            
       'atom/browser/net/url_request_string_job.cc',
       'atom/browser/net/url_request_string_job.h',
       'atom/browser/net/url_request_buffer_job.cc',

--- a/spec/api-protocol-spec.coffee
+++ b/spec/api-protocol-spec.coffee
@@ -197,3 +197,24 @@ describe 'protocol module', ->
         protocol.uninterceptProtocol 'http'
         done()
       protocol.interceptProtocol 'http', handler
+
+    it 'can override https protocol handler', (done) ->
+      handler = remote.createFunctionWithReturnValue 'valar morghulis'
+      protocol.once 'intercepted', ->
+        protocol.uninterceptProtocol 'https'
+        done()
+      protocol.interceptProtocol 'https', handler
+
+    it 'can override ws protocol handler', (done) ->
+      handler = remote.createFunctionWithReturnValue 'valar morghulis'
+      protocol.once 'intercepted', ->
+        protocol.uninterceptProtocol 'ws'
+        done()
+      protocol.interceptProtocol 'ws', handler
+
+    it 'can override wss protocol handler', (done) ->
+      handler = remote.createFunctionWithReturnValue 'valar morghulis'
+      protocol.once 'intercepted', ->
+        protocol.uninterceptProtocol 'wss'
+        done()
+      protocol.interceptProtocol 'wss', handler

--- a/spec/api-protocol-spec.coffee
+++ b/spec/api-protocol-spec.coffee
@@ -190,3 +190,10 @@ describe 'protocol module', ->
             assert false, 'Got error: ' + errorType + ' ' + error
             free()
       protocol.interceptProtocol 'file', handler
+
+    it 'can override http protocol handler', (done) ->
+      handler = remote.createFunctionWithReturnValue 'valar morghulis'
+      protocol.once 'intercepted', ->
+        protocol.uninterceptProtocol 'http'
+        done()
+      protocol.interceptProtocol 'http', handler


### PR DESCRIPTION
Fixes https://github.com/atom/electron/issues/542

Need some clarification on how useful is this interceptor api, is there any wide use case for it to be present ? If its just offline scenario, wont service workers help out.. ?