### PR TITLE
webContents: providing response headers in did-get-response-details event

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -278,13 +278,19 @@ void WebContents::DidStopLoading(content::RenderViewHost* render_view_host) {
 
 void WebContents::DidGetResourceResponseStart(
     const content::ResourceRequestDetails& details) {
+  auto context = AtomBrowserContext::Get();
+  std::string headers;
+  if (context)
+    headers = context->GetNetworkDelegate()->GetResponseHeaders(details.url);
+
   Emit("did-get-response-details",
        details.socket_address.IsEmpty(),
        details.url,
        details.original_url,
        details.http_response_code,
        details.method,
-       details.referrer);
+       details.referrer,
+       headers);
 }
 
 void WebContents::DidGetRedirectForResourceRequest(

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -37,6 +37,7 @@
 #include "native_mate/callback.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
+#include "net/url_request/url_request_context.h"
 
 #include "atom/common/node_includes.h"
 
@@ -278,7 +279,8 @@ void WebContents::DidStopLoading(content::RenderViewHost* render_view_host) {
 
 void WebContents::DidGetResourceResponseStart(
     const content::ResourceRequestDetails& details) {
-  auto context = AtomBrowserContext::Get();
+  auto context = static_cast<brightray::BrowserContext*>(
+                    web_contents()->GetBrowserContext());
   std::string headers;
   if (context)
     headers = context->GetNetworkDelegate()->GetResponseHeaders(details.url);

--- a/atom/renderer/lib/web-view/guest-view-internal.coffee
+++ b/atom/renderer/lib/web-view/guest-view-internal.coffee
@@ -10,7 +10,8 @@ WEB_VIEW_EVENTS =
   'did-start-loading': []
   'did-stop-loading': []
   'did-get-response-details': ['status', 'newUrl', 'originalUrl',
-                               'httpResponseCode', 'requestMethod', 'referrer']
+                               'httpResponseCode', 'requestMethod', 'referrer',
+                               'headers']
   'did-get-redirect-request': ['oldUrl', 'newUrl', 'isMainFrame']
   'dom-ready': []
   'console-message': ['level', 'message', 'line', 'sourceId']

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -666,9 +666,11 @@ Corresponds to the points in time when the spinner of the tab stops spinning.
 * `httpResponseCode` Integer
 * `requestMethod` String
 * `referrer` String
+* `headers` String
 
 Emitted when details regarding a requested resource is available.
 `status` indicates the socket connection to download the resource.
+`headers` is key-value string separated by new-line character.
 
 ### Event: 'did-get-redirect-request'
 

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -325,9 +325,11 @@ Corresponds to the points in time when the spinner of the tab stops spinning.
 * `httpResponseCode` Integer
 * `requestMethod` String
 * `referrer` String
+* `headers` String
 
 Fired when details regarding a requested resource is available.
 `status` indicates socket connection to download the resource.
+`headers` is key-value string separated by new-line character.
 
 ### did-get-redirect-request
 


### PR DESCRIPTION
Fixes #1253 

the event now provides response headers as a string with key-value separated by new-line character. Just left the parsing to users or should we do it and return as an object ?

```
[30920:0507/170512:INFO:CONSOLE(116)] "HTTP/1.1 200 OK
Content-Disposition: inline; filename="Untitled-5.jpg"
X-Thumbnailer: Vignette
Content-Type: image/jpeg
X-Surrogate-Key: 77b98cc1f264c61cfe91a373a74e6d646daca3ad
Server: Jetty(9.2.z-SNAPSHOT)
X-Cacheable: YES
Content-Length: 8933224
Accept-Ranges: bytes
Date: Wed, 06 May 2015 13:19:31 GMT
Age: 1332140
X-Served-By: vignette-s1, cache-wk-sjc3160-WIKIA, cache-sn87-SIN
X-Cache: ORIGIN, HIT, HIT
X-Cache-Hits: ORIGIN, 1, 1
X-Timer: S1430918371.297632,VS0,VE20
Vary: Accept-Encoding
Timing-Allow-Origin: *
Cache-Control: max-age=31536000, public
", source: file:///Users/dmohan/projects/github/hello-atom/tray-app/index.html (116)
```

Depends on https://github.com/atom/brightray/pull/105