### PR TITLE
Fix wording in docs/api/remote.md

### DIFF
--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -49,7 +49,7 @@ Primary value types like strings and numbers, however, are sent by copy.
 
 ## Passing callbacks to the main process
 
-Some APIs in the main process accept callbacks, and it would be attempting to
+Some APIs in the main process accept callbacks, and it would be tempting to
 pass callbacks when calling a remote function. The `remote` module does support
 doing this, but you should also be extremely careful with this.
 


### PR DESCRIPTION
[...] it would be `attempting -> tempting` to pass callbacks when calling a remote function.