### PR TITLE
Don't use [NSScreen mainScreen]

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -303,7 +303,7 @@ NativeWindowMac::NativeWindowMac(content::WebContents* web_contents,
   options.Get(switches::kWidth, &width);
   options.Get(switches::kHeight, &height);
 
-  NSRect main_screen_rect = [[NSScreen mainScreen] frame];
+  NSRect main_screen_rect = [[[NSScreen screens] objectAtIndex:0] frame];
   NSRect cocoa_bounds = NSMakeRect(
       round((NSWidth(main_screen_rect) - width) / 2) ,
       round((NSHeight(main_screen_rect) - height) / 2),
@@ -463,7 +463,7 @@ void NativeWindowMac::SetBounds(const gfx::Rect& bounds) {
                                    bounds.width(),
                                    bounds.height());
   // Flip coordinates based on the primary screen.
-  NSScreen* screen = [NSScreen mainScreen];
+  NSScreen* screen = [[NSScreen screens] objectAtIndex:0];
   cocoa_bounds.origin.y =
       NSHeight([screen frame]) - bounds.height() - bounds.y();
 
@@ -473,7 +473,7 @@ void NativeWindowMac::SetBounds(const gfx::Rect& bounds) {
 gfx::Rect NativeWindowMac::GetBounds() {
   NSRect frame = [window_ frame];
   gfx::Rect bounds(frame.origin.x, 0, NSWidth(frame), NSHeight(frame));
-  NSScreen* screen = [NSScreen mainScreen];
+  NSScreen* screen = [[NSScreen screens] objectAtIndex:0];
   bounds.set_y(NSHeight([screen frame]) - NSMaxY(frame));
   return bounds;
 }

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -30,7 +30,7 @@
   NSRect frame = [NSApp currentEvent].window.frame;
   gfx::Rect bounds(frame.origin.x, 0, NSWidth(frame), NSHeight(frame));
   // Flip coordinates to gfx (0,0 in top-left corner) using current screen.
-  NSScreen* screen = [NSScreen mainScreen];
+  NSScreen* screen = [[NSScreen screens] objectAtIndex:0];
   bounds.set_y(NSHeight([screen frame]) - NSMaxY(frame));
 
   trayIcon_->NotifyClicked(bounds);


### PR DESCRIPTION
For multiple monitors we still want to get window positions based on primary monitor so we can correctly show the window on specified monitor. Fixes #1625.