### PR TITLE
Keep asar archive's file opened in the archive's whole life time

### DIFF
--- a/atom/common/api/atom_api_asar.cc
+++ b/atom/common/api/atom_api_asar.cc
@@ -88,6 +88,13 @@ class Archive : public mate::Wrappable {
     return mate::ConvertToV8(isolate, new_path);
   }
 
+  // Return the file descriptor.
+  int GetFD() const {
+    if (!archive_)
+      return -1;
+    return archive_->GetFD();
+  }
+
   // Free the resources used by archive.
   void Destroy() {
     archive_.reset();
@@ -102,6 +109,7 @@ class Archive : public mate::Wrappable {
         .SetMethod("readdir", &Archive::Readdir)
         .SetMethod("realpath", &Archive::Realpath)
         .SetMethod("copyFileOut", &Archive::CopyFileOut)
+        .SetMethod("getFd", &Archive::GetFD)
         .SetMethod("destroy", &Archive::Destroy);
   }
 

--- a/atom/common/asar/archive.cc
+++ b/atom/common/asar/archive.cc
@@ -104,6 +104,7 @@ bool FillFileInfoWithNode(Archive::FileInfo* info,
 
 Archive::Archive(const base::FilePath& path)
     : path_(path),
+      file_(path_, base::File::FLAG_OPEN | base::File::FLAG_READ),
       header_size_(0) {
 }
 
@@ -111,15 +112,14 @@ Archive::~Archive() {
 }
 
 bool Archive::Init() {
-  base::File file(path_, base::File::FLAG_OPEN | base::File::FLAG_READ);
-  if (!file.IsValid())
+  if (!file_.IsValid())
     return false;
 
   std::vector<char> buf;
   int len;
 
   buf.resize(8);
-  len = file.ReadAtCurrentPos(buf.data(), buf.size());
+  len = file_.ReadAtCurrentPos(buf.data(), buf.size());
   if (len != static_cast<int>(buf.size())) {
     PLOG(ERROR) << "Failed to read header size from " << path_.value();
     return false;
@@ -132,7 +132,7 @@ bool Archive::Init() {
   }
 
   buf.resize(size);
-  len = file.ReadAtCurrentPos(buf.data(), buf.size());
+  len = file_.ReadAtCurrentPos(buf.data(), buf.size());
   if (len != static_cast<int>(buf.size())) {
     PLOG(ERROR) << "Failed to read header from " << path_.value();
     return false;
@@ -250,7 +250,7 @@ bool Archive::CopyFileOut(const base::FilePath& path, base::FilePath* out) {
   }
 
   scoped_ptr<ScopedTemporaryFile> temp_file(new ScopedTemporaryFile);
-  if (!temp_file->InitFromFile(path_, info.offset, info.size))
+  if (!temp_file->InitFromFile(file_, info.offset, info.size))
     return false;
 
   *out = temp_file->path();

--- a/atom/common/asar/archive.h
+++ b/atom/common/asar/archive.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "base/containers/scoped_ptr_hash_map.h"
+#include "base/files/file.h"
 #include "base/files/file_path.h"
 #include "base/memory/scoped_ptr.h"
 
@@ -64,6 +65,7 @@ class Archive {
 
  private:
   base::FilePath path_;
+  base::File file_;
   uint32 header_size_;
   scoped_ptr<base::DictionaryValue> header_;
 

--- a/atom/common/asar/archive.h
+++ b/atom/common/asar/archive.h
@@ -60,6 +60,9 @@ class Archive {
   // For unpacked file, this method will return its real path.
   bool CopyFileOut(const base::FilePath& path, base::FilePath* out);
 
+  // Returns the file's fd.
+  int GetFD() const;
+
   base::FilePath path() const { return path_; }
   base::DictionaryValue* header() const { return header_.get(); }
 

--- a/atom/common/asar/scoped_temporary_file.cc
+++ b/atom/common/asar/scoped_temporary_file.cc
@@ -36,13 +36,12 @@ bool ScopedTemporaryFile::Init() {
   return base::CreateTemporaryFile(&path_);
 }
 
-bool ScopedTemporaryFile::InitFromFile(const base::FilePath& path,
+bool ScopedTemporaryFile::InitFromFile(base::File& src,
                                        uint64 offset, uint64 size) {
-  if (!Init())
+  if (!src.IsValid())
     return false;
 
-  base::File src(path, base::File::FLAG_OPEN | base::File::FLAG_READ);
-  if (!src.IsValid())
+  if (!Init())
     return false;
 
   std::vector<char> buf(size);

--- a/atom/common/asar/scoped_temporary_file.cc
+++ b/atom/common/asar/scoped_temporary_file.cc
@@ -36,16 +36,16 @@ bool ScopedTemporaryFile::Init() {
   return base::CreateTemporaryFile(&path_);
 }
 
-bool ScopedTemporaryFile::InitFromFile(base::File& src,
+bool ScopedTemporaryFile::InitFromFile(base::File* src,
                                        uint64 offset, uint64 size) {
-  if (!src.IsValid())
+  if (!src->IsValid())
     return false;
 
   if (!Init())
     return false;
 
   std::vector<char> buf(size);
-  int len = src.Read(offset, buf.data(), buf.size());
+  int len = src->Read(offset, buf.data(), buf.size());
   if (len != static_cast<int>(size))
     return false;
 

--- a/atom/common/asar/scoped_temporary_file.h
+++ b/atom/common/asar/scoped_temporary_file.h
@@ -26,7 +26,7 @@ class ScopedTemporaryFile {
   bool Init();
 
   // Init an temporary file and fill it with content of |path|.
-  bool InitFromFile(base::File& src, uint64 offset, uint64 size);
+  bool InitFromFile(base::File* src, uint64 offset, uint64 size);
 
   base::FilePath path() const { return path_; }
 

--- a/atom/common/asar/scoped_temporary_file.h
+++ b/atom/common/asar/scoped_temporary_file.h
@@ -7,6 +7,10 @@
 
 #include "base/files/file_path.h"
 
+namespace base {
+class File;
+}
+
 namespace asar {
 
 // An object representing a temporary file that should be cleaned up when this
@@ -22,7 +26,7 @@ class ScopedTemporaryFile {
   bool Init();
 
   // Init an temporary file and fill it with content of |path|.
-  bool InitFromFile(const base::FilePath& path, uint64 offset, uint64 size);
+  bool InitFromFile(base::File& src, uint64 offset, uint64 size);
 
   base::FilePath path() const { return path_; }
 


### PR DESCRIPTION
This PR keeps asar archive opened so we don't need to reopen it for every fs operation on it, we can have potential performance boost from it.

As a side effect, when the asar archive is overwritten or deleted due to auto-updating or something else, Electron will still read the original archive. Fixes #1219.