### PR TITLE
Fix handling in-page navigations

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -6,6 +6,7 @@
 
 #include <set>
 
+#include "atom/browser/atom_browser_client.h"
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/atom_javascript_dialog_manager.h"
 #include "atom/browser/native_window.h"
@@ -444,10 +445,12 @@ void WebContents::ReloadIgnoringCache() {
 }
 
 void WebContents::GoBack() {
+  atom::AtomBrowserClient::SuppressRendererProcessRestartForOnce();
   web_contents()->GetController().GoBack();
 }
 
 void WebContents::GoForward() {
+  atom::AtomBrowserClient::SuppressRendererProcessRestartForOnce();
   web_contents()->GetController().GoForward();
 }
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -454,6 +454,11 @@ void WebContents::GoForward() {
   web_contents()->GetController().GoForward();
 }
 
+void WebContents::GoToOffset(int offset) {
+  atom::AtomBrowserClient::SuppressRendererProcessRestartForOnce();
+  web_contents()->GetController().GoToOffset(offset);
+}
+
 int WebContents::GetRoutingID() const {
   return web_contents()->GetRoutingID();
 }
@@ -624,6 +629,7 @@ mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
         .SetMethod("_reloadIgnoringCache", &WebContents::ReloadIgnoringCache)
         .SetMethod("_goBack", &WebContents::GoBack)
         .SetMethod("_goForward", &WebContents::GoForward)
+        .SetMethod("_goToOffset", &WebContents::GoToOffset)
         .SetMethod("getRoutingId", &WebContents::GetRoutingID)
         .SetMethod("getProcessId", &WebContents::GetProcessID)
         .SetMethod("isCrashed", &WebContents::IsCrashed)

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -443,6 +443,14 @@ void WebContents::ReloadIgnoringCache() {
   web_contents()->GetController().ReloadIgnoringCache(false);
 }
 
+void WebContents::GoBack() {
+  web_contents()->GetController().GoBack();
+}
+
+void WebContents::GoForward() {
+  web_contents()->GetController().GoForward();
+}
+
 int WebContents::GetRoutingID() const {
   return web_contents()->GetRoutingID();
 }
@@ -611,6 +619,8 @@ mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
         .SetMethod("isWaitingForResponse", &WebContents::IsWaitingForResponse)
         .SetMethod("_stop", &WebContents::Stop)
         .SetMethod("_reloadIgnoringCache", &WebContents::ReloadIgnoringCache)
+        .SetMethod("_goBack", &WebContents::GoBack)
+        .SetMethod("_goForward", &WebContents::GoForward)
         .SetMethod("getRoutingId", &WebContents::GetRoutingID)
         .SetMethod("getProcessId", &WebContents::GetProcessID)
         .SetMethod("isCrashed", &WebContents::IsCrashed)

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -348,8 +348,9 @@ void WebContents::WebContentsDestroyed() {
 }
 
 void WebContents::NavigationEntryCommitted(
-    const content::LoadCommittedDetails& load_details) {
-  Emit("navigation-entry-commited", load_details.entry->GetURL());
+    const content::LoadCommittedDetails& details) {
+  Emit("navigation-entry-commited", details.entry->GetURL(),
+       details.is_in_page, details.did_replace_entry);
 }
 
 void WebContents::DidAttach(int guest_proxy_routing_id) {

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -53,6 +53,9 @@ class WebContents : public mate::EventEmitter,
   bool IsWaitingForResponse() const;
   void Stop();
   void ReloadIgnoringCache();
+  void GoBack();
+  void GoForward();
+  void GoToIndex();
   int GetRoutingID() const;
   int GetProcessID() const;
   bool IsCrashed() const;

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -55,7 +55,7 @@ class WebContents : public mate::EventEmitter,
   void ReloadIgnoringCache();
   void GoBack();
   void GoForward();
-  void GoToIndex();
+  void GoToOffset(int offset);
   int GetRoutingID() const;
   int GetProcessID() const;
   bool IsCrashed() const;

--- a/atom/browser/api/lib/navigation-controller.coffee
+++ b/atom/browser/api/lib/navigation-controller.coffee
@@ -1,3 +1,9 @@
+ipc = require 'ipc'
+
+# The history operation in renderer is redirected to browser.
+ipc.on 'ATOM_SHELL_NAVIGATION_CONTROLLER', (event, method, args...) ->
+  event.sender[method] args...
+
 # JavaScript implementation of Chromium's NavigationController.
 # Instead of relying on Chromium for history control, we compeletely do history
 # control on user land, and only rely on WebContents.loadUrl for navigation.

--- a/atom/browser/api/lib/navigation-controller.coffee
+++ b/atom/browser/api/lib/navigation-controller.coffee
@@ -94,7 +94,12 @@ class NavigationController
 
   goToOffset: (offset) ->
     return unless @canGoToOffset offset
-    @goToIndex @currentIndex + offset
+    pendingIndex = @currentIndex + offset
+    if @inPageIndex > -1 and pendingIndex >= @inPageIndex
+      @pendingIndex = pendingIndex
+      @webContents._goToOffset offset
+    else
+      @goToIndex pendingIndex
 
   getActiveIndex: ->
     if @pendingIndex is -1 then @currentIndex else @pendingIndex

--- a/atom/browser/api/lib/web-contents.coffee
+++ b/atom/browser/api/lib/web-contents.coffee
@@ -29,7 +29,6 @@ module.exports.wrap = (webContents) ->
 
   # The navigation controller.
   controller = new NavigationController(webContents)
-  webContents.controller = controller
   for name, method of NavigationController.prototype when method instanceof Function
     do (name, method) ->
       webContents[name] = -> method.apply controller, arguments

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -32,6 +32,9 @@ namespace atom {
 
 namespace {
 
+// Next navigation should not restart renderer process.
+bool g_suppress_renderer_process_restart = false;
+
 struct FindByProcessId {
   explicit FindByProcessId(int child_process_id)
       : child_process_id_(child_process_id) {
@@ -50,6 +53,11 @@ struct FindByProcessId {
 };
 
 }  // namespace
+
+// static
+void AtomBrowserClient::SuppressRendererProcessRestartForOnce() {
+  g_suppress_renderer_process_restart = true;
+}
 
 AtomBrowserClient::AtomBrowserClient()
     : dying_render_process_(nullptr) {
@@ -131,6 +139,11 @@ void AtomBrowserClient::OverrideSiteInstanceForNavigation(
     content::SiteInstance* current_instance,
     const GURL& url,
     content::SiteInstance** new_instance) {
+  if (g_suppress_renderer_process_restart) {
+    g_suppress_renderer_process_restart = false;
+    return;
+  }
+
   if (current_instance->HasProcess())
     dying_render_process_ = current_instance->GetProcess();
 

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -18,6 +18,9 @@ class AtomBrowserClient : public brightray::BrowserClient {
   AtomBrowserClient();
   virtual ~AtomBrowserClient();
 
+  // Don't force renderer process to restart for once.
+  static void SuppressRendererProcessRestartForOnce();
+
  protected:
   // content::ContentBrowserClient:
   void RenderProcessWillLaunch(content::RenderProcessHost* host) override;

--- a/atom/browser/lib/rpc-server.coffee
+++ b/atom/browser/lib/rpc-server.coffee
@@ -107,6 +107,9 @@ ipc.on 'ATOM_BROWSER_CURRENT_WINDOW', (event, guestInstanceId) ->
   catch e
     event.returnValue = errorToMeta e
 
+ipc.on 'ATOM_BROWSER_CURRENT_WEB_CONTENTS', (event) ->
+  event.returnValue = valueToMeta event.sender, event.sender
+
 ipc.on 'ATOM_BROWSER_CONSTRUCTOR', (event, id, args) ->
   try
     args = unwrapArgs event.sender, args

--- a/atom/renderer/api/lib/remote.coffee
+++ b/atom/renderer/api/lib/remote.coffee
@@ -110,12 +110,19 @@ exports.require = (module) ->
   meta = ipc.sendSync 'ATOM_BROWSER_REQUIRE', module
   moduleCache[module] = metaToValue meta
 
-# Get current window object.
+# Get current BrowserWindow object.
 windowCache = null
 exports.getCurrentWindow = ->
   return windowCache if windowCache?
   meta = ipc.sendSync 'ATOM_BROWSER_CURRENT_WINDOW', process.guestInstanceId
   windowCache = metaToValue meta
+
+# Get current WebContents object.
+webContentsCache = null
+exports.getCurrentWebContents = ->
+  return webContentsCache if webContentsCache?
+  meta = ipc.sendSync 'ATOM_BROWSER_CURRENT_WEB_CONTENTS'
+  webContentsCache = metaToValue meta
 
 # Get a global object in browser.
 exports.getGlobal = (name) ->

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -74,6 +74,12 @@ window.confirm = (message, title='') ->
 window.prompt = ->
   throw new Error('prompt() is and will not be supported.')
 
+# Forward history operations to browser.
+window.history.back = ->
+  remote.getCurrentWebContents().goBack()
+window.history.forward = ->
+  remote.getCurrentWebContents().goForward()
+
 window.opener =
   postMessage: (message, targetOrigin='*') ->
     ipc.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', message, targetOrigin

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -74,15 +74,16 @@ window.confirm = (message, title='') ->
 window.prompt = ->
   throw new Error('prompt() is and will not be supported.')
 
-# Forward history operations to browser.
-window.history.back = ->
-  remote.getCurrentWebContents().goBack()
-window.history.forward = ->
-  remote.getCurrentWebContents().goForward()
-
+# Simple implementation of postMessage.
 window.opener =
   postMessage: (message, targetOrigin='*') ->
     ipc.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', message, targetOrigin
 
 ipc.on 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', (message, targetOrigin) ->
   window.postMessage message, targetOrigin
+
+# Forward history operations to browser.
+sendHistoryOperation = (args...) ->
+  ipc.send 'ATOM_SHELL_NAVIGATION_CONTROLLER', args...
+window.history.back = -> sendHistoryOperation 'goBack'
+window.history.forward = -> sendHistoryOperation 'goForward'

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -87,3 +87,4 @@ sendHistoryOperation = (args...) ->
   ipc.send 'ATOM_SHELL_NAVIGATION_CONTROLLER', args...
 window.history.back = -> sendHistoryOperation 'goBack'
 window.history.forward = -> sendHistoryOperation 'goForward'
+window.history.go = (offset) -> sendHistoryOperation 'goToOffset', offset

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -138,6 +138,10 @@ Returns the object returned by `require(module)` in the main process.
 Returns the [BrowserWindow](browser-window.md) object which this web page
 belongs to.
 
+## remote.getCurrentWebContent()
+
+Returns the WebContents object of this web page.
+
 ## remote.getGlobal(name)
 
 * `name` String


### PR DESCRIPTION
When in-page navigations happened we should not do full page refreshes. Fixes #1608.