### PR TITLE
Correct link of debugging UI

### DIFF
--- a/docs/tutorial/debugging-main-process.md
+++ b/docs/tutorial/debugging-main-process.md
@@ -44,6 +44,6 @@ $ electron --debug-brk=5858 your/app
 
 ### 3. Load the debugger UI
 
-Open http://127.0.0.1:8080/debug?port=5858 in the Chrome browser.
+Open http://127.0.0.1:8080/debug?ws=127.0.0.1:8080&port=5858 in the Chrome browser.
 
 [node-inspector]: https://github.com/node-inspector/node-inspector


### PR DESCRIPTION
Using the link provided one receives a response of `Cannot GET /[object%20Object]`.

I've tested this on electron 0.25.3 using the example application and node-inspector version 0.10.0.
The url change is the url provided by node-inspector in the terminal window.