### PR TITLE
Load pdf library dynamically

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -124,7 +124,9 @@
                       '<@(libchromiumcontent_shared_v8_libraries)',
                     ],
                   }, {
-                    'copied_libraries': [],
+                    'copied_libraries': [
+                      '<(libchromiumcontent_dir)/pdf.dll',
+                    ],
                   }],
                 ],
               },
@@ -134,7 +136,6 @@
                 '<(libchromiumcontent_dir)/ffmpegsumo.dll',
                 '<(libchromiumcontent_dir)/libEGL.dll',
                 '<(libchromiumcontent_dir)/libGLESv2.dll',
-                '<(libchromiumcontent_dir)/pdf.dll',
                 '<(libchromiumcontent_dir)/icudtl.dat',
                 '<(libchromiumcontent_dir)/content_resources_200_percent.pak',
                 '<(libchromiumcontent_dir)/content_shell.pak',

--- a/atom.gyp
+++ b/atom.gyp
@@ -134,6 +134,7 @@
                 '<(libchromiumcontent_dir)/ffmpegsumo.dll',
                 '<(libchromiumcontent_dir)/libEGL.dll',
                 '<(libchromiumcontent_dir)/libGLESv2.dll',
+                '<(libchromiumcontent_dir)/pdf.dll',
                 '<(libchromiumcontent_dir)/icudtl.dat',
                 '<(libchromiumcontent_dir)/content_resources_200_percent.pak',
                 '<(libchromiumcontent_dir)/content_shell.pak',

--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -64,6 +64,12 @@ void AtomMainDelegate::PreSandboxStartup() {
   std::string process_type = command_line->GetSwitchValueASCII(
       switches::kProcessType);
 
+#if defined(OS_WIN)
+  if (process_type == switches::kUtilityProcess) {
+    AtomContentUtilityClient::PreSandboxStartup();
+  }
+#endif
+
   // Only append arguments for browser process.
   if (!process_type.empty())
     return;

--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -64,11 +64,9 @@ void AtomMainDelegate::PreSandboxStartup() {
   std::string process_type = command_line->GetSwitchValueASCII(
       switches::kProcessType);
 
-#if defined(OS_WIN)
   if (process_type == switches::kUtilityProcess) {
     AtomContentUtilityClient::PreSandboxStartup();
   }
-#endif
 
   // Only append arguments for browser process.
   if (!process_type.empty())

--- a/atom/utility/atom_content_utility_client.cc
+++ b/atom/utility/atom_content_utility_client.cc
@@ -71,4 +71,9 @@ void AtomContentUtilityClient::OnStartupPing() {
   // Don't release the process, we assume further messages are on the way.
 }
 
+// static
+void AtomContentUtilityClient::PreSandboxStartup() {
+  PrintingHandler::PreSandboxStartup();
+}
+
 }  // namespace atom

--- a/atom/utility/atom_content_utility_client.cc
+++ b/atom/utility/atom_content_utility_client.cc
@@ -17,7 +17,7 @@
 
 
 #if defined(OS_WIN)
-#include "chrome/utility/printing_handler.h"
+#include "chrome/utility/printing_handler_win.h"
 #endif
 
 
@@ -37,7 +37,7 @@ int64_t AtomContentUtilityClient::max_ipc_message_size_ =
 AtomContentUtilityClient::AtomContentUtilityClient()
     : filter_messages_(false) {
 #if defined(OS_WIN)
-  handlers_.push_back(new PrintingHandler());
+  handlers_.push_back(new PrintingHandlerWin());
 #endif
 }
 
@@ -73,7 +73,9 @@ void AtomContentUtilityClient::OnStartupPing() {
 
 // static
 void AtomContentUtilityClient::PreSandboxStartup() {
-  PrintingHandler::PreSandboxStartup();
+#if defined(OS_WIN)
+  PrintingHandlerWin::PreSandboxStartup();
+#endif
 }
 
 }  // namespace atom

--- a/atom/utility/atom_content_utility_client.h
+++ b/atom/utility/atom_content_utility_client.h
@@ -31,6 +31,7 @@ class AtomContentUtilityClient : public content::ContentUtilityClient {
   void UtilityThreadStarted() override;
   bool OnMessageReceived(const IPC::Message& message) override;
 
+  static void PreSandboxStartup();
 
   static void set_max_ipc_message_size_for_test(int64_t max_message_size) {
     max_ipc_message_size_ = max_message_size;

--- a/chromium_src/chrome/utility/printing_handler.h
+++ b/chromium_src/chrome/utility/printing_handler.h
@@ -30,6 +30,8 @@ class PrintingHandler : public UtilityMessageHandler {
   // IPC::Listener:
   bool OnMessageReceived(const IPC::Message& message) override;
 
+  static void PrintingHandler::PreSandboxStartup();
+
  private:
   // IPC message handlers.
 #if defined(OS_WIN)

--- a/chromium_src/chrome/utility/printing_handler_win.h
+++ b/chromium_src/chrome/utility/printing_handler_win.h
@@ -2,18 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef CHROME_UTILITY_PRINTING_HANDLER_H_
-#define CHROME_UTILITY_PRINTING_HANDLER_H_
+#ifndef CHROME_UTILITY_PRINTING_HANDLER_WIN_H_
+#define CHROME_UTILITY_PRINTING_HANDLER_WIN_H_
 
 #include "base/compiler_specific.h"
 #include "base/macros.h"
 #include "chrome/utility/utility_message_handler.h"
 #include "ipc/ipc_platform_file.h"
 #include "printing/pdf_render_settings.h"
-
-#if !defined(ENABLE_PRINT_PREVIEW) && !defined(OS_WIN)
-#error "Windows or full printing must be enabled"
-#endif
 
 namespace printing {
 class PdfRenderSettings;
@@ -22,40 +18,34 @@ struct PageRange;
 }
 
 // Dispatches IPCs for printing.
-class PrintingHandler : public UtilityMessageHandler {
+class PrintingHandlerWin : public UtilityMessageHandler {
  public:
-  PrintingHandler();
-  ~PrintingHandler() override;
+  PrintingHandlerWin();
+  ~PrintingHandlerWin() override;
 
   // IPC::Listener:
   bool OnMessageReceived(const IPC::Message& message) override;
 
-  static void PrintingHandler::PreSandboxStartup();
+  static void PrintingHandlerWin::PreSandboxStartup();
 
  private:
   // IPC message handlers.
-#if defined(OS_WIN)
   void OnRenderPDFPagesToMetafile(IPC::PlatformFileForTransit pdf_transit,
                                   const printing::PdfRenderSettings& settings);
   void OnRenderPDFPagesToMetafileGetPage(
       int page_number,
       IPC::PlatformFileForTransit output_file);
   void OnRenderPDFPagesToMetafileStop();
-#endif  // OS_WIN
 
-#if defined(OS_WIN)
   int LoadPDF(base::File pdf_file);
   bool RenderPdfPageToMetafile(int page_number,
                                base::File output_file,
                                float* scale_factor);
-#endif  // OS_WIN
 
-#if defined(OS_WIN)
   std::vector<char> pdf_data_;
   printing::PdfRenderSettings pdf_rendering_settings_;
-#endif
 
-  DISALLOW_COPY_AND_ASSIGN(PrintingHandler);
+  DISALLOW_COPY_AND_ASSIGN(PrintingHandlerWin);
 };
 
-#endif  // CHROME_UTILITY_PRINTING_HANDLER_H_
+#endif  // CHROME_UTILITY_PRINTING_HANDLER_WIN_H_

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -543,6 +543,10 @@ up system's default printer and default settings for printing.
 Calling `window.print()` in web page is equivalent to call
 `BrowserWindow.print({silent: false, printBackground: false})`.
 
+**Note:** On Windows, the print API relies on `pdf.dll`. If your application
+doesn't need print feature, you can safely remove `pdf.dll` in saving binary
+size.
+
 ### BrowserWindow.loadUrl(url)
 
 Same with `webContents.loadUrl(url)`.

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -381,8 +381,8 @@
       'chromium_src/chrome/browser/ui/views/color_chooser_win.cc',
       'chromium_src/chrome/browser/printing/pdf_to_emf_converter.cc',
       'chromium_src/chrome/browser/printing/pdf_to_emf_converter.h',
-      'chromium_src/chrome/utility/printing_handler.cc',
-      'chromium_src/chrome/utility/printing_handler.h',
+      'chromium_src/chrome/utility/printing_handler_win.cc',
+      'chromium_src/chrome/utility/printing_handler_win.h',
     ],
     'framework_sources': [
       'atom/app/atom_library_main.h',


### PR DESCRIPTION
Instead of linking pdf libraries statically, we make the pdf libraries into a single shared library(pdf.dll).

Electron.exe will only load the `pdf.dll` programmatically during `print` API invoking. Moreover, the developer can safely remove `pdf.dll` if they don't need the `print` API in saving binary size.

Below is some compared data of binary size with the latest release v0.26.0:
* v0.26.0:  80.6 MB(`electron.exe`)
* with this patch:  74.6MB(`electron.exe`) + 9.3 MB(`pdf.dll`)

Depends on atom/libchromiumcontent#115

## TODO


* [x] Test Release build
* [x] Test Debug build
 


