### PR TITLE
Add demos repository in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Guides and the API reference are located in the
 [docs](https://github.com/atom/electron/tree/master/docs) directory. It also
 contains documents describing how to build and contribute to Electron.
 
+## Demos
+
+You can find sample apps [in the demos repository](https://github.com/hokein/electron-sample-apps).
+
 ## Community
 
 There is an [`electron` category on the Atom forums](http://discuss.atom.io/category/electron)


### PR DESCRIPTION
I have migrated all the sample apps from [nw-sample-apps](https://github.com/zcbenz/nw-sample-apps), enable them running on electron. 