### PR TITLE
Replace 'standard-window' option with 'textured'

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -310,12 +310,12 @@ NativeWindowMac::NativeWindowMac(content::WebContents* web_contents,
       width,
       height);
 
-  bool useStandardWindow = true;
-  options.Get(switches::kStandardWindow, &useStandardWindow);
+  bool useTexturedWindow = false;
+  options.Get(switches::kTextured, &useTexturedWindow);
 
   NSUInteger styleMask = NSTitledWindowMask | NSClosableWindowMask |
                          NSMiniaturizableWindowMask | NSResizableWindowMask;
-  if (!useStandardWindow || transparent_ || !has_frame_) {
+  if (useTexturedWindow || transparent_ || !has_frame_) {
     styleMask |= NSTexturedBackgroundWindowMask;
   }
 

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -78,14 +78,14 @@ const char kPreloadScript[] = "preload";
 // Whether the window should be transparent.
 const char kTransparent[] = "transparent";
 
+// Use OS X's textured window background.
+const char kTextured[] = "textured";
+
 // Window type hint.
 const char kType[] = "type";
 
 // Disable auto-hiding cursor.
 const char kDisableAutoHideCursor[] = "disable-auto-hide-cursor";
-
-// Use the OS X's standard window instead of the textured window.
-const char kStandardWindow[] = "standard-window";
 
 // Web runtime features.
 const char kExperimentalFeatures[]       = "experimental-features";

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -42,9 +42,9 @@ extern const char kPpapiFlashVersion[];
 extern const char kGuestInstanceID[];
 extern const char kPreloadScript[];
 extern const char kTransparent[];
+extern const char kTextured[];
 extern const char kType[];
 extern const char kDisableAutoHideCursor[];
-extern const char kStandardWindow[];
 
 extern const char kExperimentalFeatures[];
 extern const char kExperimentalCanvasFeatures[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -72,8 +72,8 @@ You can also create a window without chrome by using
   * `type` String - Specifies the type of the window, possible types are
     `desktop`, `dock`, `toolbar`, `splash`, `notification`. This only works on
     Linux.
-  * `standard-window` Boolean - Uses the OS X's standard window instead of the
-    textured window. Defaults to `true`.
+  * `textured` Boolean - Uses OS X's textured window background instead of the
+    standard appearance. Defaults to `false`.
   * `web-preferences` Object - Settings of web page's features
     * `javascript` Boolean
     * `web-security` Boolean


### PR DESCRIPTION
This provides clearer semantics and gets the naming consistent with other flags
that control appearance. Amendment to #1585.