### PR TITLE
compile-coffee.py searches for node even on non-windows systems

### DIFF
--- a/tools/compile-coffee.py
+++ b/tools/compile-coffee.py
@@ -10,6 +10,11 @@ WINDOWS_NODE_PATHs = [
   'C:/Program Files (x86)/nodejs',
   'C:/Program Files/nodejs',
 ] + os.environ['PATH'].split(os.pathsep)
+NIX_NODE_PATHs = [
+  '/usr/local/bin',
+  '/usr/bin',
+  '/bin',
+] + os.environ['PATH'].split(os.pathsep)
 
 
 def main():
@@ -18,20 +23,24 @@ def main():
 
   coffee = os.path.join(SOURCE_ROOT, 'node_modules', 'coffee-script', 'bin',
                         'coffee')
+
+  node = 'node'
   if sys.platform in ['win32', 'cygwin']:
-    node = find_node()
-    if not node:
-      print 'Node.js not found in PATH for building atom-shell'
-      return 1
-    subprocess.check_call(['node', coffee, '-c', '-o', output_dir, input_file],
-                          executable=node)
+    node = find_node(WINDOWS_NODE_PATHs, 'node.exe')
   else:
-    subprocess.check_call(['node', coffee, '-c', '-o', output_dir, input_file])
+    node = find_node(NIX_NODE_PATHs, 'node')
+
+  if not node:
+    print 'Node.js not found in PATH for building electron'
+    return 1
+
+  subprocess.check_call(['node', coffee, '-c', '-o', output_dir, input_file],
+                        executable=node)
 
 
-def find_node():
-  for path in WINDOWS_NODE_PATHs:
-    full_path = os.path.join(path, 'node.exe')
+def find_node(paths, target):
+  for path in paths:
+    full_path = os.path.join(path, target)
     if os.path.exists(full_path):
       return full_path
   return None

--- a/tools/compile-coffee.py
+++ b/tools/compile-coffee.py
@@ -6,16 +6,15 @@ import sys
 
 
 SOURCE_ROOT = os.path.dirname(os.path.dirname(__file__))
-WINDOWS_NODE_PATHs = [
+WINDOWS_NODE_PATHs = os.environ['PATH'].split(os.pathsep) + [
   'C:/Program Files (x86)/nodejs',
   'C:/Program Files/nodejs',
-] + os.environ['PATH'].split(os.pathsep)
-NIX_NODE_PATHs = [
+]
+NIX_NODE_PATHs = os.environ['PATH'].split(os.pathsep) + [
   '/usr/local/bin',
   '/usr/bin',
   '/bin',
-] + os.environ['PATH'].split(os.pathsep)
-
+]
 
 def main():
   input_file = sys.argv[1]


### PR DESCRIPTION
I found myself executing compile-coffee.py in an environment where 'node' was not found in my $PATH (iirc, an Xcode shell script action) so I augmented compile-coffee.py to check the usual suspects -- /usr/local/bin, /usr/bin, and /bin (in addition to $PATH) -- to find 'node'