### PR TITLE
Explicitly null the crash reporter before assigning it

### DIFF
--- a/atom/common/crash_reporter/crash_reporter_win.cc
+++ b/atom/common/crash_reporter/crash_reporter_win.cc
@@ -54,6 +54,7 @@ void CrashReporterWin::InitBreakpad(const std::string& product_name,
   if (waiting_event != INVALID_HANDLE_VALUE)
     WaitForSingleObject(waiting_event, 1000);
 
+  breakpad_.reset(nullptr);
   int handler_types = google_breakpad::ExceptionHandler::HANDLER_EXCEPTION |
       google_breakpad::ExceptionHandler::HANDLER_PURECALL;
   breakpad_.reset(new google_breakpad::ExceptionHandler(

--- a/atom/common/crash_reporter/crash_reporter_win.cc
+++ b/atom/common/crash_reporter/crash_reporter_win.cc
@@ -54,7 +54,11 @@ void CrashReporterWin::InitBreakpad(const std::string& product_name,
   if (waiting_event != INVALID_HANDLE_VALUE)
     WaitForSingleObject(waiting_event, 1000);
 
-  breakpad_.reset(nullptr);
+  // ExceptionHandler() attaches our handler and ~ExceptionHandler() detaches
+  // it, so we must explicitly reset *before* we instantiate our new handler
+  // to allow any previous handler to detach in the correct order.
+  breakpad_.reset();
+
   int handler_types = google_breakpad::ExceptionHandler::HANDLER_EXCEPTION |
       google_breakpad::ExceptionHandler::HANDLER_PURECALL;
   breakpad_.reset(new google_breakpad::ExceptionHandler(


### PR DESCRIPTION
In my app I call CrashReporter start() multiple times (when I need to update the metadata) -- but this doesn't work out of the box -- crashes fail to report.

This change explicitly nulls the existing breakpad EH before allocating a new one to make sure we're cleaning out the old EH before installing the new one.