### PR TITLE
navigation: fix accessing url from history array for goToIndex

### DIFF
--- a/atom/browser/api/lib/navigation-controller.coffee
+++ b/atom/browser/api/lib/navigation-controller.coffee
@@ -90,7 +90,7 @@ class NavigationController
   goToIndex: (index) ->
     return unless @canGoToIndex index
     @pendingIndex = index
-    @webContents._loadUrl @history[@pendingIndex].url, {}
+    @webContents._loadUrl @history[@pendingIndex], {}
 
   goToOffset: (offset) ->
     return unless @canGoToOffset offset


### PR DESCRIPTION
Fixes #1695 