### PR TITLE
navigation: adding clearHistory method

### DIFF
--- a/atom/browser/api/lib/navigation-controller.coffee
+++ b/atom/browser/api/lib/navigation-controller.coffee
@@ -4,6 +4,9 @@ ipc = require 'ipc'
 ipc.on 'ATOM_SHELL_NAVIGATION_CONTROLLER', (event, method, args...) ->
   event.sender[method] args...
 
+ipc.on 'ATOM_SHELL_SYNC_NAVIGATION_CONTROLLER', (event, method, args...) ->
+  event.returnValue = event.sender[method] args...
+
 # JavaScript implementation of Chromium's NavigationController.
 # Instead of relying on Chromium for history control, we compeletely do history
 # control on user land, and only rely on WebContents.loadUrl for navigation.
@@ -11,10 +14,7 @@ ipc.on 'ATOM_SHELL_NAVIGATION_CONTROLLER', (event, method, args...) ->
 # process is restarted everytime.
 class NavigationController
   constructor: (@webContents) ->
-    @history = []
-    @currentIndex = -1
-    @pendingIndex = -1
-    @inPageIndex = -1
+    @clearHistory()
 
     @webContents.on 'navigation-entry-commited', (event, url, inPage, replaceEntry) =>
       if @inPageIndex > -1 and not inPage
@@ -71,6 +71,12 @@ class NavigationController
   canGoToOffset: (offset) ->
     @canGoToIndex @currentIndex + offset
 
+  clearHistory: ->
+    @history = []
+    @currentIndex = -1
+    @pendingIndex = -1
+    @inPageIndex = -1
+
   goBack: ->
     return unless @canGoBack()
     @pendingIndex = @getActiveIndex() - 1
@@ -103,5 +109,8 @@ class NavigationController
 
   getActiveIndex: ->
     if @pendingIndex is -1 then @currentIndex else @pendingIndex
+
+  length: ->
+    @history.length
 
 module.exports = NavigationController

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -85,6 +85,13 @@ ipc.on 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', (message, targetOrigin) ->
 # Forward history operations to browser.
 sendHistoryOperation = (args...) ->
   ipc.send 'ATOM_SHELL_NAVIGATION_CONTROLLER', args...
+
+getHistoryOperation = (args...) ->
+  ipc.sendSync 'ATOM_SHELL_SYNC_NAVIGATION_CONTROLLER', args...
+
 window.history.back = -> sendHistoryOperation 'goBack'
 window.history.forward = -> sendHistoryOperation 'goForward'
 window.history.go = (offset) -> sendHistoryOperation 'goToOffset', offset
+Object.defineProperty window.history, 'length',
+  get: ->
+    getHistoryOperation 'length'

--- a/atom/renderer/lib/web-view/web-view.coffee
+++ b/atom/renderer/lib/web-view/web-view.coffee
@@ -244,6 +244,7 @@ registerWebViewElement = ->
     "canGoBack"
     "canGoForward"
     "canGoToOffset"
+    "clearHistory"
     "goBack"
     "goForward"
     "goToIndex"

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -778,6 +778,10 @@ Returns whether the web page can go forward.
 
 Returns whether the web page can go to `offset`.
 
+### WebContents.clearHistory()
+
+Clears the navigation history.
+
 ### WebContents.goBack()
 
 Makes the web page go back.

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -165,6 +165,10 @@ Returns whether guest page can go forward.
 
 Returns whether guest page can go to `offset`.
 
+### `<webview>`.clearHistory()
+
+Clears the navigation history.
+
 ### `<webview>`.goBack()
 
 Makes guest page go back.

--- a/spec/fixtures/pages/history.html
+++ b/spec/fixtures/pages/history.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  window.history.pushState(window.history.state, "test page", "foo.html")
+  require('ipc').sendToHost('history', window.history.length);
+</script>
+</body>
+</html>

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -193,3 +193,18 @@ describe '<webview> tag', ->
       webview.setAttribute 'nodeintegration', 'on'
       webview.src = "file://#{fixtures}/pages/beforeunload-false.html"
       document.body.appendChild webview
+
+  describe '<webview>.clearHistory()', ->
+    it 'should clear the navigation history', (done) ->
+      listener = (e) ->
+        assert.equal e.channel, 'history'
+        assert.equal e.args[0], 2
+        assert webview.canGoBack()
+        webview.clearHistory()
+        assert not webview.canGoBack()
+        webview.removeEventListener 'ipc-message', listener
+        done()
+      webview.addEventListener 'ipc-message', listener
+      webview.setAttribute 'nodeintegration', 'on'      
+      webview.src = "file://#{fixtures}/pages/history.html"
+      document.body.appendChild webview


### PR DESCRIPTION
Fixes #1645 

Also `window.history.length` will return the value of the history list we maintain on the browser.