### PR TITLE
Simplify how we find NativeWindow from WebContents

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -51,9 +51,7 @@ v8::Persistent<v8::ObjectTemplate> template_;
 NativeWindow* GetWindowFromGuest(const content::WebContents* guest) {
   WebViewManager::WebViewInfo info;
   if (WebViewManager::GetInfoForProcess(guest->GetRenderProcessHost(), &info))
-    return NativeWindow::FromRenderView(
-        info.embedder->GetRenderProcessHost()->GetID(),
-        info.embedder->GetRoutingID());
+    return NativeWindow::FromWebContents(info.embedder);
   else
     return nullptr;
 }

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -124,8 +124,7 @@ void AtomBrowserClient::OverrideWebkitPrefs(
     return;
   }
 
-  NativeWindow* window = NativeWindow::FromRenderView(
-      process->GetID(), render_view_host->GetRoutingID());
+  NativeWindow* window = NativeWindow::FromWebContents(web_contents);
   if (window)
     window->OverrideWebkitPrefs(prefs);
 }

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -169,18 +169,13 @@ NativeWindow* NativeWindow::Create(const mate::Dictionary& options) {
 }
 
 // static
-NativeWindow* NativeWindow::FromRenderView(int process_id, int routing_id) {
-  // Stupid iterating.
+NativeWindow* NativeWindow::FromWebContents(
+    content::WebContents* web_contents) {
   WindowList& window_list = *WindowList::GetInstance();
-  for (auto w = window_list.begin(); w != window_list.end(); ++w) {
-    auto& window = *w;
-    content::WebContents* web_contents = window->GetWebContents();
-    int window_process_id = web_contents->GetRenderProcessHost()->GetID();
-    int window_routing_id = web_contents->GetRoutingID();
-    if (window_routing_id == routing_id && window_process_id == process_id)
+  for (NativeWindow* window : window_list) {
+    if (window->GetWebContents() == web_contents)
       return window;
   }
-
   return nullptr;
 }
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -91,8 +91,8 @@ class NativeWindow : public brightray::DefaultWebContentsDelegate,
   // managing the window's live.
   static NativeWindow* Create(const mate::Dictionary& options);
 
-  // Find a window from its process id and routing id.
-  static NativeWindow* FromRenderView(int process_id, int routing_id);
+  // Find a window from its WebContents
+  static NativeWindow* FromWebContents(content::WebContents* web_contents);
 
   void InitFromOptions(const mate::Dictionary& options);
 


### PR DESCRIPTION
This fixes `web-preferences` option not working after Chrome42, closes #1592.