### PR TITLE
Notify the click event in Linux tray icon

### DIFF
--- a/atom/browser/ui/tray_icon_gtk.cc
+++ b/atom/browser/ui/tray_icon_gtk.cc
@@ -42,6 +42,7 @@ void TrayIconGtk::SetContextMenu(ui::SimpleMenuModel* menu_model) {
 }
 
 void TrayIconGtk::OnClick() {
+  NotifyClicked();
 }
 
 bool TrayIconGtk::HasClickAction() {


### PR DESCRIPTION
Not sure why it wasn't implemented, fixes #1715.