### PR TITLE
clipboard: api to list supported types, reading and writing markup

### DIFF
--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -37,10 +37,12 @@ struct Converter<ui::ClipboardType> {
 
 namespace {
 
-bool Has(const std::string& format_string, ui::ClipboardType type) {
+std::vector<base::string16> AvailableFormats(ui::ClipboardType type) {
+  std::vector<base::string16> format_types;
+  bool ignore;
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
-  ui::Clipboard::FormatType format(ui::Clipboard::GetFormatType(format_string));
-  return clipboard->IsFormatAvailable(format, type);
+  clipboard->ReadAvailableTypes(type, &format_types, &ignore);
+  return format_types;
 }
 
 std::string Read(const std::string& format_string,
@@ -64,6 +66,24 @@ void WriteText(const base::string16& text, ui::ClipboardType type) {
   writer.WriteText(text);
 }
 
+base::string16 ReadHtml(ui::ClipboardType type) {
+  base::string16 data;
+  base::string16 html;
+  std::string url;
+  uint32 start;
+  uint32 end;
+  ui::Clipboard::GetForCurrentThread()->ReadHTML(type, &html, &url,
+                                                 &start, &end);
+  data = html.substr(start, end - start);
+  return data;
+}
+
+void WriteHtml(const base::string16& html,
+               ui::ClipboardType type) {
+  ui::ScopedClipboardWriter writer(type);
+  writer.WriteHTML(html, std::string());
+}
+
 gfx::Image ReadImage(ui::ClipboardType type) {
   SkBitmap bitmap = ui::Clipboard::GetForCurrentThread()->ReadImage(type);
   return gfx::Image::CreateFrom1xBitmap(bitmap);
@@ -81,10 +101,12 @@ void Clear(ui::ClipboardType type) {
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   mate::Dictionary dict(context->GetIsolate(), exports);
-  dict.SetMethod("_has", &Has);
+  dict.SetMethod("_availableFormats", &AvailableFormats);
   dict.SetMethod("_read", &Read);
   dict.SetMethod("_readText", &ReadText);
   dict.SetMethod("_writeText", &WriteText);
+  dict.SetMethod("_readHtml", &ReadHtml);
+  dict.SetMethod("_writeHtml", &WriteHtml);
   dict.SetMethod("_readImage", &ReadImage);
   dict.SetMethod("_writeImage", &WriteImage);
   dict.SetMethod("_clear", &Clear);

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -45,6 +45,12 @@ std::vector<base::string16> AvailableFormats(ui::ClipboardType type) {
   return format_types;
 }
 
+bool Has(const std::string& format_string, ui::ClipboardType type) {
+  ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
+  ui::Clipboard::FormatType format(ui::Clipboard::GetFormatType(format_string));
+  return clipboard->IsFormatAvailable(format, type);
+}
+
 std::string Read(const std::string& format_string,
                  ui::ClipboardType type) {
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
@@ -102,6 +108,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   mate::Dictionary dict(context->GetIsolate(), exports);
   dict.SetMethod("_availableFormats", &AvailableFormats);
+  dict.SetMethod("_has", &Has);
   dict.SetMethod("_read", &Read);
   dict.SetMethod("_readText", &ReadText);
   dict.SetMethod("_writeText", &WriteText);

--- a/atom/common/api/lib/clipboard.coffee
+++ b/atom/common/api/lib/clipboard.coffee
@@ -1,6 +1,7 @@
 binding = process.atomBinding 'clipboard'
 module.exports =
   availableFormats: (type='standard') -> binding._availableFormats type
+  has: (format, type='standard') -> binding._has format, type
   read: (format, type='standard') -> binding._read format, type
   readText: (type='standard') -> binding._readText type
   writeText: (text, type='standard') -> binding._writeText text, type

--- a/atom/common/api/lib/clipboard.coffee
+++ b/atom/common/api/lib/clipboard.coffee
@@ -1,9 +1,11 @@
 binding = process.atomBinding 'clipboard'
 module.exports =
-  has: (format, type='standard') -> binding._has format, type
+  availableFormats: (type='standard') -> binding._availableFormats type
   read: (format, type='standard') -> binding._read format, type
   readText: (type='standard') -> binding._readText type
   writeText: (text, type='standard') -> binding._writeText text, type
+  readHtml: (type='standard') -> binding._readHtml type
+  writeHtml: (markup, type='standard') -> binding._writeHtml markup, type
   readImage: (type='standard') -> binding._readImage type
   writeImage: (image, type='standard') -> binding._writeImage image, type
   clear: (type='standard') -> binding._clear type

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -30,6 +30,19 @@ Returns the content in clipboard as plain text.
 
 Writes the `text` into clipboard as plain text.
 
+## clipboard.readHtml([type])
+
+* `type` String
+
+Returns the content in clipboard as markup.
+
+## clipboard.writeHtml(markup[, type])
+
+* `markup` String
+* `type` String
+
+Writes the `markup` into clipboard.
+
 ## clipboard.readImage([type])
 
 * `type` String
@@ -49,14 +62,9 @@ Writes the `image` into clipboard.
 
 Clears everything in clipboard.
 
-## clipboard.has(format[, type])
+## clipboard.availableFormats([type])
 
-* `format` String
-* `type` String
-
-Returns whether clipboard has data in specified `format`.
-
-**Note:** This API is experimental and could be removed in future.
+Returns an array of supported `format` for the clipboard `type`.
 
 ## clipboard.read(format[, type])
 

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -66,11 +66,25 @@ Clears everything in clipboard.
 
 Returns an array of supported `format` for the clipboard `type`.
 
-## clipboard.read(format[, type])
+## clipboard.has(data[, type])
 
-* `format` String
+* `data` String
 * `type` String
 
-Reads the data in clipboard of the `format`.
+Returns whether clipboard supports the format of specified `data`.
+
+```javascript
+var clipboard = require('clipboard');
+console.log(clipboard.has('<p>selection</p>'));
+```
+
+**Note:** This API is experimental and could be removed in future.
+
+## clipboard.read(data[, type])
+
+* `data` String
+* `type` String
+
+Reads the `data` in clipboard.
 
 **Note:** This API is experimental and could be removed in future.

--- a/spec/api-clipboard-spec.coffee
+++ b/spec/api-clipboard-spec.coffee
@@ -18,3 +18,15 @@ describe 'clipboard module', ->
       text = '千江有水千江月，万里无云万里天'
       clipboard.writeText text
       assert.equal clipboard.readText(), text
+
+  describe 'clipboard.readHtml()', ->
+    it 'returns markup correctly', ->
+      text = '<string>Hi</string>'
+      markup =
+        if process.platform is 'darwin'
+          '<meta charset=\'utf-8\'><string>Hi</string>'
+        else
+          '<meta http-equiv="content-type" ' +
+          'content="text/html; charset=utf-8"><string>Hi</string>'
+      clipboard.writeHtml text
+      assert.equal clipboard.readHtml(), markup


### PR DESCRIPTION
Fixes #1729 

Have removed `has(format)` api , since its no use with `availableFormats` . Also  we have a generic `Read` api which can read to the supported type but doesnt respond what type it is, can we remove that  and just leave with the explicit types [`text`, `html`, `bitmap`, `rtf`] ?