### PR TITLE
Replace cmd with bash

### DIFF
--- a/docs/tutorial/application-distribution.md
+++ b/docs/tutorial/application-distribution.md
@@ -111,7 +111,7 @@ environment variable and have a clean rebuild:
 
 __Windows__
 
-```cmd
+```bash
 > set "GYP_DEFINES=project_name=myapp product_name=MyApp"
 > python script\clean.py
 > python script\bootstrap.py

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -133,7 +133,7 @@ Electron binary to execute your app directly.
 
 On Windows:
 
-```cmd
+```bash
 $ .\electron\electron.exe your-app\
 ```
 


### PR DESCRIPTION
This is a wee update to change `cmd` to `bash` in the documentation's markdown code snippets. The markdown parser we're using in the Jekyll docs doesn't recognize `cmd` and fails to render at all when it encounters it, which is kind of silly, but since we just use it in these two places I think it's OK to use `bash` instead. 