### PR TITLE
Use gcc-4.8 on CI machine

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -15,6 +15,8 @@ LINUX_DEPS = [
   'libgnome-keyring-dev',
   'libgtk2.0-dev',
   'libnotify-dev',
+  'gcc-4.8',
+  'g++-4.8',
   'gcc-multilib',
   'g++-multilib',
 ]
@@ -26,6 +28,7 @@ def main():
   is_travis = (os.getenv('TRAVIS') == 'true')
   if is_travis and sys.platform == 'linux2':
     print 'Setup travis CI'
+    execute(['sudo', 'add-apt-repository', '-y', 'ppa:ubuntu-toolchain-r/test'])
     execute(['sudo', 'apt-get', 'update'])
     execute(['sudo', 'apt-get', 'install'] + LINUX_DEPS)
 
@@ -41,8 +44,8 @@ def main():
                      'libchromiumcontent'))
 
   if is_travis and sys.platform == 'linux2':
-    with scoped_env('CXX', 'g++'):
-      with scoped_env('CC', 'gcc'):
+    with scoped_env('CXX', 'g++-4.8'):
+      with scoped_env('CC', 'gcc-4.8'):
         run_script('bootstrap.py', ['--dev'])
     run_script('update.py')
   else:


### PR DESCRIPTION
The old gcc on travis ci now can not compile V8 4.3's header.