### PR TITLE
protocol: supporting async request jobs

### DIFF
--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -12,6 +12,10 @@
 #include "base/callback.h"
 #include "native_mate/handle.h"
 
+namespace mate {
+class Arguments;
+}
+
 namespace net {
 class URLRequest;
 }
@@ -26,6 +30,8 @@ class Protocol : public mate::EventEmitter {
  public:
   typedef base::Callback<v8::Local<v8::Value>(const net::URLRequest*)>
           JsProtocolHandler;
+  typedef base::Callback<void(v8::Local<v8::Value>)>
+          JsAsyncJobHandler;
 
   static mate::Handle<Protocol> Create(v8::Isolate* isolate);
 

--- a/atom/browser/api/lib/protocol.coffee
+++ b/atom/browser/api/lib/protocol.coffee
@@ -26,6 +26,14 @@ class RequestBufferJob
     @encoding = encoding ? 'utf8'
     @data = new Buffer(data)
 
+protocol.RequestAsyncBufferJob =
+class RequestAsyncBufferJob
+  constructor: (callback) ->
+    if typeof callback isnt 'function'
+      throw new TypeError('Argument should be function')
+
+    @callback = callback
+
 protocol.RequestFileJob =
 class RequestFileJob
   constructor: (@path) ->

--- a/atom/browser/net/adapter_request_job.h
+++ b/atom/browser/net/adapter_request_job.h
@@ -17,6 +17,10 @@ namespace base {
 class FilePath;
 }
 
+namespace mate {
+class Arguments;
+}
+
 namespace atom {
 
 // Ask JS which type of job it wants, and then delegate corresponding methods.
@@ -47,6 +51,7 @@ class AdapterRequestJob : public net::URLRequestJob {
 
   // Override this function to determine which job should be started.
   virtual void GetJobTypeInUI() = 0;
+  virtual void RunAsyncJob(mate::Arguments*) = 0;
 
   void CreateErrorJobAndStart(int error_code);
   void CreateStringJobAndStart(const std::string& mime_type,

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -14,7 +14,7 @@ app.on('ready', function() {
     var protocol = require('protocol');
     protocol.registerProtocol('atom', function(request) {
       var url = request.url.substr(7)
-      return new protocol.RequestFileJob(path.normalize(__dirname + '/' + url));
+      return protocol.RequestFileJob(path.normalize(__dirname + '/' + url));
     });
 });
 ```
@@ -84,12 +84,19 @@ Create a request job which sends a string as response.
 
 Create a request job which sends a buffer as response.
 
+## Class: protocol.RequestAsyncBufferJob(callback)
+
+* `callback` Function
+
+Create a asynchromous request job which provides a handler to `callback` that
+can be called with `errorCode` and buffer `data` to be sent as response.
+
 ## Class: protocol.RequestErrorJob(code)
 
 * `code` Integer
 
 Create a request job which sets appropriate network error message to console.
-Default message is `net::ERR_NOT_IMPLEMENTED`. Code should be in the following 
+Default message is `net::ERR_NOT_IMPLEMENTED`. Code should be in the following
 range.
 
 * Ranges:

--- a/spec/api-protocol-spec.coffee
+++ b/spec/api-protocol-spec.coffee
@@ -92,6 +92,26 @@ describe 'protocol module', ->
           assert false, 'Got error: ' + errorType + ' ' + error
           protocol.unregisterProtocol 'atom-buffer-job'
 
+    it 'returns RequestAsyncBufferJob should send buffer', (done) ->
+      data = new Buffer("async-hello")
+      job = new protocol.RequestAsyncBufferJob (cb) ->
+        cb(data)
+      handler = remote.createFunctionWithReturnValue job
+      protocol.registerProtocol 'atom-async-buffer-job', handler
+
+      $.ajax
+        url: 'atom-async-buffer-job://fake-host'
+        success: (response) ->
+          assert.equal response.length, data.length
+          buf = new Buffer(response.length)
+          buf.write(response)
+          assert buf.equals(data)
+          protocol.unregisterProtocol 'atom-async-buffer-job'
+          done()
+        error: (xhr, errorType, error) ->
+          assert false, 'Got error: ' + errorType + ' ' + error
+          protocol.unregisterProtocol 'atom-async-buffer-job'
+
     it 'returns RequestFileJob should send file', (done) ->
       job = new protocol.RequestFileJob(__filename)
       handler = remote.createFunctionWithReturnValue job


### PR DESCRIPTION
Fixes #410 

Have started with an api like

```js
protocol.RequestAsyncJob(<jobtype>, function(cb) {
  cb(<object>)
})
```

- [x] support all existing sync jobs
- [x] Add Tests
- [ ] buffer data goes out of context in callback