### PR TITLE
Change how webview is resized

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -112,7 +112,6 @@ content::ServiceWorkerContext* GetServiceWorkerContext(
 WebContents::WebContents(content::WebContents* web_contents)
     : content::WebContentsObserver(web_contents),
       guest_instance_id_(-1),
-      element_instance_id_(-1),
       guest_opaque_(true),
       guest_host_(nullptr),
       auto_size_enabled_(false),
@@ -121,7 +120,6 @@ WebContents::WebContents(content::WebContents* web_contents)
 
 WebContents::WebContents(const mate::Dictionary& options)
     : guest_instance_id_(-1),
-      element_instance_id_(-1),
       guest_opaque_(true),
       guest_host_(nullptr),
       auto_size_enabled_(false),
@@ -450,14 +448,6 @@ void WebContents::DidAttach(int guest_proxy_routing_id) {
   Emit("did-attach");
 }
 
-void WebContents::ElementSizeChanged(const gfx::Size& size) {
-  element_size_ = size;
-
-  // Only resize if needed.
-  if (!size.IsEmpty())
-    guest_host_->SizeContents(size);
-}
-
 content::WebContents* WebContents::GetOwnerWebContents() const {
   return embedder_web_contents_;
 }
@@ -477,7 +467,6 @@ void WebContents::WillAttach(content::WebContents* embedder_web_contents,
                              int element_instance_id,
                              bool is_full_page_plugin) {
   embedder_web_contents_ = embedder_web_contents;
-  element_instance_id_ = element_instance_id;
   is_full_page_plugin_ = is_full_page_plugin;
 }
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -62,7 +62,7 @@ struct Converter<atom::api::SetSizeParams> {
       out->min_size.reset(new gfx::Size(size));
     if (params.Get("max", &size))
       out->max_size.reset(new gfx::Size(size));
-    if (params.Get("elementSize", &size))
+    if (params.Get("normal", &size))
       out->normal_size.reset(new gfx::Size(size));
     return true;
   }

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -62,6 +62,8 @@ struct Converter<atom::api::SetSizeParams> {
       out->min_size.reset(new gfx::Size(size));
     if (params.Get("max", &size))
       out->max_size.reset(new gfx::Size(size));
+    if (params.Get("elementSize", &size))
+      out->normal_size.reset(new gfx::Size(size));
     return true;
   }
 };
@@ -476,6 +478,7 @@ void WebContents::WillAttach(content::WebContents* embedder_web_contents,
                              bool is_full_page_plugin) {
   embedder_web_contents_ = embedder_web_contents;
   element_instance_id_ = element_instance_id;
+  is_full_page_plugin_ = is_full_page_plugin;
 }
 
 void WebContents::Destroy() {

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -211,7 +211,6 @@ class WebContents : public mate::EventEmitter,
 
   // content::BrowserPluginGuestDelegate:
   void DidAttach(int guest_proxy_routing_id) final;
-  void ElementSizeChanged(const gfx::Size& size) final;
   content::WebContents* GetOwnerWebContents() const final;
   void GuestSizeChanged(const gfx::Size& new_size) final;
   void SetGuestHost(content::GuestHost* guest_host) final;
@@ -248,10 +247,6 @@ class WebContents : public mate::EventEmitter,
 
   // Unique ID for a guest WebContents.
   int guest_instance_id_;
-
-  // |element_instance_id_| is an identifer that's unique to a particular
-  // element.
-  int element_instance_id_;
 
   // Stores whether the contents of the guest can be transparent.
   bool guest_opaque_;

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -33,6 +33,22 @@ class WebDialogHelper;
 
 namespace api {
 
+// A struct of parameters for SetSize(). The parameters are all declared as
+// scoped pointers since they are all optional. Null pointers indicate that the
+// parameter has not been provided, and the last used value should be used. Note
+// that when |enable_auto_size| is true, providing |normal_size| is not
+// meaningful. This is because the normal size of the guestview is overridden
+// whenever autosizing occurs.
+struct SetSizeParams {
+  SetSizeParams() {}
+  ~SetSizeParams() {}
+
+  scoped_ptr<bool> enable_auto_size;
+  scoped_ptr<gfx::Size> min_size;
+  scoped_ptr<gfx::Size> max_size;
+  scoped_ptr<gfx::Size> normal_size;
+};
+
 class WebContents : public mate::EventEmitter,
                     public content::BrowserPluginGuestDelegate,
                     public content::WebContentsDelegate,
@@ -89,10 +105,9 @@ class WebContents : public mate::EventEmitter,
   bool SendIPCMessage(const base::string16& channel,
                       const base::ListValue& args);
 
-  // Toggles autosize mode for corresponding <webview>.
-  void SetAutoSize(bool enabled,
-                   const gfx::Size& min_size,
-                   const gfx::Size& max_size);
+  // Used to toggle autosize mode for this GuestView, and set both the automatic
+  // and normal sizes.
+  void SetSize(const SetSizeParams& params);
 
   // Sets the transparency of the guest.
   void SetAllowTransparency(bool allow);
@@ -217,8 +232,16 @@ class WebContents : public mate::EventEmitter,
                              const base::ListValue& args,
                              IPC::Message* message);
 
+  // This method is invoked when the contents auto-resized to give the container
+  // an opportunity to match it if it wishes.
+  //
+  // This gives the derived class an opportunity to inform its container element
+  // or perform other actions.
   void GuestSizeChangedDueToAutoSize(const gfx::Size& old_size,
                                      const gfx::Size& new_size);
+
+  // Returns the default size of the guestview.
+  gfx::Size GetDefaultSize() const;
 
   scoped_ptr<WebDialogHelper> web_dialog_helper_;
   scoped_ptr<AtomJavaScriptDialogManager> dialog_manager_;
@@ -257,6 +280,12 @@ class WebContents : public mate::EventEmitter,
 
   // The minimum size constraints of the container element in autosize mode.
   gfx::Size min_auto_size_;
+
+  // The size that will be used when autosize mode is disabled.
+  gfx::Size normal_size_;
+
+  // Whether the guest view is inside a plugin document.
+  bool is_full_page_plugin_;
 
   DISALLOW_COPY_AND_ASSIGN(WebContents);
 };

--- a/atom/browser/default_app/default_app.js
+++ b/atom/browser/default_app/default_app.js
@@ -15,7 +15,6 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
-    resizable: false,
     'auto-hide-menu-bar': true,
     'use-content-size': true,
   });

--- a/atom/browser/lib/guest-view-manager.coffee
+++ b/atom/browser/lib/guest-view-manager.coffee
@@ -41,7 +41,6 @@ createGuest = (embedder, params) ->
   guest = webContents.create
     isGuest: true
     guestInstanceId: id
-    storagePartitionId: params.storagePartitionId
   guestInstances[id] = {guest, embedder}
 
   # Destroy guest when the embedder is gone or navigated.
@@ -58,9 +57,12 @@ createGuest = (embedder, params) ->
     delete @attachParams
 
     @viewInstanceId = params.instanceId
-    min = width: params.minwidth, height: params.minheight
-    max = width: params.maxwidth, height: params.maxheight
-    @setSize params.autosize, min, max
+    @setSize
+      enableAutoSize: params.autosize
+      min:
+        width: params.minwidth, height: params.minheight
+      max:
+        width: params.maxwidth, height: params.maxheight
 
     if params.src
       opts = {}
@@ -123,7 +125,7 @@ destroyGuest = (embedder, id) ->
     delete reverseEmbedderElementsMap[id]
     delete embedderElementsMap[key]
 
-ipc.on 'ATOM_SHELL_GUEST_VIEW_MANAGER_CREATE_GUEST', (event, type, params, requestId) ->
+ipc.on 'ATOM_SHELL_GUEST_VIEW_MANAGER_CREATE_GUEST', (event, params, requestId) ->
   event.sender.send "ATOM_SHELL_RESPONSE_#{requestId}", createGuest(event.sender, params)
 
 ipc.on 'ATOM_SHELL_GUEST_VIEW_MANAGER_ATTACH_GUEST', (event, elementInstanceId, guestInstanceId, params) ->

--- a/atom/browser/lib/guest-view-manager.coffee
+++ b/atom/browser/lib/guest-view-manager.coffee
@@ -60,7 +60,7 @@ createGuest = (embedder, params) ->
     @viewInstanceId = params.instanceId
     min = width: params.minwidth, height: params.minheight
     max = width: params.maxwidth, height: params.maxheight
-    @setAutoSize params.autosize, min, max
+    @setSize params.autosize, min, max
 
     if params.src
       opts = {}
@@ -132,8 +132,8 @@ ipc.on 'ATOM_SHELL_GUEST_VIEW_MANAGER_ATTACH_GUEST', (event, elementInstanceId, 
 ipc.on 'ATOM_SHELL_GUEST_VIEW_MANAGER_DESTROY_GUEST', (event, id) ->
   destroyGuest event.sender, id
 
-ipc.on 'ATOM_SHELL_GUEST_VIEW_MANAGER_SET_AUTO_SIZE', (event, id, params) ->
-  guestInstances[id]?.guest.setAutoSize params.enableAutoSize, params.min, params.max
+ipc.on 'ATOM_SHELL_GUEST_VIEW_MANAGER_SET_SIZE', (event, id, params) ->
+  guestInstances[id]?.guest.setSize params
 
 ipc.on 'ATOM_SHELL_GUEST_VIEW_MANAGER_SET_ALLOW_TRANSPARENCY', (event, id, allowtransparency) ->
   guestInstances[id]?.guest.setAllowTransparency allowtransparency

--- a/atom/browser/lib/guest-view-manager.coffee
+++ b/atom/browser/lib/guest-view-manager.coffee
@@ -58,6 +58,8 @@ createGuest = (embedder, params) ->
 
     @viewInstanceId = params.instanceId
     @setSize
+      normal:
+        width: params.elementWidth, height: params.elementHeight
       enableAutoSize: params.autosize
       min:
         width: params.minwidth, height: params.minheight

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -10,9 +10,11 @@
 #define USE(WTF_FEATURE) (defined WTF_USE_##WTF_FEATURE  && WTF_USE_##WTF_FEATURE)  // NOLINT
 #define ENABLE(WTF_FEATURE) (defined ENABLE_##WTF_FEATURE  && ENABLE_##WTF_FEATURE)  // NOLINT
 
+#include "atom/common/native_mate_converters/gfx_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/renderer/api/atom_api_spell_check_client.h"
 #include "content/public/renderer/render_frame.h"
+#include "native_mate/callback.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
 #include "third_party/WebKit/public/web/WebDocument.h"
@@ -78,6 +80,14 @@ v8::Local<v8::Value> WebFrame::RegisterEmbedderCustomElement(
   return web_frame_->document().registerEmbedderCustomElement(name, options, c);
 }
 
+void WebFrame::RegisterElementResizeCallback(
+    int element_instance_id,
+    const GuestViewContainer::ResizeCallback& callback) {
+  auto guest_view_container = GuestViewContainer::FromID(element_instance_id);
+  if (guest_view_container)
+    guest_view_container->RegisterElementResizeCallback(callback);
+}
+
 void WebFrame::AttachGuest(int id) {
   content::RenderFrame::FromWebFrame(web_frame_)->AttachGuest(id);
 }
@@ -106,6 +116,8 @@ mate::ObjectTemplateBuilder WebFrame::GetObjectTemplateBuilder(
       .SetMethod("getZoomFactor", &WebFrame::GetZoomFactor)
       .SetMethod("registerEmbedderCustomElement",
                  &WebFrame::RegisterEmbedderCustomElement)
+      .SetMethod("registerElementResizeCallback",
+                 &WebFrame::RegisterElementResizeCallback)
       .SetMethod("attachGuest", &WebFrame::AttachGuest)
       .SetMethod("setSpellCheckProvider", &WebFrame::SetSpellCheckProvider)
       .SetMethod("registerUrlSchemeAsSecure",

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "atom/renderer/guest_view_container.h"
 #include "base/memory/scoped_ptr.h"
 #include "native_mate/handle.h"
 #include "native_mate/wrappable.h"
@@ -42,6 +43,9 @@ class WebFrame : public mate::Wrappable {
 
   v8::Local<v8::Value> RegisterEmbedderCustomElement(
       const base::string16& name, v8::Local<v8::Object> options);
+  void RegisterElementResizeCallback(
+      int element_instance_id,
+      const GuestViewContainer::ResizeCallback& callback);
   void AttachGuest(int element_instance_id);
 
   // Set the provider that will be used by SpellCheckClient for spell check.

--- a/atom/renderer/guest_view_container.h
+++ b/atom/renderer/guest_view_container.h
@@ -5,17 +5,38 @@
 #ifndef ATOM_RENDERER_GUEST_VIEW_CONTAINER_H_
 #define ATOM_RENDERER_GUEST_VIEW_CONTAINER_H_
 
+#include "base/callback.h"
 #include "content/public/renderer/browser_plugin_delegate.h"
-#include "v8/include/v8.h"
+
+namespace gfx {
+class Size;
+}
 
 namespace atom {
 
 class GuestViewContainer : public content::BrowserPluginDelegate {
  public:
+  typedef base::Callback<void(const gfx::Size&, const gfx::Size&)>
+      ResizeCallback;
+
   explicit GuestViewContainer(content::RenderFrame* render_frame);
   ~GuestViewContainer() override;
 
+  static GuestViewContainer* FromID(int element_instance_id);
+
+  void RegisterElementResizeCallback(const ResizeCallback& callback);
+
+  // content::BrowserPluginDelegate:
+  void SetElementInstanceID(int element_instance_id) final;
+  void DidResizeElement(const gfx::Size& old_size,
+                        const gfx::Size& new_size) final;
+
  private:
+  int element_instance_id_;
+  content::RenderFrame* render_frame_;
+
+  ResizeCallback element_resize_callback_;
+
   DISALLOW_COPY_AND_ASSIGN(GuestViewContainer);
 };
 

--- a/atom/renderer/lib/web-view/guest-view-internal.coffee
+++ b/atom/renderer/lib/web-view/guest-view-internal.coffee
@@ -55,9 +55,9 @@ module.exports =
     ipc.removeAllListeners "ATOM_SHELL_GUEST_VIEW_INTERNAL_IPC_MESSAGE-#{viewInstanceId}"
     ipc.removeAllListeners "ATOM_SHELL_GUEST_VIEW_INTERNAL_SIZE_CHANGED-#{viewInstanceId}"
 
-  createGuest: (type, params, callback) ->
+  createGuest: (params, callback) ->
     requestId++
-    ipc.send 'ATOM_SHELL_GUEST_VIEW_MANAGER_CREATE_GUEST', type, params, requestId
+    ipc.send 'ATOM_SHELL_GUEST_VIEW_MANAGER_CREATE_GUEST', params, requestId
     ipc.once "ATOM_SHELL_RESPONSE_#{requestId}", callback
 
   attachGuest: (elementInstanceId, guestInstanceId, params) ->

--- a/atom/renderer/lib/web-view/guest-view-internal.coffee
+++ b/atom/renderer/lib/web-view/guest-view-internal.coffee
@@ -67,8 +67,8 @@ module.exports =
   destroyGuest: (guestInstanceId) ->
     ipc.send 'ATOM_SHELL_GUEST_VIEW_MANAGER_DESTROY_GUEST', guestInstanceId
 
-  setAutoSize: (guestInstanceId, params) ->
-    ipc.send 'ATOM_SHELL_GUEST_VIEW_MANAGER_SET_AUTO_SIZE', guestInstanceId, params
+  setSize: (guestInstanceId, params) ->
+    ipc.send 'ATOM_SHELL_GUEST_VIEW_MANAGER_SET_SIZE', guestInstanceId, params
 
   setAllowTransparency: (guestInstanceId, allowtransparency) ->
     ipc.send 'ATOM_SHELL_GUEST_VIEW_MANAGER_SET_ALLOW_TRANSPARENCY', guestInstanceId, allowtransparency

--- a/atom/renderer/lib/web-view/web-view-attributes.coffee
+++ b/atom/renderer/lib/web-view/web-view-attributes.coffee
@@ -72,7 +72,7 @@ class AutosizeDimensionAttribute extends WebViewAttribute
 
   handleMutation: (oldValue, newValue) ->
     return unless @webViewImpl.guestInstanceId
-    guestViewInternal.setAutoSize @webViewImpl.guestInstanceId,
+    guestViewInternal.setSize @webViewImpl.guestInstanceId,
       enableAutoSize: @webViewImpl.attributes[webViewConstants.ATTRIBUTE_AUTOSIZE].getValue()
       min:
         width: parseInt @webViewImpl.attributes[webViewConstants.ATTRIBUTE_MINWIDTH].getValue() || 0

--- a/atom/renderer/lib/web-view/web-view.coffee
+++ b/atom/renderer/lib/web-view/web-view.coffee
@@ -107,6 +107,9 @@ class WebViewImpl
     minWidth = @attributes[webViewConstants.ATTRIBUTE_MINWIDTH].getValue() | width
     minHeight = @attributes[webViewConstants.ATTRIBUTE_MINHEIGHT].getValue() | width
 
+    minWidth = Math.min minWidth, maxWidth
+    minHeight = Math.min minHeight, maxHeight
+
     if not @attributes[webViewConstants.ATTRIBUTE_AUTOSIZE].getValue() or
        (newWidth >= minWidth and
         newWidth <= maxWidth and

--- a/atom/renderer/lib/web-view/web-view.coffee
+++ b/atom/renderer/lib/web-view/web-view.coffee
@@ -13,7 +13,6 @@ class WebViewImpl
   constructor: (@webviewNode) ->
     v8Util.setHiddenValue @webviewNode, 'internal', this
     @attached = false
-    @pendingGuestCreation = false
     @elementAttached = false
 
     @beforeFirstNavigation = true
@@ -122,16 +121,10 @@ class WebViewImpl
       @dispatchEvent webViewEvent
 
   createGuest: ->
-    return if @pendingGuestCreation
     params =
       storagePartitionId: @attributes[webViewConstants.ATTRIBUTE_PARTITION].getValue()
     guestViewInternal.createGuest 'webview', params, (guestInstanceId) =>
-      @pendingGuestCreation = false
-      unless @elementAttached
-        guestViewInternal.destroyGuest guestInstanceId
-        return
       @attachWindow guestInstanceId
-    @pendingGuestCreation = true
 
   dispatchEvent: (webViewEvent) ->
     @webviewNode.dispatchEvent webViewEvent


### PR DESCRIPTION
Chrome 43 has changed how webview's WebContents is resized according to the webview element in embedder, this PR updates our webview implementation for that.

Fixes #1804.