### PR TITLE
Print real error messages even if it looks like an invalid app

### DIFF
--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -51,12 +51,12 @@ if (option.file && !option.webdriver) {
     // Run the app.
     require('module')._load(packagePath, module, true);
   } catch(e) {
+    console.error('App threw an error when running', e);
     if (e.code == 'MODULE_NOT_FOUND') {
       app.focus();
-      dialog.showErrorBox('Error opening app', 'The app provided is not a valid electron app, please read the docs on how to write one:\nhttps://github.com/atom/electron/tree/master/docs');
+      dialog.showErrorBox('Error opening app', 'The app provided is not a valid electron app, please read the docs on how to write one:\nhttps://github.com/atom/electron/tree/master/docs\n\n' + e.toString());
       process.exit(1);
     } else {
-      console.error('App threw an error when running', e);
       throw e;
     }
   }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/158528/7878047/15f9155c-0615-11e5-9a82-39af4b9d610b.png)


This patch adds the actual error message to the user-friendly™ dialog, so developers can find out broken node modules in their own apps without being confused.