### PR TITLE
convert message to string for window.alert method

### DIFF
--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -62,6 +62,7 @@ window.open = (url, frameName='', features='') ->
 window.alert = (message, title='') ->
   dialog = remote.require 'dialog'
   buttons = ['OK']
+  message = message.toString()
   dialog.showMessageBox remote.getCurrentWindow(), {message, title, buttons}
 
 # And the confirm().


### PR DESCRIPTION
Fixed #1813  window.alert(new Error('test')) cause "dialog.showMessageBox argument 2" error