### PR TITLE
Crashpad!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /vendor/brightray/vendor/download/
 /vendor/python_26/
 /vendor/npm/
+/vendor/.gclient
 node_modules/
 *.xcodeproj
 *.swp

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "vendor/native_mate"]
 	path = vendor/native_mate
 	url = https://github.com/zcbenz/native-mate.git
+[submodule "vendor/crashpad"]
+	path = vendor/crashpad
+	url = https://github.com/atom/crashpad.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,3 @@
 [submodule "vendor/native_mate"]
 	path = vendor/native_mate
 	url = https://github.com/zcbenz/native-mate.git
-[submodule "vendor/crashpad"]
-	path = vendor/crashpad
-	url = https://github.com/hokein/crashpad.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "vendor/native_mate"]
 	path = vendor/native_mate
 	url = https://github.com/zcbenz/native-mate.git
+[submodule "vendor/crashpad"]
+	path = vendor/crashpad
+	url = https://github.com/hokein/crashpad.git

--- a/atom.gyp
+++ b/atom.gyp
@@ -273,7 +273,8 @@
         }],  # OS=="win"
         ['OS=="mac"', {
           'dependencies': [
-            'vendor/breakpad/breakpad.gyp:breakpad',
+            'vendor/crashpad/client/client.gyp:crashpad_client',
+            'vendor/crashpad/handler/handler.gyp:crashpad_handler',
           ],
         }],  # OS=="mac"
         ['OS=="linux"', {
@@ -428,8 +429,7 @@
             {
               'destination': '<(PRODUCT_DIR)/<(product_name) Framework.framework/Versions/A/Resources',
               'files': [
-                '<(PRODUCT_DIR)/Inspector',
-                '<(PRODUCT_DIR)/crash_report_sender.app',
+                '<(PRODUCT_DIR)/crashpad_handler',
               ],
             },
           ],

--- a/atom/common/api/atom_api_crash_reporter.cc
+++ b/atom/common/api/atom_api_crash_reporter.cc
@@ -11,6 +11,8 @@
 
 #include "atom/common/node_includes.h"
 
+using crash_reporter::CrashReporter;
+
 namespace mate {
 
 template<>
@@ -32,10 +34,9 @@ struct Converter<std::map<std::string, std::string> > {
 };
 
 template<>
-struct Converter<std::vector<crash_reporter::CrashReporter::UploadReportResult> > {
+struct Converter<std::vector<CrashReporter::UploadReportResult> > {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-      const std::vector<
-          crash_reporter::CrashReporter::UploadReportResult>& reports) {
+      const std::vector<CrashReporter::UploadReportResult>& reports) {
     v8::Local<v8::Array> result(v8::Array::New(isolate, reports.size()));
     for (size_t i = 0; i < reports.size(); ++i) {
       mate::Dictionary dict(isolate, v8::Object::New(isolate));
@@ -54,14 +55,12 @@ struct Converter<std::vector<crash_reporter::CrashReporter::UploadReportResult> 
 
 namespace {
 
-std::vector<crash_reporter::CrashReporter::UploadReportResult>
-GetUploadedReports() {
-  return (crash_reporter::CrashReporter::GetInstance())->GetUploadedReports();
+std::vector<CrashReporter::UploadReportResult> GetUploadedReports() {
+  return (CrashReporter::GetInstance())->GetUploadedReports();
 }
 
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
-  using crash_reporter::CrashReporter;
   mate::Dictionary dict(context->GetIsolate(), exports);
   dict.SetMethod("start",
                  base::Bind(&CrashReporter::Start,

--- a/atom/common/api/lib/crash-reporter.coffee
+++ b/atom/common/api/lib/crash-reporter.coffee
@@ -41,6 +41,10 @@ class CrashReporter
       start()
 
   getLastCrashReport: ->
+    if process.platform is 'darwin'
+      reports = binding._getUploadedReports()
+      return if reports.length > 0 then reports[0] else null
+
     tmpdir =
       if process.platform is 'win32'
         os.tmpdir()

--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -39,7 +39,8 @@ void CrashReporter::SetUploadParameters(const StringMap& parameters) {
   SetUploadParameters();
 }
 
-std::vector<CrashReporter::UploadReportResult> CrashReporter::GetUploadedReports() {
+std::vector<CrashReporter::UploadReportResult>
+CrashReporter::GetUploadedReports() {
   return std::vector<CrashReporter::UploadReportResult>();
 }
 

--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -39,4 +39,8 @@ void CrashReporter::SetUploadParameters(const StringMap& parameters) {
   SetUploadParameters();
 }
 
+std::vector<CrashReporter::UploadReportResult> CrashReporter::GetUploadedReports() {
+  return std::vector<CrashReporter::UploadReportResult>();
+}
+
 }  // namespace crash_reporter

--- a/atom/common/crash_reporter/crash_reporter.h
+++ b/atom/common/crash_reporter/crash_reporter.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "base/basictypes.h"
@@ -16,7 +17,7 @@ namespace crash_reporter {
 class CrashReporter {
  public:
   typedef std::map<std::string, std::string> StringMap;
-  typedef std::pair<int, std::string> UploadReportResult; // upload-date, id
+  typedef std::pair<int, std::string> UploadReportResult;  // upload-date, id
 
   static CrashReporter* GetInstance();
 

--- a/atom/common/crash_reporter/crash_reporter.h
+++ b/atom/common/crash_reporter/crash_reporter.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 #include "base/basictypes.h"
 
@@ -15,6 +16,7 @@ namespace crash_reporter {
 class CrashReporter {
  public:
   typedef std::map<std::string, std::string> StringMap;
+  typedef std::pair<int, std::string> UploadReportResult; // upload-date, id
 
   static CrashReporter* GetInstance();
 
@@ -24,6 +26,8 @@ class CrashReporter {
              bool auto_submit,
              bool skip_system_crash_handler,
              const StringMap& extra_parameters);
+
+  virtual std::vector<CrashReporter::UploadReportResult> GetUploadedReports();
 
  protected:
   CrashReporter();

--- a/atom/common/crash_reporter/crash_reporter_mac.h
+++ b/atom/common/crash_reporter/crash_reporter_mac.h
@@ -9,7 +9,6 @@
 
 #include "atom/common/crash_reporter/crash_reporter.h"
 #include "base/compiler_specific.h"
-#import "vendor/breakpad/src/client/mac/Framework/Breakpad.h"
 
 template <typename T> struct DefaultSingletonTraits;
 
@@ -32,8 +31,6 @@ class CrashReporterMac : public CrashReporter {
 
   CrashReporterMac();
   virtual ~CrashReporterMac();
-
-  BreakpadRef breakpad_;
 
   DISALLOW_COPY_AND_ASSIGN(CrashReporterMac);
 };

--- a/atom/common/crash_reporter/crash_reporter_mac.h
+++ b/atom/common/crash_reporter/crash_reporter_mac.h
@@ -6,6 +6,7 @@
 #define ATOM_COMMON_CRASH_REPORTER_CRASH_REPORTER_MAC_H_
 
 #include <string>
+#include <vector>
 
 #include "atom/common/crash_reporter/crash_reporter.h"
 #include "base/compiler_specific.h"

--- a/atom/common/crash_reporter/crash_reporter_mac.h
+++ b/atom/common/crash_reporter/crash_reporter_mac.h
@@ -43,6 +43,8 @@ class CrashReporterMac : public CrashReporter {
   void SetCrashKeyValue(const base::StringPiece& key,
                         const base::StringPiece& value);
 
+  std::vector<UploadReportResult> GetUploadedReports() override;
+
   scoped_ptr<crashpad::SimpleStringDictionary> simple_string_dictionary_;
   scoped_ptr<crashpad::CrashReportDatabase> crash_report_database_;
 

--- a/atom/common/crash_reporter/crash_reporter_mac.h
+++ b/atom/common/crash_reporter/crash_reporter_mac.h
@@ -9,8 +9,15 @@
 
 #include "atom/common/crash_reporter/crash_reporter.h"
 #include "base/compiler_specific.h"
+#include "base/memory/scoped_ptr.h"
+#include "base/strings/string_piece.h"
+#include "vendor/crashpad/client/simple_string_dictionary.h"
 
 template <typename T> struct DefaultSingletonTraits;
+
+namespace crashpad {
+class CrashReportDatabase;
+}
 
 namespace crash_reporter {
 
@@ -31,6 +38,13 @@ class CrashReporterMac : public CrashReporter {
 
   CrashReporterMac();
   virtual ~CrashReporterMac();
+
+  void SetUploadsEnabled(bool enable_uploads);
+  void SetCrashKeyValue(const base::StringPiece& key,
+                        const base::StringPiece& value);
+
+  scoped_ptr<crashpad::SimpleStringDictionary> simple_string_dictionary_;
+  scoped_ptr<crashpad::CrashReportDatabase> crash_report_database_;
 
   DISALLOW_COPY_AND_ASSIGN(CrashReporterMac);
 };

--- a/atom/common/crash_reporter/crash_reporter_mac.mm
+++ b/atom/common/crash_reporter/crash_reporter_mac.mm
@@ -64,10 +64,12 @@ void CrashReporterMac::InitBreakpad(const std::string& product_name,
           framework_bundle_path.Append("Resources").Append("crashpad_handler");
 
       crashpad::CrashpadClient crashpad_client;
+      // Send all crash reports.
+      std::vector<std::string> arguments = { "--upload-internal=0" };
       if (crashpad_client.StartHandler(handler_path, database_path,
                                        submit_url,
                                        StringMap(),
-                                       std::vector<std::string>())) {
+                                       arguments)) {
         crashpad_client.UseHandler();
       }
     }  // @autoreleasepool

--- a/common.gypi
+++ b/common.gypi
@@ -30,6 +30,7 @@
     'v8_enable_i18n_support': 'false',
     # Required by Linux (empty for now, should support it in future).
     'sysroot': '',
+    'crashpad_standalone': 1,
   },
   # Settings to compile node under Windows.
   'target_defaults': {

--- a/common.gypi
+++ b/common.gypi
@@ -30,7 +30,6 @@
     'v8_enable_i18n_support': 'false',
     # Required by Linux (empty for now, should support it in future).
     'sysroot': '',
-    'crashpad_standalone': 1,
   },
   # Settings to compile node under Windows.
   'target_defaults': {

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -29,7 +29,8 @@ crashReporter.start({
 
 **Note:** On OS X, electron uses a new `crashpad` client, which is different
 with the `breakpad` on Windows and Linux. To enable crash collection feature,
-you are required to call `crashReporter.start` API to initiliaze `crashpad` in Browser Process, even you only collect crash report in Renderer Process.
+you are required to call `crashReporter.start` API to initiliaze `crashpad` in
+main process, even you only collect crash report in renderer process.
 
 ## crashReporter.getLastCrashReport()
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -27,6 +27,10 @@ crashReporter.start({
     * Only string properties are send correctly.
     * Nested objects are not supported.
 
+**Note:** On OS X, electron uses a new `crashpad` client, which is different
+with the `breakpad` on Windows and Linux. To enable crash collection feature,
+you are required to call `crashReporter.start` API to initiliaze `crashpad` in Browser Process, even you only collect crash report in Renderer Process.
+
 ## crashReporter.getLastCrashReport()
 
 Returns the date and ID of last crash report, when there was no crash report

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -12,6 +12,7 @@ from lib.util import execute_stdout, get_atom_shell_version, scoped_cwd
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 VENDOR_DIR = os.path.join(SOURCE_ROOT, 'vendor')
 PYTHON_26_URL = 'https://chromium.googlesource.com/chromium/deps/python_26'
+CRACKPAD_URL = 'https://github.com/hokein/crashpad.git'
 NPM = 'npm.cmd' if sys.platform in ['win32', 'cygwin'] else 'npm'
 
 
@@ -27,6 +28,8 @@ def main():
     update_win32_python()
   update_submodules()
   update_node_modules('.')
+  if sys.platform == 'darwin':
+    update_crashpad()
   bootstrap_brightray(args.dev, args.url, args.target_arch)
 
   create_chrome_version_h()
@@ -90,6 +93,18 @@ def update_node_modules(dirname, env=None):
       execute_stdout([NPM, 'install', '--verbose'], env)
     else:
       execute_stdout([NPM, 'install'], env)
+
+
+def update_crashpad():
+  gclient = os.path.join(VENDOR_DIR, 'depot_tools', 'gclient.py')
+  args = [
+    'config',
+    '--unmanaged',
+    CRACKPAD_URL,
+  ]
+  with scoped_cwd(VENDOR_DIR):
+    execute_stdout([sys.executable, gclient] + args)
+    execute_stdout([sys.executable, gclient] +  ['sync'])
 
 
 def update_electron_modules(dirname, target_arch):

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -12,7 +12,6 @@ from lib.util import execute_stdout, get_atom_shell_version, scoped_cwd
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 VENDOR_DIR = os.path.join(SOURCE_ROOT, 'vendor')
 PYTHON_26_URL = 'https://chromium.googlesource.com/chromium/deps/python_26'
-CRACKPAD_URL = 'https://github.com/hokein/crashpad.git'
 NPM = 'npm.cmd' if sys.platform in ['win32', 'cygwin'] else 'npm'
 
 
@@ -28,8 +27,6 @@ def main():
     update_win32_python()
   update_submodules()
   update_node_modules('.')
-  if sys.platform == 'darwin':
-    update_crashpad()
   bootstrap_brightray(args.dev, args.url, args.target_arch)
 
   create_chrome_version_h()
@@ -93,18 +90,6 @@ def update_node_modules(dirname, env=None):
       execute_stdout([NPM, 'install', '--verbose'], env)
     else:
       execute_stdout([NPM, 'install'], env)
-
-
-def update_crashpad():
-  gclient = os.path.join(VENDOR_DIR, 'depot_tools', 'gclient.py')
-  args = [
-    'config',
-    '--unmanaged',
-    CRACKPAD_URL,
-  ]
-  with scoped_cwd(VENDOR_DIR):
-    execute_stdout([sys.executable, gclient] + args)
-    execute_stdout([sys.executable, gclient] +  ['sync'])
 
 
 def update_electron_modules(dirname, target_arch):

--- a/spec/api-crash-reporter-spec.coffee
+++ b/spec/api-crash-reporter-spec.coffee
@@ -45,5 +45,5 @@ describe 'crash-reporter module', ->
         protocol: 'file'
         pathname: path.join fixtures, 'api', 'crash.html'
         search: "?port=#{port}"
-        crashReporter.start {'submitUrl': 'http://127.0.0.1:' + port}
+      crashReporter.start {'submitUrl': 'http://127.0.0.1:' + port}
       w.loadUrl url

--- a/spec/api-crash-reporter-spec.coffee
+++ b/spec/api-crash-reporter-spec.coffee
@@ -5,12 +5,10 @@ url        = require 'url'
 remote     = require 'remote'
 formidable = require 'formidable'
 
+crashReporter = remote.require 'crash-reporter'
 BrowserWindow = remote.require 'browser-window'
 
 describe 'crash-reporter module', ->
-  # We have trouble makeing crash reporter work on Yosemite.
-  return if process.platform is 'darwin'
-
   fixtures = path.resolve __dirname, 'fixtures'
 
   w = null
@@ -47,4 +45,5 @@ describe 'crash-reporter module', ->
         protocol: 'file'
         pathname: path.join fixtures, 'api', 'crash.html'
         search: "?port=#{port}"
+        crashReporter.start {'submitUrl': 'http://127.0.0.1:' + port}
       w.loadUrl url


### PR DESCRIPTION
Replace the current breakpad on OS X, fixes #1638 . Crash spec test is passed on OS X 10.9.4.

There are some follow-ups:
* We need a mirror `crashpad` repo, currently it's under my account.
*  The new `crashpad` client is a new out-process architecture. To enable crash feature, we need to launch a new process from Browser process to run [`crashpad_handler`](http://docs.crashpad.googlecode.com/git/man/crashpad_handler.html). We might need to custom the `crash-reporter` API to make it more clearer(I keep it the same now). 