### PR TITLE
Ship pdf.dll in release, fix #1826

### DIFF
--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -38,6 +38,7 @@ TARGET_BINARIES = {
     'msvcp120.dll',
     'msvcr120.dll',
     'node.dll',
+    'pdf.dll',
     'content_resources_200_percent.pak',
     'ui_resources_200_percent.pak',
     'xinput1_3.dll',


### PR DESCRIPTION
The current release of `electron` doesn't ship `pdf.dll`. Fixes #1826 .