### PR TITLE
devtools: initialise devtoolsWebContents when opened with inspect* apis

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -527,7 +527,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("_openDevTools", &Window::OpenDevTools)
       .SetMethod("closeDevTools", &Window::CloseDevTools)
       .SetMethod("isDevToolsOpened", &Window::IsDevToolsOpened)
-      .SetMethod("inspectElement", &Window::InspectElement)
+      .SetMethod("_inspectElement", &Window::InspectElement)
       .SetMethod("focusOnWebView", &Window::FocusOnWebView)
       .SetMethod("blurWebView", &Window::BlurWebView)
       .SetMethod("isWebViewFocused", &Window::IsWebViewFocused)
@@ -549,7 +549,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
 #endif
       .SetMethod("_getWebContents", &Window::GetWebContents)
       .SetMethod("_getDevToolsWebContents", &Window::GetDevToolsWebContents)
-      .SetMethod("inspectServiceWorker", &Window::InspectServiceWorker);
+      .SetMethod("_inspectServiceWorker", &Window::InspectServiceWorker);
 }
 
 }  // namespace api

--- a/atom/browser/api/lib/browser-window.coffee
+++ b/atom/browser/api/lib/browser-window.coffee
@@ -55,6 +55,14 @@ BrowserWindow::openDevTools = (options={}) ->
 BrowserWindow::toggleDevTools = ->
   if @isDevToolsOpened() then @closeDevTools() else @openDevTools()
 
+BrowserWindow::inspectElement = (x, y) ->
+  @openDevTools true
+  @_inspectElement x, y
+
+BrowserWindow::inspectServiceWorker = ->
+  @openDevTools true
+  @_inspectServiceWorker()
+
 BrowserWindow::getWebContents = ->
   wrapWebContents @_getWebContents()
 

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -308,7 +308,6 @@ bool NativeWindow::IsDevToolsOpened() {
 }
 
 void NativeWindow::InspectElement(int x, int y) {
-  OpenDevTools(true);
   scoped_refptr<content::DevToolsAgentHost> agent(
       content::DevToolsAgentHost::GetOrCreateFor(GetWebContents()));
   agent->InspectElement(x, y);
@@ -318,7 +317,6 @@ void NativeWindow::InspectServiceWorker() {
   for (const auto& agent_host : content::DevToolsAgentHost::GetOrCreateAll()) {
     if (agent_host->GetType() ==
         content::DevToolsAgentHost::TYPE_SERVICE_WORKER) {
-      OpenDevTools(true);
       inspectable_web_contents()->AttachTo(agent_host);
       break;
     }


### PR DESCRIPTION
context menu would have been broken when devtools was not opened with `openDevTools` , this fixes it.