### PR TITLE
Added `bounds` payload to tray `clicked` event on Windows

### DIFF
--- a/atom/browser/ui/win/notify_icon.cc
+++ b/atom/browser/ui/win/notify_icon.cc
@@ -49,7 +49,18 @@ void NotifyIcon::HandleClickEvent(const gfx::Point& cursor_pos,
                                   bool left_mouse_click) {
   // Pass to the observer if appropriate.
   if (left_mouse_click) {
-    NotifyClicked();
+    NOTIFYICONIDENTIFIER icon_id;
+    memset(&icon_id, 0, sizeof(NOTIFYICONIDENTIFIER));
+    icon_id.uID = icon_id_;
+    icon_id.hWnd = window_;
+    icon_id.cbSize = sizeof(NOTIFYICONIDENTIFIER);
+
+    RECT rect;
+    Shell_NotifyIconGetRect(&icon_id, &rect);
+
+    int width = rect.right - rect.left;
+    int height =  rect.bottom - rect.top;
+    NotifyClicked(gfx::Rect(rect.left, rect.top, width, height));
     return;
   }
 

--- a/atom/browser/ui/win/notify_icon.cc
+++ b/atom/browser/ui/win/notify_icon.cc
@@ -58,9 +58,7 @@ void NotifyIcon::HandleClickEvent(const gfx::Point& cursor_pos,
     RECT rect;
     Shell_NotifyIconGetRect(&icon_id, &rect);
 
-    int width = rect.right - rect.left;
-    int height = rect.bottom - rect.top;
-    NotifyClicked(gfx::Rect(rect.left, rect.top, width, height));
+    NotifyClicked(gfx::Rect(rect));
     return;
   }
 

--- a/atom/browser/ui/win/notify_icon.cc
+++ b/atom/browser/ui/win/notify_icon.cc
@@ -59,7 +59,7 @@ void NotifyIcon::HandleClickEvent(const gfx::Point& cursor_pos,
     Shell_NotifyIconGetRect(&icon_id, &rect);
 
     int width = rect.right - rect.left;
-    int height =  rect.bottom - rect.top;
+    int height = rect.bottom - rect.top;
     NotifyClicked(gfx::Rect(rect.left, rect.top, width, height));
     return;
   }

--- a/atom/browser/ui/win/notify_icon.cc
+++ b/atom/browser/ui/win/notify_icon.cc
@@ -55,7 +55,7 @@ void NotifyIcon::HandleClickEvent(const gfx::Point& cursor_pos,
     icon_id.hWnd = window_;
     icon_id.cbSize = sizeof(NOTIFYICONIDENTIFIER);
 
-    RECT rect;
+    RECT rect = { 0 };
     Shell_NotifyIconGetRect(&icon_id, &rect);
 
     NotifyClicked(gfx::Rect(rect));

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -55,7 +55,7 @@ Creates a new tray icon associated with the `image`.
 
 Emitted when the tray icon is clicked.
 
-__Note:__ The `bounds` payload is only implemented on OS X.
+__Note:__ The `bounds` payload is only implemented on OS X and Windows 7 or newer.
 
 ### Event: 'double-clicked'
 


### PR DESCRIPTION
Used [Shell_NotifyIconGetRect function](https://msdn.microsoft.com/en-us/library/windows/desktop/dd378426) to get the bounds of the application's tray icon.

Note that this only works with Windows 7 or Windows Server 2008 R2 and later.
I did not test this on Windows XP. Since even Microsoft stopped supporting Windows XP, I think decent support on modern OS's is more important than supporting legacy systems.

It would be nice if someone could check if no things got broken to badly though (is there an error when clicking the tray icon on Windows XP?)... If so, could this be handled gracefully?

Fixes #1159 and related to #1500.