### PR TITLE
Don't search NativeWindow or guest view by child process ID

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -85,7 +85,7 @@ v8::Persistent<v8::ObjectTemplate> template_;
 // Get the window that has the |guest| embedded.
 NativeWindow* GetWindowFromGuest(const content::WebContents* guest) {
   WebViewManager::WebViewInfo info;
-  if (WebViewManager::GetInfoForProcess(guest->GetRenderProcessHost(), &info))
+  if (WebViewManager::GetInfoForWebContents(guest, &info))
     return NativeWindow::FromWebContents(info.embedder);
   else
     return nullptr;

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -31,22 +31,23 @@ namespace atom {
 
 namespace {
 
-// The default routing id of WebContents, since in Electron a WebContents
-// always owns its own RenderProcessHost, this ID is same for every WebContents.
+// The default routing id of WebContents.
+// In Electron each RenderProcessHost only has one WebContents, so this ID is
+// same for every WebContents.
 int kDefaultRoutingID = 2;
 
 // Next navigation should not restart renderer process.
 bool g_suppress_renderer_process_restart = false;
 
-// Find out the owner of the child process according to child_process_id.
+// Find out the owner of the child process according to |process_id|.
 enum ProcessOwner {
   OWNER_NATIVE_WINDOW,
   OWNER_GUEST_WEB_CONTENTS,
   OWNER_NONE,  // it might be devtools though.
 };
 ProcessOwner GetProcessOwner(int process_id,
-                                 NativeWindow** window,
-                                 WebViewManager::WebViewInfo* info) {
+                             NativeWindow** window,
+                             WebViewManager::WebViewInfo* info) {
   auto web_contents = content::WebContents::FromRenderViewHost(
       content::RenderViewHost::FromID(process_id, kDefaultRoutingID));
   if (!web_contents)

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -46,9 +46,6 @@ class AtomBrowserClient : public brightray::BrowserClient {
   brightray::BrowserMainParts* OverrideCreateBrowserMainParts(
       const content::MainFunctionParams&) override;
 
-  // The render process which would be swapped out soon.
-  content::RenderProcessHost* dying_render_process_;
-
   DISALLOW_COPY_AND_ASSIGN(AtomBrowserClient);
 };
 

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -422,7 +422,7 @@ content::WebContents* NativeWindow::GetDevToolsWebContents() const {
 }
 
 void NativeWindow::AppendExtraCommandLineSwitches(
-    base::CommandLine* command_line, int child_process_id) {
+    base::CommandLine* command_line) {
   // Append --node-integration to renderer process.
   command_line->AppendSwitchASCII(switches::kNodeIntegration,
                                   node_integration_ ? "true" : "false");

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -192,8 +192,7 @@ class NativeWindow : public brightray::DefaultWebContentsDelegate,
   content::WebContents* GetDevToolsWebContents() const;
 
   // Called when renderer process is going to be started.
-  void AppendExtraCommandLineSwitches(base::CommandLine* command_line,
-                                      int child_process_id);
+  void AppendExtraCommandLineSwitches(base::CommandLine* command_line);
   void OverrideWebkitPrefs(content::WebPreferences* prefs);
 
   // Set fullscreen mode triggered by html api.

--- a/atom/browser/web_view_manager.cc
+++ b/atom/browser/web_view_manager.cc
@@ -12,10 +12,9 @@ namespace atom {
 
 namespace {
 
-WebViewManager* GetManagerFromProcess(content::RenderProcessHost* process) {
-  if (!process)
-    return nullptr;
-  auto context = process->GetBrowserContext();
+WebViewManager* GetManagerFromWebContents(
+    const content::WebContents* web_contents) {
+  auto context = web_contents->GetBrowserContext();
   if (!context)
     return nullptr;
   return static_cast<WebViewManager*>(context->GetGuestManager());
@@ -24,24 +23,9 @@ WebViewManager* GetManagerFromProcess(content::RenderProcessHost* process) {
 }  // namespace
 
 // static
-bool WebViewManager::GetInfoForProcess(content::RenderProcessHost* process,
-                                       WebViewInfo* info) {
-  auto manager = GetManagerFromProcess(process);
-  if (!manager)
-    return false;
-  base::AutoLock auto_lock(manager->lock_);
-  for (auto iter : manager->webview_info_map_)
-    if (iter.first->GetRenderProcessHost() == process) {
-      *info = iter.second;
-      return true;
-    }
-  return false;
-}
-
-// static
-bool WebViewManager::GetInfoForWebContents(content::WebContents* web_contents,
-                                           WebViewInfo* info) {
-  auto manager = GetManagerFromProcess(web_contents->GetRenderProcessHost());
+bool WebViewManager::GetInfoForWebContents(
+    const content::WebContents* web_contents, WebViewInfo* info) {
+  auto manager = GetManagerFromWebContents(web_contents);
   if (!manager)
     return false;
   base::AutoLock auto_lock(manager->lock_);

--- a/atom/browser/web_view_manager.h
+++ b/atom/browser/web_view_manager.h
@@ -29,13 +29,9 @@ class WebViewManager : public content::BrowserPluginGuestManager {
     base::FilePath preload_script;
   };
 
-  // Finds the WebViewManager attached with |process| and returns the
+  // Finds the WebViewManager attached with |web_contents| and returns the
   // WebViewInfo of it.
-  static bool GetInfoForProcess(content::RenderProcessHost* process,
-                                WebViewInfo* info);
-
-  // Same with GetInfoForProcess but search for |web_contents| instead.
-  static bool GetInfoForWebContents(content::WebContents* web_contents,
+  static bool GetInfoForWebContents(const content::WebContents* web_contents,
                                     WebViewInfo* info);
 
   explicit WebViewManager(content::BrowserContext* context);
@@ -85,7 +81,7 @@ class WebViewManager : public content::BrowserPluginGuestManager {
   // (embedder_process_id, element_instance_id) => guest_instance_id
   std::map<ElementInstanceKey, int> element_instance_id_to_guest_map_;
 
-  typedef std::map<content::WebContents*, WebViewInfo> WebViewInfoMap;
+  typedef std::map<const content::WebContents*, WebViewInfo> WebViewInfoMap;
   // web_contents => (guest_instance_id, embedder, ...)
   WebViewInfoMap webview_info_map_;
 

--- a/atom/browser/web_view_manager.h
+++ b/atom/browser/web_view_manager.h
@@ -34,9 +34,9 @@ class WebViewManager : public content::BrowserPluginGuestManager {
   static bool GetInfoForProcess(content::RenderProcessHost* process,
                                 WebViewInfo* info);
 
-  // Updates the guest process ID.
-  static void UpdateGuestProcessID(content::RenderProcessHost* old_process,
-                                   content::RenderProcessHost* new_process);
+  // Same with GetInfoForProcess but search for |web_contents| instead.
+  static bool GetInfoForWebContents(content::WebContents* web_contents,
+                                    WebViewInfo* info);
 
   explicit WebViewManager(content::BrowserContext* context);
   virtual ~WebViewManager();
@@ -47,10 +47,6 @@ class WebViewManager : public content::BrowserPluginGuestManager {
                 content::WebContents* web_contents,
                 const WebViewInfo& info);
   void RemoveGuest(int guest_instance_id);
-
-  // Looks up the information for the embedder <webview> for a given render
-  // view, if one exists. Called on the IO thread.
-  bool GetInfo(int guest_process_id, WebViewInfo* webview_info);
 
  protected:
   // content::BrowserPluginGuestManager:
@@ -89,8 +85,8 @@ class WebViewManager : public content::BrowserPluginGuestManager {
   // (embedder_process_id, element_instance_id) => guest_instance_id
   std::map<ElementInstanceKey, int> element_instance_id_to_guest_map_;
 
-  typedef std::map<int, WebViewInfo> WebViewInfoMap;
-  // guest_process_id => (guest_instance_id, embedder, ...)
+  typedef std::map<content::WebContents*, WebViewInfo> WebViewInfoMap;
+  // web_contents => (guest_instance_id, embedder, ...)
   WebViewInfoMap webview_info_map_;
 
   base::Lock lock_;


### PR DESCRIPTION
The renderer process's ID is not reliable to be used to search for NativeWindow or guest WebContents, because pending navigations can happen for multiple times before the WebContents switches to the new renderer process, so it would be impossible to determine the owner of a pending renderer process according to its process.

This PR changes to only use WebContents for search, which doesn't change between navigations. It also fixed a bug of `<webview>` that changing `src` would call `loadUrl` for twice, which is the direct cause of #1843.

Fix #1766
Fix #1754
Fix #1820
Fix #1843
Fix #1823