### PR TITLE
Support multiple-line headers in `did-get-response-details'

### DIFF
--- a/atom/common/native_mate_converters/value_converter.cc
+++ b/atom/common/native_mate_converters/value_converter.cc
@@ -23,6 +23,13 @@ bool Converter<base::DictionaryValue>::FromV8(v8::Isolate* isolate,
   }
 }
 
+v8::Local<v8::Value> Converter<base::DictionaryValue>::ToV8(
+    v8::Isolate* isolate,
+    const base::DictionaryValue& val) {
+  scoped_ptr<atom::V8ValueConverter> converter(new atom::V8ValueConverter);
+  return converter->ToV8Value(&val, isolate->GetCurrentContext());
+}
+
 bool Converter<base::ListValue>::FromV8(v8::Isolate* isolate,
                                         v8::Local<v8::Value> val,
                                         base::ListValue* out) {

--- a/atom/common/native_mate_converters/value_converter.h
+++ b/atom/common/native_mate_converters/value_converter.h
@@ -19,6 +19,8 @@ struct Converter<base::DictionaryValue> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      base::DictionaryValue* out);
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const base::DictionaryValue& val);
 };
 
 template<>
@@ -27,7 +29,7 @@ struct Converter<base::ListValue> {
                      v8::Local<v8::Value> val,
                      base::ListValue* out);
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                    const base::ListValue& val);
+                                   const base::ListValue& val);
 };
 
 }  // namespace mate


### PR DESCRIPTION
If a response header has multiple-lines field, it will just show the last line.

A simple server example:
```
var http = require('http')

var server = http.createServer(function (req, res) {
  console.log('listen');
  res.setHeader('Access-Control-Allow-Origin', 'file://')
  res.setHeader('Access-Control-Allow-Methods', ['GET,PUT,POST', 'DELETE'])
  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
  res.setHeader('Set-Cookie', ['type=ninja', 'language=javascript']);
  res.end('whoop!')
})

server.listen(8888);
```

The response header in `did-get-response-details` will be 
```
{ 'access-control-allow-origin': 'file://',
  'access-control-allow-methods': 'delete',
  'access-control-allow-headers': 'content-type',
  'set-cookie': 'language=javascript',
  date: 'fri, 05 jun 2015 05:44:01 gmt',
  connection: 'keep-alive',
  'transfer-encoding': 'chunked' }
```

This PR make it support multiple lines, the result is 

```
{ 'access-control-allow-headers': [ 'content-type' ],
  'access-control-allow-methods': [ 'get,put,post', 'delete' ],
  'access-control-allow-origin': [ 'file://' ],
  connection: [ 'keep-alive' ],
  date: [ 'fri, 05 jun 2015 05:45:39 gmt' ],
  'set-cookie': [ 'type=ninja', 'language=javascript' ],
  'transfer-encoding': [ 'chunked' ] }
```

\cc @deepak1556 
