### PR TITLE
Implement crash-reporter.getUploadedReports API

### DIFF
--- a/atom/common/api/lib/crash-reporter.coffee
+++ b/atom/common/api/lib/crash-reporter.coffee
@@ -41,23 +41,23 @@ class CrashReporter
       start()
 
   getLastCrashReport: ->
-    if process.platform is 'darwin'
-      reports = binding._getUploadedReports()
-      return if reports.length > 0 then reports[0] else null
+    reports = this.getUploadedReports()
+    if reports.length > 0 then reports[0] else null
 
+  getUploadedReports: ->
     tmpdir =
       if process.platform is 'win32'
         os.tmpdir()
       else
         '/tmp'
-    log = path.join tmpdir, "#{@productName} Crashes", 'uploads.log'
-    try
-      reports = String(fs.readFileSync(log)).split('\n')
-      return null unless reports.length > 1
-      [time, id] = reports[reports.length - 2].split ','
-      return {date: new Date(parseInt(time) * 1000), id}
-    catch e
-      return null
+    log =
+      if process.platform is 'darwin'
+        path.join tmpdir, "#{@productName} Crashes"
+      else
+        path.join tmpdir, "#{@productName} Crashes", 'uploads.log'
+    console.log log;
+    binding._getUploadedReports(log)
+
 
 crashRepoter = new CrashReporter
 module.exports = crashRepoter

--- a/atom/common/api/lib/crash-reporter.coffee
+++ b/atom/common/api/lib/crash-reporter.coffee
@@ -55,8 +55,7 @@ class CrashReporter
         path.join tmpdir, "#{@productName} Crashes"
       else
         path.join tmpdir, "#{@productName} Crashes", 'uploads.log'
-    console.log log;
-    binding._getUploadedReports(log)
+    binding._getUploadedReports log
 
 
 crashRepoter = new CrashReporter

--- a/atom/common/crash_reporter/crash_reporter.h
+++ b/atom/common/crash_reporter/crash_reporter.h
@@ -28,7 +28,8 @@ class CrashReporter {
              bool skip_system_crash_handler,
              const StringMap& extra_parameters);
 
-  virtual std::vector<CrashReporter::UploadReportResult> GetUploadedReports();
+  virtual std::vector<CrashReporter::UploadReportResult> GetUploadedReports(
+      const std::string& path);
 
  protected:
   CrashReporter();

--- a/atom/common/crash_reporter/crash_reporter_mac.h
+++ b/atom/common/crash_reporter/crash_reporter_mac.h
@@ -16,10 +16,6 @@
 
 template <typename T> struct DefaultSingletonTraits;
 
-namespace crashpad {
-class CrashReportDatabase;
-}
-
 namespace crash_reporter {
 
 class CrashReporterMac : public CrashReporter {
@@ -44,10 +40,10 @@ class CrashReporterMac : public CrashReporter {
   void SetCrashKeyValue(const base::StringPiece& key,
                         const base::StringPiece& value);
 
-  std::vector<UploadReportResult> GetUploadedReports() override;
+  std::vector<UploadReportResult> GetUploadedReports(
+      const std::string& path) override;
 
   scoped_ptr<crashpad::SimpleStringDictionary> simple_string_dictionary_;
-  scoped_ptr<crashpad::CrashReportDatabase> crash_report_database_;
 
   DISALLOW_COPY_AND_ASSIGN(CrashReporterMac);
 };

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -27,6 +27,9 @@ crashReporter.start({
     * Only string properties are send correctly.
     * Nested objects are not supported.
 
+Developers are required to call the API before using other crashReporter APIs.
+
+
 **Note:** On OS X, electron uses a new `crashpad` client, which is different
 with the `breakpad` on Windows and Linux. To enable crash collection feature,
 you are required to call `crashReporter.start` API to initiliaze `crashpad` in
@@ -36,6 +39,10 @@ main process, even you only collect crash report in renderer process.
 
 Returns the date and ID of last crash report, when there was no crash report
 sent or the crash reporter is not started, `null` will be returned.
+
+## crashReporter.getUploadedReports()
+
+Returns all uploaded crash reports, each report contains date and uploaded ID.
 
 # crash-reporter payload
 


### PR DESCRIPTION
**TODO**
- [x] Test on OS X.
- [x]  Check the behavior of handling `uploads.log` is same with the `coffeescipt` implementation.