### PR TITLE
Fixed example with correct capturePage api.

### DIFF
--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -98,7 +98,7 @@ returns a `Buffer` by calling the passed callback:
 var remote = require('remote');
 var fs = require('fs');
 remote.getCurrentWindow().capturePage(function(image) {
-  var buf = image.toPng()
+  var buf = image.toPng();
   fs.writeFile('/tmp/screenshot.png', buf, function(err) {
     console.log(err);
   });
@@ -117,7 +117,7 @@ The work-around is to write the `buf` in the main process, where it is a real
 ```javascript
 var remote = require('remote');
 remote.getCurrentWindow().capturePage(function(image) {
-  var buf = image.toPng()
+  var buf = image.toPng();
   remote.require('fs').writeFile('/tmp/screenshot.png', buf, function(err) {
     console.log(err);
   });

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -97,7 +97,8 @@ returns a `Buffer` by calling the passed callback:
 ```javascript
 var remote = require('remote');
 var fs = require('fs');
-remote.getCurrentWindow().capturePage(function(buf) {
+remote.getCurrentWindow().capturePage(function(image) {
+  var buf = image.toPng()
   fs.writeFile('/tmp/screenshot.png', buf, function(err) {
     console.log(err);
   });
@@ -115,7 +116,8 @@ The work-around is to write the `buf` in the main process, where it is a real
 
 ```javascript
 var remote = require('remote');
-remote.getCurrentWindow().capturePage(function(buf) {
+remote.getCurrentWindow().capturePage(function(image) {
+  var buf = image.toPng()
   remote.require('fs').writeFile('/tmp/screenshot.png', buf, function(err) {
     console.log(err);
   });


### PR DESCRIPTION
The example was probably using an older API where capturePage would return a Buffer.

Now that capturePage returns a NativeImage, we must add the extra 'toPng()' step in this example to avoid confusing users.

The example was tested and creates correct PNG files.