### PR TITLE
mac: Build dump_syms

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -45,6 +45,7 @@
           'dependencies': [
             '<(project_name)_framework',
             '<(project_name)_helper',
+            'vendor/breakpad/breakpad.gyp:dump_syms',
           ],
           'xcode_settings': {
             'ATOM_BUNDLE_ID': 'com.<(company_abbr).<(project_name)',


### PR DESCRIPTION
Crashpad doesn't ship dump_syms, we have to build it from breakpad.

Related:
#1822
https://code.google.com/p/crashpad/issues/detail?id=29