### PR TITLE
Guarding against polluted Object.prototypes

### DIFF
--- a/atom/common/lib/asar.coffee
+++ b/atom/common/lib/asar.coffee
@@ -14,7 +14,7 @@ getOrCreateArchive = (p) ->
 
 # Clean cache on quit.
 process.on 'exit', ->
-  archive.destroy() for p, archive of cachedArchives
+  archive.destroy() for own p, archive of cachedArchives
 
 # Separate asar package's path from full path.
 splitPath = (p) ->


### PR DESCRIPTION
Was running into a errors with archive.destroy breaking when using a JavaScript library that modified the Object.prototype, this small fix resolves the issue.