### PR TITLE
Documentation fixes: grammar, spelling and code

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -43,7 +43,7 @@ You can also create a window without chrome by using
      other windows
   * `fullscreen` Boolean - Whether the window should show in fullscreen, when
     set to `false` the fullscreen button would also be hidden on OS X
-  * `skip-taskbar` Boolean - Do not show window in Taskbar
+  * `skip-taskbar` Boolean - Do not show window in taskbar
   * `zoom-factor` Number - The default zoom factor of the page, zoom factor is
     zoom percent / 100, so `3.0` represents `300%`
   * `kiosk` Boolean - The kiosk mode
@@ -464,7 +464,7 @@ Starts or stops flashing the window to attract user's attention.
 
 * `skip` Boolean
 
-Makes the window do not show in Taskbar.
+Makes the window not show in the taskbar.
 
 ### BrowserWindow.setKiosk(flag)
 
@@ -604,12 +604,12 @@ it will assume `app.getName().desktop`.
 ### BrowserWindow.setOverlayIcon(overlay, description)
 
 * `overlay` [NativeImage](native-image.md) - the icon to display on the bottom
-right corner of the Taskbar icon. If this parameter is `null`, the overlay is
+right corner of the taskbar icon. If this parameter is `null`, the overlay is
 cleared
 * `description` String - a description that will be provided to Accessibility
 screen readers
 
-Sets a 16px overlay onto the current Taskbar icon, usually used to convey some sort of application status or to passively notify the user.
+Sets a 16px overlay onto the current taskbar icon, usually used to convey some sort of application status or to passively notify the user.
 
 __Note:__ This API is only available on Windows, Win7 or above
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -131,9 +131,9 @@ window.onbeforeunload = function(e) {
   console.log('I do not want to be closed');
 
   // Unlike usual browsers, in which a string should be returned and the user is
-  // prompted to confirm the page unload. Electron gives the power completely
-  // to the developers, return empty string or false would prevent the unloading
-  // now. You can also use the dialog API to let user confirm it.
+  // prompted to confirm the page unload, Electron gives developers more options.
+  // Returning empty string or false would prevent the unloading now.
+  // You can also use the dialog API to let the user confirm closing the application.
   return false;
 };
 ```

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -753,7 +753,7 @@ Calling `event.preventDefault()` can prevent creating new windows.
 Emitted when user or the page wants to start an navigation, it can happen when
 `window.location` object is changed or user clicks a link in the page.
 
-This event will not emit when the navigation is started programmely with APIs
+This event will not emit when the navigation is started programmatically with APIs
 like `WebContents.loadUrl` and `WebContents.back`.
 
 Calling `event.preventDefault()` can prevent the navigation.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -483,13 +483,13 @@ Returns whether the window is in kiosk mode.
 Sets the pathname of the file the window represents, and the icon of the file
 will show in window's title bar.
 
-__Note__: This API is available only on OS X.
+__Note__: This API is only available on OS X.
 
 ### BrowserWindow.getRepresentedFilename()
 
 Returns the pathname of the file the window represents.
 
-__Note__: This API is available only on OS X.
+__Note__: This API is only available on OS X.
 
 ### BrowserWindow.setDocumentEdited(edited)
 
@@ -498,13 +498,13 @@ __Note__: This API is available only on OS X.
 Specifies whether the window’s document has been edited, and the icon in title
 bar will become grey when set to `true`.
 
-__Note__: This API is available only on OS X.
+__Note__: This API is only available on OS X.
 
 ### BrowserWindow.IsDocumentEdited()
 
 Whether the window's document has been edited.
 
-__Note__: This API is available only on OS X.
+__Note__: This API is only available on OS X.
 
 ### BrowserWindow.openDevTools([options])
 
@@ -611,13 +611,13 @@ screen readers
 
 Sets a 16px overlay onto the current taskbar icon, usually used to convey some sort of application status or to passively notify the user.
 
-__Note:__ This API is only available on Windows, Win7 or above
+__Note:__ This API is only available on Windows (Windows 7 and above)
 
 ### BrowserWindow.showDefinitionForSelection()
 
 Shows pop-up dictionary that searches the selected word on the page.
 
-__Note__: This API is available only on OS X.
+__Note__: This API is only available on OS X.
 
 ### BrowserWindow.setAutoHideMenuBar(hide)
 

--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -1,6 +1,6 @@
 # Supported Chrome command line switches
 
-Following command lines switches in Chrome browser are also Supported in
+The following command lines switches in Chrome browser are also supported in
 Electron, you can use [app.commandLine.appendSwitch][append-switch] to append
 them in your app's main script before the [ready][ready] event of [app][app]
 module is emitted:
@@ -11,6 +11,7 @@ app.commandLine.appendSwitch('remote-debugging-port', '8315');
 app.commandLine.appendSwitch('host-rules', 'MAP * 127.0.0.1');
 
 app.on('ready', function() {
+  // Your code here
 });
 ```
 

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -36,8 +36,8 @@ selected, an example is:
   filters: [
     { name: 'Images', extensions: ['jpg', 'png', 'gif'] },
     { name: 'Movies', extensions: ['mkv', 'avi', 'mp4'] },
-    { name: 'Custom File Type', extensions: ['as'] },
-  ],
+    { name: 'Custom File Type', extensions: ['as'] }
+  ]
 }
 ```
 

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -28,7 +28,7 @@ var win = new BrowserWindow({ transparent: true, frame: false });
   API to set window shape to solve this, but currently blocked at an
   [upstream bug](https://code.google.com/p/chromium/issues/detail?id=387234).
 * Transparent window is not resizable, setting `resizable` to `true` may make
-  transprent window stop working on some platforms.
+  transparent window stop working on some platforms.
 * The `blur` filter only applies to the web page, so there is no way to apply
   blur effect to the content below the window.
 * On Windows transparent window will not work when DWM is disabled.

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -10,7 +10,7 @@ var globalShortcut = require('global-shortcut');
 // Register a 'ctrl+x' shortcut listener.
 var ret = globalShortcut.register('ctrl+x', function() { console.log('ctrl+x is pressed'); })
 if (!ret)
-  console.log('registerion fails');
+  console.log('registration failed');
 
 // Check whether a shortcut is registered.
 console.log(globalShortcut.isRegistered('ctrl+x'));

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -9,8 +9,10 @@ var globalShortcut = require('global-shortcut');
 
 // Register a 'ctrl+x' shortcut listener.
 var ret = globalShortcut.register('ctrl+x', function() { console.log('ctrl+x is pressed'); })
-if (!ret)
+
+if (!ret) {
   console.log('registration failed');
+}
 
 // Check whether a shortcut is registered.
 console.log(globalShortcut.isRegistered('ctrl+x'));

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -281,10 +281,10 @@ Template:
 
 ```javascript
 [
-  {label: '4', id: '4'}
-  {label: '5', id: '5'}
-  {label: '1', id: '1', position: 'before=4'}
-  {label: '2', id: '2'}
+  {label: '4', id: '4'},
+  {label: '5', id: '5'},
+  {label: '1', id: '1', position: 'before=4'},
+  {label: '2', id: '2'},
   {label: '3', id: '3'}
 ]
 ```
@@ -303,11 +303,11 @@ Template:
 
 ```javascript
 [
-  {label: 'a', position: 'endof=letters'}
-  {label: '1', position: 'endof=numbers'}
-  {label: 'b', position: 'endof=letters'}
-  {label: '2', position: 'endof=numbers'}
-  {label: 'c', position: 'endof=letters'}
+  {label: 'a', position: 'endof=letters'},
+  {label: '1', position: 'endof=numbers'},
+  {label: 'b', position: 'endof=letters'},
+  {label: '2', position: 'endof=numbers'},
+  {label: 'c', position: 'endof=letters'},
   {label: '3', position: 'endof=numbers'}
 ]
 ```

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -70,7 +70,7 @@ var template = [
         label: 'Quit',
         accelerator: 'Command+Q',
         click: function() { app.quit(); }
-      },
+      }
     ]
   },
   {
@@ -108,7 +108,7 @@ var template = [
         label: 'Select All',
         accelerator: 'Command+A',
         selector: 'selectAll:'
-      },
+      }
     ]
   },
   {
@@ -123,7 +123,7 @@ var template = [
         label: 'Toggle DevTools',
         accelerator: 'Alt+Command+I',
         click: function() { BrowserWindow.getFocusedWindow().toggleDevTools(); }
-      },
+      }
     ]
   },
   {
@@ -145,13 +145,13 @@ var template = [
       {
         label: 'Bring All to Front',
         selector: 'arrangeInFront:'
-      },
+      }
     ]
   },
   {
     label: 'Help',
     submenu: []
-  },
+  }
 ];
 
 menu = Menu.buildFromTemplate(template);

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -7,8 +7,8 @@ An example of implementing a protocol that has the same effect with the
 `file://` protocol:
 
 ```javascript
-var app = require('app'),
-    path = require('path');
+var app = require('app');
+var path = require('path');
 
 app.on('ready', function() {
     var protocol = require('protocol');

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -15,7 +15,7 @@ app.on('ready', function(){
     { label: 'Item1', type: 'radio' },
     { label: 'Item2', type: 'radio' },
     { label: 'Item3', type: 'radio', checked: true },
-    { label: 'Item4', type: 'radio' },
+    { label: 'Item4', type: 'radio' }
   ]);
   appIcon.setToolTip('This is my application.');
   appIcon.setContextMenu(contextMenu);

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -390,7 +390,7 @@ without regard for log level or other properties.
 
 ```javascript
 webview.addEventListener('console-message', function(e) {
-  console.log('Guest page logged a message: ', e.message);
+  console.log('Guest page logged a message:', e.message);
 });
 ```
 

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -448,7 +448,7 @@ webview.send('ping');
 var ipc = require('ipc');
 ipc.on('ping', function() {
   ipc.sendToHost('pong');
-})
+});
 ```
 
 ### crashed

--- a/docs/tutorial/application-distribution.md
+++ b/docs/tutorial/application-distribution.md
@@ -35,7 +35,7 @@ exposing your app's source code to users.
 
 To use an `asar` archive to replace the `app` folder, you need to rename the
 archive to `app.asar`, and put it under Electron's resources directory like
-bellow, and Electron will then try read the archive and start from it.
+below, and Electron will then try read the archive and start from it.
 
 On OS X:
 

--- a/docs/tutorial/desktop-environment-integration.md
+++ b/docs/tutorial/desktop-environment-integration.md
@@ -70,9 +70,9 @@ var dockMenu = Menu.buildFromTemplate([
   { label: 'New Window', click: function() { console.log('New Window'); } },
   { label: 'New Window with Settings', submenu: [
     { label: 'Basic' },
-    { label: 'Pro'},
+    { label: 'Pro'}
   ]},
-  { label: 'New Command...'},
+  { label: 'New Command...'}
 ]);
 app.dock.setMenu(dockMenu);
 ```
@@ -119,7 +119,7 @@ app.setUserTasks([
     iconPath: process.execPath,
     iconIndex: 0,
     title: 'New Window',
-    description: 'Create a new window',
+    description: 'Create a new window'
   }
 ]);
 ```

--- a/docs/tutorial/desktop-environment-integration.md
+++ b/docs/tutorial/desktop-environment-integration.md
@@ -149,8 +149,8 @@ On Windows, a taskbar button can be used to display a progress bar. This enables
 a window to provide progress information to the user without that user having to
 switch to the window itself.
 
-The Unity DE also has a simililar feature that allows you to specify progress
-bar in the lancher.
+The Unity DE also has a similar feature that allows you to specify the progress
+bar in the launcher.
 
 __Progress bar in taskbar button:__
 

--- a/docs/tutorial/devtools-extension.md
+++ b/docs/tutorial/devtools-extension.md
@@ -20,14 +20,14 @@ Then you can load the extension in Electron by opening devtools in any window,
 and then running the following code in the devtools console:
 
 ```javascript
-require('remote').require('browser-window').addDevToolsExtension('/some-directory/react-devtools')
+require('remote').require('browser-window').addDevToolsExtension('/some-directory/react-devtools');
 ```
 
 To unload the extension, you can call `BrowserWindow.removeDevToolsExtension`
 API with its name and it will not load the next time you open the devtools:
 
 ```javascript
-require('remote').require('browser-window').removeDevToolsExtension('React Developer Tools')
+require('remote').require('browser-window').removeDevToolsExtension('React Developer Tools');
 ```
 
 ## Format of devtools extension

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -82,8 +82,9 @@ var mainWindow = null;
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function() {
-  if (process.platform != 'darwin')
+  if (process.platform != 'darwin') {
     app.quit();
+  }
 });
 
 // This method will be called when Electron has done everything

--- a/docs/tutorial/using-pepper-flash-plugin.md
+++ b/docs/tutorial/using-pepper-flash-plugin.md
@@ -23,8 +23,9 @@ var mainWindow = null;
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function() {
-  if (process.platform != 'darwin')
+  if (process.platform != 'darwin') {
     app.quit();
+  }
 });
 
 // Specify flash path.

--- a/docs/tutorial/using-selenium-and-webdriver.md
+++ b/docs/tutorial/using-selenium-and-webdriver.md
@@ -49,14 +49,14 @@ and where to find Electron's binary:
 ```javascript
 var webdriver = require('selenium-webdriver');
 
-var driver = new webdriver.Builder().
-   // The "9515" is the port opened by chrome driver.
-   usingServer('http://localhost:9515').
-   withCapabilities({chromeOptions: {
-     // Here is the path to your Electron binary.
-     binary: '/Path-to-Your-App.app/Contents/MacOS/Atom'}}).
-   forBrowser('electron').
-   build();
+var driver = new webdriver.Builder()
+  // The "9515" is the port opened by chrome driver.
+  .usingServer('http://localhost:9515')
+  .withCapabilities({chromeOptions: {
+    // Here is the path to your Electron binary.
+    binary: '/Path-to-Your-App.app/Contents/MacOS/Atom'}})
+  .forBrowser('electron')
+  .build();
 
 driver.get('http://www.google.com');
 driver.findElement(webdriver.By.name('q')).sendKeys('webdriver');


### PR DESCRIPTION
This PR fixes several nitpicks in the documentation related to either spelling/grammar or code style.

Let me know if I took too many liberties when changing the code examples, and I'll make changes accordingly. I couldn't find any information in the contributing guidelines about a JavaScript style guide, so I assumed that you would be using a generic style.