### PR TITLE
adds display:inline-block to style tag

### DIFF
--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -18,7 +18,7 @@ form, the `webview` tag includes the `src` of the web page and css styles that
 control the appearance of the `webview` container:
 
 ```html
-<webview id="foo" src="https://www.github.com/" style="width:640px; height:480px"></webview>
+<webview id="foo" src="https://www.github.com/" style="display:inline-block; width:640px; height:480px"></webview>
 ```
 
 If you want to control the guest content in any way, you can write JavaScript


### PR DESCRIPTION
The example attempts to change the height of an inline element (webview), which has no effect. 
The height styling will now take effect.