### PR TITLE
Don't use clipboard module in renderer process on Linux

### DIFF
--- a/atom/browser/lib/rpc-server.coffee
+++ b/atom/browser/lib/rpc-server.coffee
@@ -7,6 +7,7 @@ v8Util = process.atomBinding 'v8_util'
 valueToMeta = (sender, value) ->
   meta = type: typeof value
 
+  meta.type = 'buffer' if Buffer.isBuffer value
   meta.type = 'value' if value is null
   meta.type = 'array' if Array.isArray value
 
@@ -26,6 +27,8 @@ valueToMeta = (sender, value) ->
 
     meta.members = []
     meta.members.push {name: prop, type: typeof field} for prop, field of value
+  else if meta.type is 'buffer'
+    meta.value = Array::slice.call value, 0
   else
     meta.type = 'value'
     meta.value = value
@@ -43,6 +46,7 @@ unwrapArgs = (sender, args) ->
       when 'value' then meta.value
       when 'remote-object' then objectsRegistry.get meta.id
       when 'array' then unwrapArgs sender, meta.value
+      when 'buffer' then new Buffer(meta.value)
       when 'object'
         ret = v8Util.createObjectWithName meta.name
         for member in meta.members

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -7,6 +7,7 @@
 
 #include "atom/common/native_mate_converters/image_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
+#include "native_mate/arguments.h"
 #include "native_mate/dictionary.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/base/clipboard/clipboard.h"
@@ -15,44 +16,32 @@
 
 #include "atom/common/node_includes.h"
 
-namespace mate {
-
-template<>
-struct Converter<ui::ClipboardType> {
-  static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
-                     ui::ClipboardType* out) {
-    std::string type;
-    if (!Converter<std::string>::FromV8(isolate, val, &type))
-      return false;
-
-    if (type == "selection")
-      *out = ui::CLIPBOARD_TYPE_SELECTION;
-    else
-      *out = ui::CLIPBOARD_TYPE_COPY_PASTE;
-    return true;
-  }
-};
-
-}  // namespace mate
-
 namespace {
 
-std::vector<base::string16> AvailableFormats(ui::ClipboardType type) {
+ui::ClipboardType GetClipboardType(mate::Arguments* args) {
+  std::string type;
+  if (args->GetNext(&type) && type == "selection")
+    return ui::CLIPBOARD_TYPE_SELECTION;
+  else
+    return ui::CLIPBOARD_TYPE_COPY_PASTE;
+}
+
+std::vector<base::string16> AvailableFormats(mate::Arguments* args) {
   std::vector<base::string16> format_types;
   bool ignore;
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
-  clipboard->ReadAvailableTypes(type, &format_types, &ignore);
+  clipboard->ReadAvailableTypes(GetClipboardType(args), &format_types, &ignore);
   return format_types;
 }
 
-bool Has(const std::string& format_string, ui::ClipboardType type) {
+bool Has(const std::string& format_string, mate::Arguments* args) {
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
   ui::Clipboard::FormatType format(ui::Clipboard::GetFormatType(format_string));
-  return clipboard->IsFormatAvailable(format, type);
+  return clipboard->IsFormatAvailable(format, GetClipboardType(args));
 }
 
 std::string Read(const std::string& format_string,
-                 ui::ClipboardType type) {
+                 mate::Arguments* args) {
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
   ui::Clipboard::FormatType format(ui::Clipboard::GetFormatType(format_string));
 
@@ -61,62 +50,62 @@ std::string Read(const std::string& format_string,
   return data;
 }
 
-base::string16 ReadText(ui::ClipboardType type) {
+base::string16 ReadText(mate::Arguments* args) {
   base::string16 data;
-  ui::Clipboard::GetForCurrentThread()->ReadText(type, &data);
+  ui::Clipboard::GetForCurrentThread()->ReadText(GetClipboardType(args), &data);
   return data;
 }
 
-void WriteText(const base::string16& text, ui::ClipboardType type) {
-  ui::ScopedClipboardWriter writer(type);
+void WriteText(const base::string16& text, mate::Arguments* args) {
+  ui::ScopedClipboardWriter writer(GetClipboardType(args));
   writer.WriteText(text);
 }
 
-base::string16 ReadHtml(ui::ClipboardType type) {
+base::string16 ReadHtml(mate::Arguments* args) {
   base::string16 data;
   base::string16 html;
   std::string url;
   uint32 start;
   uint32 end;
-  ui::Clipboard::GetForCurrentThread()->ReadHTML(type, &html, &url,
-                                                 &start, &end);
+  ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
+  clipboard->ReadHTML(GetClipboardType(args), &html, &url, &start, &end);
   data = html.substr(start, end - start);
   return data;
 }
 
-void WriteHtml(const base::string16& html,
-               ui::ClipboardType type) {
-  ui::ScopedClipboardWriter writer(type);
+void WriteHtml(const base::string16& html, mate::Arguments* args) {
+  ui::ScopedClipboardWriter writer(GetClipboardType(args));
   writer.WriteHTML(html, std::string());
 }
 
-gfx::Image ReadImage(ui::ClipboardType type) {
-  SkBitmap bitmap = ui::Clipboard::GetForCurrentThread()->ReadImage(type);
+gfx::Image ReadImage(mate::Arguments* args) {
+  ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
+  SkBitmap bitmap = clipboard->ReadImage(GetClipboardType(args));
   return gfx::Image::CreateFrom1xBitmap(bitmap);
 }
 
-void WriteImage(const gfx::Image& image, ui::ClipboardType type) {
-  ui::ScopedClipboardWriter writer(type);
+void WriteImage(const gfx::Image& image, mate::Arguments* args) {
+  ui::ScopedClipboardWriter writer(GetClipboardType(args));
   writer.WriteImage(image.AsBitmap());
 }
 
-void Clear(ui::ClipboardType type) {
-  ui::Clipboard::GetForCurrentThread()->Clear(type);
+void Clear(mate::Arguments* args) {
+  ui::Clipboard::GetForCurrentThread()->Clear(GetClipboardType(args));
 }
 
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   mate::Dictionary dict(context->GetIsolate(), exports);
-  dict.SetMethod("_availableFormats", &AvailableFormats);
-  dict.SetMethod("_has", &Has);
-  dict.SetMethod("_read", &Read);
-  dict.SetMethod("_readText", &ReadText);
-  dict.SetMethod("_writeText", &WriteText);
-  dict.SetMethod("_readHtml", &ReadHtml);
-  dict.SetMethod("_writeHtml", &WriteHtml);
-  dict.SetMethod("_readImage", &ReadImage);
-  dict.SetMethod("_writeImage", &WriteImage);
-  dict.SetMethod("_clear", &Clear);
+  dict.SetMethod("availableFormats", &AvailableFormats);
+  dict.SetMethod("has", &Has);
+  dict.SetMethod("read", &Read);
+  dict.SetMethod("readText", &ReadText);
+  dict.SetMethod("writeText", &WriteText);
+  dict.SetMethod("readHtml", &ReadHtml);
+  dict.SetMethod("writeHtml", &WriteHtml);
+  dict.SetMethod("readImage", &ReadImage);
+  dict.SetMethod("writeImage", &WriteImage);
+  dict.SetMethod("clear", &Clear);
 }
 
 }  // namespace

--- a/atom/common/api/lib/clipboard.coffee
+++ b/atom/common/api/lib/clipboard.coffee
@@ -1,12 +1,17 @@
-binding = process.atomBinding 'clipboard'
-module.exports =
-  availableFormats: (type='standard') -> binding._availableFormats type
-  has: (format, type='standard') -> binding._has format, type
-  read: (format, type='standard') -> binding._read format, type
-  readText: (type='standard') -> binding._readText type
-  writeText: (text, type='standard') -> binding._writeText text, type
-  readHtml: (type='standard') -> binding._readHtml type
-  writeHtml: (markup, type='standard') -> binding._writeHtml markup, type
-  readImage: (type='standard') -> binding._readImage type
-  writeImage: (image, type='standard') -> binding._writeImage image, type
-  clear: (type='standard') -> binding._clear type
+if process.platform is 'linux' and process.type is 'renderer'
+  # On Linux we could not access clipboard in renderer process.
+  module.exports = require('remote').require 'clipboard'
+else
+  binding = process.atomBinding 'clipboard'
+
+  module.exports =
+    availableFormats: (type='standard') -> binding._availableFormats type
+    has: (format, type='standard') -> binding._has format, type
+    read: (format, type='standard') -> binding._read format, type
+    readText: (type='standard') -> binding._readText type
+    writeText: (text, type='standard') -> binding._writeText text, type
+    readHtml: (type='standard') -> binding._readHtml type
+    writeHtml: (markup, type='standard') -> binding._writeHtml markup, type
+    readImage: (type='standard') -> binding._readImage type
+    writeImage: (image, type='standard') -> binding._writeImage image, type
+    clear: (type='standard') -> binding._clear type

--- a/atom/common/api/lib/clipboard.coffee
+++ b/atom/common/api/lib/clipboard.coffee
@@ -2,16 +2,4 @@ if process.platform is 'linux' and process.type is 'renderer'
   # On Linux we could not access clipboard in renderer process.
   module.exports = require('remote').require 'clipboard'
 else
-  binding = process.atomBinding 'clipboard'
-
-  module.exports =
-    availableFormats: (type='standard') -> binding._availableFormats type
-    has: (format, type='standard') -> binding._has format, type
-    read: (format, type='standard') -> binding._read format, type
-    readText: (type='standard') -> binding._readText type
-    writeText: (text, type='standard') -> binding._writeText text, type
-    readHtml: (type='standard') -> binding._readHtml type
-    writeHtml: (markup, type='standard') -> binding._writeHtml markup, type
-    readImage: (type='standard') -> binding._readImage type
-    writeImage: (image, type='standard') -> binding._writeImage image, type
-    clear: (type='standard') -> binding._clear type
+  module.exports = process.atomBinding 'clipboard'

--- a/atom/renderer/api/lib/remote.coffee
+++ b/atom/renderer/api/lib/remote.coffee
@@ -10,6 +10,8 @@ wrapArgs = (args) ->
   valueToMeta = (value) ->
     if Array.isArray value
       type: 'array', value: wrapArgs(value)
+    else if Buffer.isBuffer value
+      type: 'buffer', value: Array::slice.call(value, 0)
     else if value? and typeof value is 'object' and v8Util.getHiddenValue value, 'atomId'
       type: 'remote-object', id: v8Util.getHiddenValue value, 'atomId'
     else if value? and typeof value is 'object'
@@ -30,6 +32,7 @@ metaToValue = (meta) ->
   switch meta.type
     when 'value' then meta.value
     when 'array' then (metaToValue(el) for el in meta.members)
+    when 'buffer' then new Buffer(meta.value)
     when 'error'
       throw new Error("#{meta.message}\n#{meta.stack}")
     else


### PR DESCRIPTION
Accessing clipboard in renderer process on Linux is quite reliable, this PR forces to use clipboard module on the main process to solve it. And in order to make readImage/writeImage work in renderer process, this PR also adds `Buffer` support in the `remote` module.

Close #1878.