### PR TITLE
return bool on shell.openExternal

### DIFF
--- a/atom/common/platform_util.h
+++ b/atom/common/platform_util.h
@@ -23,7 +23,7 @@ void OpenItem(const base::FilePath& full_path);
 
 // Open the given external protocol URL in the desktop's default manner.
 // (For example, mailto: URLs in the default mail user agent.)
-void OpenExternal(const GURL& url);
+bool OpenExternal(const GURL& url);
 
 // Move a file to trash.
 bool MoveItemToTrash(const base::FilePath& full_path);

--- a/atom/common/platform_util_linux.cc
+++ b/atom/common/platform_util_linux.cc
@@ -37,12 +37,12 @@ bool XDGUtil(const std::string& util, const std::string& arg) {
   return (exit_code == 0);
 }
 
-void XDGOpen(const std::string& path) {
-  XDGUtil("xdg-open", path);
+bool XDGOpen(const std::string& path) {
+  return XDGUtil("xdg-open", path);
 }
 
-void XDGEmail(const std::string& email) {
-  XDGUtil("xdg-email", email);
+bool XDGEmail(const std::string& email) {
+  return XDGUtil("xdg-email", email);
 }
 
 }  // namespace
@@ -64,11 +64,11 @@ void OpenItem(const base::FilePath& full_path) {
   XDGOpen(full_path.value());
 }
 
-void OpenExternal(const GURL& url) {
+bool OpenExternal(const GURL& url) {
   if (url.SchemeIs("mailto"))
-    XDGEmail(url.spec());
+    return XDGEmail(url.spec());
   else
-    XDGOpen(url.spec());
+    return XDGOpen(url.spec());
 }
 
 bool MoveItemToTrash(const base::FilePath& full_path) {

--- a/atom/common/platform_util_mac.mm
+++ b/atom/common/platform_util_mac.mm
@@ -118,12 +118,19 @@ void OpenItem(const base::FilePath& full_path) {
   }
 }
 
-void OpenExternal(const GURL& url) {
+bool OpenExternal(const GURL& url) {
   DCHECK([NSThread isMainThread]);
   NSString* url_string = base::SysUTF8ToNSString(url.spec());
   NSURL* ns_url = [NSURL URLWithString:url_string];
-  if (!ns_url || ![[NSWorkspace sharedWorkspace] openURL:ns_url])
-    LOG(WARNING) << "NSWorkspace failed to open URL " << url;
+  if (!ns_url){
+    return false;
+  }
+  NSArray *appUrls = (NSArray*)LSCopyApplicationURLsForURL((CFURLRef)ns_url, kLSRolesAll);
+  if([appUrls count] > 0){
+    if([[NSWorkspace sharedWorkspace] openURL:ns_url])
+      return true;
+  }
+  return false;
 }
 
 bool MoveItemToTrash(const base::FilePath& full_path) {

--- a/atom/common/platform_util_win.cc
+++ b/atom/common/platform_util_win.cc
@@ -135,7 +135,7 @@ void OpenItem(const base::FilePath& full_path) {
     ui::win::OpenFileViaShell(full_path);
 }
 
-void OpenExternal(const GURL& url) {
+bool OpenExternal(const GURL& url) {
   // Quote the input scheme to be sure that the command does not have
   // parameters unexpected by the external program. This url should already
   // have been escaped.
@@ -150,12 +150,12 @@ void OpenExternal(const GURL& url) {
   const size_t kMaxUrlLength = 2048;
   if (escaped_url.length() > kMaxUrlLength) {
     NOTREACHED();
-    return;
+    return false;
   }
 
   if (base::win::GetVersion() < base::win::VERSION_WIN7) {
     if (!ValidateShellCommandForScheme(url.scheme()))
-      return;
+      return false;
   }
 
   if (reinterpret_cast<ULONG_PTR>(ShellExecuteA(NULL, "open",
@@ -164,8 +164,9 @@ void OpenExternal(const GURL& url) {
     // We fail to execute the call. We could display a message to the user.
     // TODO(nsylvain): we should also add a dialog to warn on errors. See
     // bug 1136923.
-    return;
+    return false;
   }
+  return true;
 }
 
 bool MoveItemToTrash(const base::FilePath& path) {


### PR DESCRIPTION
I was developing an electron app, and on Mac,  when i tried to open an externalUrl,  if there was not an application that could support the custom scheme (e.g. foobar://some/url)  it would pop up a native dialog asking if the user would like to go to the app store to look for an application to launch with.

I thought it would make more sense to let the electron app handle this failure,  so I'm proposing that the call return a boolean if it was successful or not.

This is my first pull request for electron, so any advice would be much appreciated.