### PR TITLE
protocol: api to register custom schemes to standard schemes

### DIFF
--- a/atom/app/atom_content_client.cc
+++ b/atom/app/atom_content_client.cc
@@ -75,6 +75,16 @@ std::string AtomContentClient::GetProduct() const {
 void AtomContentClient::AddAdditionalSchemes(
     std::vector<std::string>* standard_schemes,
     std::vector<std::string>* savable_schemes) {
+  auto command_line = base::CommandLine::ForCurrentProcess();
+  auto custom_schemes = command_line->GetSwitchValueASCII(
+      switches::kRegisterStandardSchemes);
+  if (!custom_schemes.empty()) {
+    std::vector<std::string> schemes;
+    base::SplitString(custom_schemes, ',', &schemes);
+    standard_schemes->insert(standard_schemes->end(),
+                             schemes.begin(),
+                             schemes.end());
+  }
   standard_schemes->push_back("chrome-extension");
 }
 

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -4,6 +4,7 @@
 
 #include "atom/browser/api/atom_api_protocol.h"
 
+#include "atom/browser/atom_browser_client.h"
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/net/adapter_request_job.h"
 #include "atom/browser/net/atom_url_request_job_factory.h"
@@ -205,6 +206,7 @@ mate::ObjectTemplateBuilder Protocol::GetObjectTemplateBuilder(
   return mate::ObjectTemplateBuilder(isolate)
       .SetMethod("registerProtocol", &Protocol::RegisterProtocol)
       .SetMethod("unregisterProtocol", &Protocol::UnregisterProtocol)
+      .SetMethod("registerStandardSchemes", &Protocol::RegisterStandardSchemes)
       .SetMethod("isHandledProtocol", &Protocol::IsHandledProtocol)
       .SetMethod("interceptProtocol", &Protocol::InterceptProtocol)
       .SetMethod("uninterceptProtocol", &Protocol::UninterceptProtocol);
@@ -235,6 +237,11 @@ void Protocol::UnregisterProtocol(v8::Isolate* isolate,
                           FROM_HERE,
                           base::Bind(&Protocol::UnregisterProtocolInIO,
                                      base::Unretained(this), scheme));
+}
+
+void Protocol::RegisterStandardSchemes(
+    const std::vector<std::string>& schemes) {
+  atom::AtomBrowserClient::SetCustomSchemes(schemes);
 }
 
 bool Protocol::IsHandledProtocol(const std::string& scheme) {

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <map>
+#include <vector>
 
 #include "atom/browser/api/event_emitter.h"
 #include "base/callback.h"
@@ -40,6 +41,9 @@ class Protocol : public mate::EventEmitter {
 
  private:
   typedef std::map<std::string, JsProtocolHandler> ProtocolHandlersMap;
+
+  // Register schemes to standard scheme list.
+  void RegisterStandardSchemes(const std::vector<std::string>& schemes);
 
   // Register/unregister an networking |scheme| which would be handled by
   // |callback|.

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -6,6 +6,7 @@
 #define ATOM_BROWSER_ATOM_BROWSER_CLIENT_H_
 
 #include <string>
+#include <vector>
 
 #include "brightray/browser/browser_client.h"
 
@@ -27,6 +28,8 @@ class AtomBrowserClient : public brightray::BrowserClient {
 
   // Don't force renderer process to restart for once.
   static void SuppressRendererProcessRestartForOnce();
+  // Custom schemes to be registered to standard.
+  static void SetCustomSchemes(const std::vector<std::string>& schemes);
 
  protected:
   // content::ContentBrowserClient:

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -104,6 +104,9 @@ const char kPageVisibility[] = "page-visibility";
 // Disable HTTP cache.
 const char kDisableHttpCache[] = "disable-http-cache";
 
+// Register schemes to standard.
+const char kRegisterStandardSchemes[] = "register-standard-schemes";
+
 }  // namespace switches
 
 }  // namespace atom

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -56,6 +56,7 @@ extern const char kSharedWorker[];
 extern const char kPageVisibility[];
 
 extern const char kDisableHttpCache[];
+extern const char kRegisterStandardSchemes[];
 
 }  // namespace switches
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -39,6 +39,12 @@ response you would like to send.
 
 Unregisters the custom protocol of `scheme`.
 
+## protocol.registerStandardSchemes(value)
+
+* `value` Array
+
+`value` is an array of custom schemes to be registered to the standard.
+
 ## protocol.isHandledProtocol(scheme)
 
 * `scheme` String


### PR DESCRIPTION
Fixes #1879 

`AddAdditionalSchemes` gets called at early stage of content [intialisation](https://code.google.com/p/chromium/codesearch#chromium/src/content/app/content_main_runner.cc&sq=package:chromium&type=cs&l=703&rcl=1434281558) and standard schemes list gets locked once its done. Couldnt come up with a better approach than extracting from environment varaible `export SCHEMES=library,test,atom`. Any better option to it ?

```
> window.location
Location {ancestorOrigins: DOMStringList, href: "test://example.com/c.html"}
ancestorOrigins: DOMStringListassign: () { [native code] }
hash: ""
host: "example.com"
hostname: "example.com"
href: "test://example.com/c.html"
origin: "test://example.com"
pathname: "/c.html"
port: ""
protocol: "test:"
reload: reload() { [native code] }
replace: () { [native code] }
search: ""
toString: toString() { [native code] }
valueOf: valueOf() { [native code] }
__proto__: Location
```