### PR TITLE
webContents: add setAudioMuted to webContents

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -580,6 +580,14 @@ void WebContents::UnregisterServiceWorker(
                                    callback);
 }
 
+void WebContents::SetAudioMuted(bool muted) {
+  web_contents()->SetAudioMuted(muted);
+}
+
+bool WebContents::IsAudioMuted() {
+  return web_contents()->IsAudioMuted();
+}
+
 void WebContents::Undo() {
   web_contents()->Undo();
 }
@@ -731,6 +739,8 @@ mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
         .SetMethod("isDevToolsOpened", &WebContents::IsDevToolsOpened)
         .SetMethod("toggleDevTools", &WebContents::ToggleDevTools)
         .SetMethod("inspectElement", &WebContents::InspectElement)
+        .SetMethod("setAudioMuted", &WebContents::SetAudioMuted)
+        .SetMethod("isAudioMuted", &WebContents::IsAudioMuted)
         .SetMethod("undo", &WebContents::Undo)
         .SetMethod("redo", &WebContents::Redo)
         .SetMethod("cut", &WebContents::Cut)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -87,6 +87,8 @@ class WebContents : public mate::EventEmitter,
   void InspectServiceWorker();
   void HasServiceWorker(const base::Callback<void(bool)>&);
   void UnregisterServiceWorker(const base::Callback<void(bool)>&);
+  void SetAudioMuted(bool muted);
+  bool IsAudioMuted();
 
   // Editing commands.
   void Undo();

--- a/atom/renderer/lib/web-view/web-view.coffee
+++ b/atom/renderer/lib/web-view/web-view.coffee
@@ -275,6 +275,8 @@ registerWebViewElement = ->
     "closeDevTools"
     "isDevToolsOpened"
     "inspectElement"
+    "setAudioMuted"
+    "isAudioMuted"
     "undo"
     "redo"
     "cut"

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -877,6 +877,16 @@ Injects CSS into this page.
 
 Evaluates `code` in page.
 
+### WebContents.setAudioMuted(muted)
+
++ `muted` Boolean
+
+Set the page muted.
+
+### WebContents.isAudioMuted()
+
+Returns whether this page has been muted.
+
 ### WebContents.undo()
 
 Executes editing command `undo` in page.

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -250,6 +250,16 @@ Starts inspecting element at position (`x`, `y`) of guest page.
 
 Opens the devtools for the service worker context present in the guest page.
 
+### `<webview>`.setAudioMuted(muted)
+
++ `muted` Boolean
+
+Set guest page muted.
+
+### `<webview>`.isAudioMuted()
+
+Returns whether guest page has been muted.
+
 ### `<webview>`.undo()
 
 Executes editing command `undo` in page.


### PR DESCRIPTION
Add `setAudioMuted`, `isAudioMuted` to webContents.
Fix https://github.com/atom/electron/issues/1881