### PR TITLE
Remove global browser context

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -13,6 +13,7 @@
 
 #include "atom/browser/api/atom_api_menu.h"
 #include "atom/browser/atom_browser_context.h"
+#include "atom/browser/atom_browser_main_parts.h"
 #include "atom/browser/browser.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
@@ -97,7 +98,8 @@ class ResolveProxyHelper {
  public:
   ResolveProxyHelper(const GURL& url, App::ResolveProxyCallback callback)
       : callback_(callback) {
-    net::ProxyService* proxy_service = AtomBrowserContext::Get()->
+    auto browser_context = AtomBrowserMainParts::Get()->browser_context();
+    net::ProxyService* proxy_service = browser_context->
         url_request_context_getter()->GetURLRequestContext()->proxy_service();
 
     // Start the request.

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -132,8 +132,8 @@ class CustomProtocolRequestJob : public AdapterRequestJob {
         dict.Get("referrer", &referrer);
 
         BrowserThread::PostTask(BrowserThread::IO, FROM_HERE,
-            base::Bind(&AdapterRequestJob::CreateHttpJobAndStart,
-                       GetWeakPtr(), url, method, referrer));
+            base::Bind(&AdapterRequestJob::CreateHttpJobAndStart, GetWeakPtr(),
+                       registry_->browser_context(), url, method, referrer));
         return;
       }
     }

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -5,6 +5,7 @@
 #include "atom/browser/api/atom_api_protocol.h"
 
 #include "atom/browser/atom_browser_context.h"
+#include "atom/browser/atom_browser_main_parts.h"
 #include "atom/browser/net/adapter_request_job.h"
 #include "atom/browser/net/atom_url_request_job_factory.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
@@ -190,8 +191,9 @@ class CustomProtocolHandler : public ProtocolHandler {
 
 }  // namespace
 
-Protocol::Protocol()
-    : job_factory_(AtomBrowserContext::Get()->job_factory()) {
+Protocol::Protocol(AtomBrowserContext* browser_context)
+    : browser_context_(browser_context),
+      job_factory_(browser_context->job_factory()) {
   CHECK(job_factory_);
 }
 
@@ -343,8 +345,9 @@ void Protocol::EmitEventInUI(const std::string& event,
 }
 
 // static
-mate::Handle<Protocol> Protocol::Create(v8::Isolate* isolate) {
-  return CreateHandle(isolate, new Protocol);
+mate::Handle<Protocol> Protocol::Create(
+    v8::Isolate* isolate, AtomBrowserContext* browser_context) {
+  return CreateHandle(isolate, new Protocol(browser_context));
 }
 
 }  // namespace api
@@ -357,7 +360,9 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   mate::Dictionary dict(isolate, exports);
-  dict.Set("protocol", atom::api::Protocol::Create(isolate));
+  auto browser_context = static_cast<atom::AtomBrowserContext*>(
+      atom::AtomBrowserMainParts::Get()->browser_context());
+  dict.Set("protocol", atom::api::Protocol::Create(isolate, browser_context));
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -18,6 +18,7 @@ class URLRequest;
 
 namespace atom {
 
+class AtomBrowserContext;
 class AtomURLRequestJobFactory;
 
 namespace api {
@@ -27,12 +28,13 @@ class Protocol : public mate::EventEmitter {
   typedef base::Callback<v8::Local<v8::Value>(const net::URLRequest*)>
           JsProtocolHandler;
 
-  static mate::Handle<Protocol> Create(v8::Isolate* isolate);
+  static mate::Handle<Protocol> Create(
+      v8::Isolate* isolate, AtomBrowserContext* browser_context);
 
   JsProtocolHandler GetProtocolHandler(const std::string& scheme);
 
  protected:
-  Protocol();
+  explicit Protocol(AtomBrowserContext* browser_context);
 
   // mate::Wrappable implementations:
   virtual mate::ObjectTemplateBuilder GetObjectTemplateBuilder(
@@ -68,6 +70,7 @@ class Protocol : public mate::EventEmitter {
   // Do protocol.emit(event, parameter) under UI thread.
   void EmitEventInUI(const std::string& event, const std::string& parameter);
 
+  AtomBrowserContext* browser_context_;
   AtomURLRequestJobFactory* job_factory_;
   ProtocolHandlersMap protocol_handlers_;
 

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -33,6 +33,8 @@ class Protocol : public mate::EventEmitter {
 
   JsProtocolHandler GetProtocolHandler(const std::string& scheme);
 
+  AtomBrowserContext* browser_context() const { return browser_context_; }
+
  protected:
   explicit Protocol(AtomBrowserContext* browser_context);
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -8,6 +8,7 @@
 
 #include "atom/browser/atom_browser_client.h"
 #include "atom/browser/atom_browser_context.h"
+#include "atom/browser/atom_browser_main_parts.h"
 #include "atom/browser/native_window.h"
 #include "atom/common/api/api_messages.h"
 #include "atom/common/native_mate_converters/gfx_converter.h"
@@ -144,7 +145,7 @@ WebContents::WebContents(const mate::Dictionary& options)
       guest_host_(nullptr),
       auto_size_enabled_(false),
       is_full_page_plugin_(false) {
-  auto browser_context = AtomBrowserContext::Get();
+  auto browser_context = AtomBrowserMainParts::Get()->browser_context();
   content::SiteInstance* site_instance = content::SiteInstance::CreateForURL(
       browser_context, GURL("chrome-guest://fake-host"));
 

--- a/atom/browser/atom_access_token_store.cc
+++ b/atom/browser/atom_access_token_store.cc
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "atom/browser/atom_browser_context.h"
+#include "atom/browser/atom_browser_main_parts.h"
 #include "atom/common/google_api_key.h"
 
 namespace atom {
@@ -39,8 +40,8 @@ void AtomAccessTokenStore::LoadAccessTokens(
   token_pair.first = GURL(kGeolocationProviderUrl);
   access_token_set.insert(token_pair);
 
-  callback.Run(access_token_set,
-               AtomBrowserContext::Get()->url_request_context_getter());
+  auto browser_context = AtomBrowserMainParts::Get()->browser_context();
+  callback.Run(access_token_set, browser_context->url_request_context_getter());
 }
 
 void AtomAccessTokenStore::SaveAccessToken(const GURL& server_url,

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -104,10 +104,4 @@ content::BrowserPluginGuestManager* AtomBrowserContext::GetGuestManager() {
   return guest_manager_.get();
 }
 
-// static
-AtomBrowserContext* AtomBrowserContext::Get() {
-  return static_cast<AtomBrowserContext*>(
-      AtomBrowserMainParts::Get()->browser_context());
-}
-
 }  // namespace atom

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -13,7 +13,6 @@
 #include "base/command_line.h"
 #include "base/threading/sequenced_worker_pool.h"
 #include "base/threading/worker_pool.h"
-#include "chrome/browser/browser_process.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/common/url_constants.h"
 #include "net/ftp/ftp_network_layer.h"
@@ -40,8 +39,7 @@ class NoCacheBackend : public net::HttpCache::BackendFactory {
 }  // namespace
 
 AtomBrowserContext::AtomBrowserContext()
-    : fake_browser_process_(new BrowserProcess),
-      job_factory_(new AtomURLRequestJobFactory) {
+    : job_factory_(new AtomURLRequestJobFactory) {
 }
 
 AtomBrowserContext::~AtomBrowserContext() {

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -7,8 +7,6 @@
 
 #include "brightray/browser/browser_context.h"
 
-class BrowserProcess;
-
 namespace atom {
 
 class AtomURLRequestJobFactory;
@@ -35,8 +33,6 @@ class AtomBrowserContext : public brightray::BrowserContext {
   AtomURLRequestJobFactory* job_factory() const { return job_factory_; }
 
  private:
-  // A fake BrowserProcess object that used to feed the source code from chrome.
-  scoped_ptr<BrowserProcess> fake_browser_process_;
   scoped_ptr<WebViewManager> guest_manager_;
 
   AtomURLRequestJobFactory* job_factory_;  // Weak reference.

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -17,9 +17,6 @@ class AtomBrowserContext : public brightray::BrowserContext {
   AtomBrowserContext();
   virtual ~AtomBrowserContext();
 
-  // Returns the browser context singleton.
-  static AtomBrowserContext* Get();
-
   // brightray::URLRequestContextGetter::Delegate:
   net::URLRequestJobFactory* CreateURLRequestJobFactory(
       content::ProtocolHandlerMap* handlers,

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -11,6 +11,7 @@
 #include "atom/common/api/atom_bindings.h"
 #include "atom/common/node_bindings.h"
 #include "base/command_line.h"
+#include "chrome/browser/browser_process.h"
 #include "v8/include/v8-debug.h"
 
 #if defined(USE_X11)
@@ -25,7 +26,8 @@ namespace atom {
 AtomBrowserMainParts* AtomBrowserMainParts::self_ = NULL;
 
 AtomBrowserMainParts::AtomBrowserMainParts()
-    : browser_(new Browser),
+    : fake_browser_process_(new BrowserProcess),
+      browser_(new Browser),
       node_bindings_(NodeBindings::Create(true)),
       atom_bindings_(new AtomBindings),
       gc_timer_(true, true) {

--- a/atom/browser/atom_browser_main_parts.h
+++ b/atom/browser/atom_browser_main_parts.h
@@ -8,6 +8,8 @@
 #include "base/timer/timer.h"
 #include "brightray/browser/browser_main_parts.h"
 
+class BrowserProcess;
+
 namespace atom {
 
 class AtomBindings;
@@ -40,6 +42,9 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
 #if defined(USE_X11)
   void SetDPIFromGSettings();
 #endif
+
+  // A fake BrowserProcess object that used to feed the source code from chrome.
+  scoped_ptr<BrowserProcess> fake_browser_process_;
 
   scoped_ptr<Browser> browser_;
   scoped_ptr<JavascriptEnvironment> js_env_;

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "atom/browser/atom_browser_context.h"
+#include "atom/browser/atom_browser_main_parts.h"
 #include "atom/browser/browser.h"
 #include "atom/browser/window_list.h"
 #include "atom/common/api/api_messages.h"
@@ -153,7 +154,8 @@ NativeWindow::~NativeWindow() {
 
 // static
 NativeWindow* NativeWindow::Create(const mate::Dictionary& options) {
-  content::WebContents::CreateParams create_params(AtomBrowserContext::Get());
+  auto browser_context = AtomBrowserMainParts::Get()->browser_context();
+  content::WebContents::CreateParams create_params(browser_context);
   return Create(content::WebContents::Create(create_params), options);
 }
 

--- a/atom/browser/net/adapter_request_job.cc
+++ b/atom/browser/net/adapter_request_job.cc
@@ -114,16 +114,18 @@ void AdapterRequestJob::CreateFileJobAndStart(const base::FilePath& path) {
   real_job_->Start();
 }
 
-void AdapterRequestJob::CreateHttpJobAndStart(const GURL& url,
-                                              const std::string& method,
-                                              const std::string& referrer) {
+void AdapterRequestJob::CreateHttpJobAndStart(
+    AtomBrowserContext* browser_context,
+    const GURL& url,
+    const std::string& method,
+    const std::string& referrer) {
   if (!url.is_valid()) {
     CreateErrorJobAndStart(net::ERR_INVALID_URL);
     return;
   }
 
-  real_job_ = new URLRequestFetchJob(request(), network_delegate(), url,
-                                     method, referrer);
+  real_job_ = new URLRequestFetchJob(browser_context, request(),
+                                     network_delegate(), url, method, referrer);
   real_job_->Start();
 }
 

--- a/atom/browser/net/adapter_request_job.h
+++ b/atom/browser/net/adapter_request_job.h
@@ -20,6 +20,8 @@ class FilePath;
 
 namespace atom {
 
+class AtomBrowserContext;
+
 // Ask JS which type of job it wants, and then delegate corresponding methods.
 class AdapterRequestJob : public net::URLRequestJob {
  public:
@@ -59,7 +61,8 @@ class AdapterRequestJob : public net::URLRequestJob {
                                const std::string& charset,
                                scoped_refptr<base::RefCountedBytes> data);
   void CreateFileJobAndStart(const base::FilePath& path);
-  void CreateHttpJobAndStart(const GURL& url,
+  void CreateHttpJobAndStart(AtomBrowserContext* browser_context,
+                             const GURL& url,
                              const std::string& method,
                              const std::string& referrer);
   void CreateJobFromProtocolHandlerAndStart();

--- a/atom/browser/net/url_request_fetch_job.cc
+++ b/atom/browser/net/url_request_fetch_job.cc
@@ -74,6 +74,7 @@ class ResponsePiper : public net::URLFetcherResponseWriter {
 }  // namespace
 
 URLRequestFetchJob::URLRequestFetchJob(
+    AtomBrowserContext* browser_context,
     net::URLRequest* request,
     net::NetworkDelegate* network_delegate,
     const GURL& url,
@@ -89,8 +90,7 @@ URLRequestFetchJob::URLRequestFetchJob(
     request_type = GetRequestType(method);
 
   fetcher_.reset(net::URLFetcher::Create(url, request_type, this));
-  auto context = AtomBrowserContext::Get()->url_request_context_getter();
-  fetcher_->SetRequestContext(context);
+  fetcher_->SetRequestContext(browser_context->url_request_context_getter());
   fetcher_->SaveResponseWithWriter(make_scoped_ptr(new ResponsePiper(this)));
 
   // Use |request|'s referrer if |referrer| is not specified.

--- a/atom/browser/net/url_request_fetch_job.h
+++ b/atom/browser/net/url_request_fetch_job.h
@@ -12,10 +12,13 @@
 
 namespace atom {
 
+class AtomBrowserContext;
+
 class URLRequestFetchJob : public net::URLRequestJob,
                            public net::URLFetcherDelegate {
  public:
-  URLRequestFetchJob(net::URLRequest* request,
+  URLRequestFetchJob(AtomBrowserContext* browser_context,
+                     net::URLRequest* request,
                      net::NetworkDelegate* network_delegate,
                      const GURL& url,
                      const std::string& method,


### PR DESCRIPTION
Refs: #959

This removes the assumption of global browser context in most code, some APIs like `app.resolveProxy` and `protocol` still uses global context, but we can easily make them fallback to use default session when we have `Session` API in future.