### PR TITLE
:memo: Add missing BrowserWindow.isDevToolsOpened method.

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -517,6 +517,10 @@ Opens the developer tools.
 
 Closes the developer tools.
 
+### BrowserWindow.isDevToolsOpened()
+
+Returns whether the developer tools are opened.
+
 ### BrowserWindow.toggleDevTools()
 
 Toggle the developer tools.


### PR DESCRIPTION
Fixes #2021 