### PR TITLE
Add app.defaultSession

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -12,6 +12,7 @@
 #endif
 
 #include "atom/browser/api/atom_api_menu.h"
+#include "atom/browser/api/atom_api_session.h"
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/atom_browser_main_parts.h"
 #include "atom/browser/browser.h"
@@ -217,6 +218,16 @@ void App::SetAppUserModelId(const std::string& app_id) {
 #endif
 }
 
+v8::Local<v8::Value> App::DefaultSession(v8::Isolate* isolate) {
+  if (default_session_.IsEmpty()) {
+    auto browser_context = static_cast<AtomBrowserContext*>(
+        AtomBrowserMainParts::Get()->browser_context());
+    auto handle = Session::Create(isolate, browser_context);
+    default_session_.Reset(isolate, handle.ToV8());
+  }
+  return v8::Local<v8::Value>::New(isolate, default_session_);
+}
+
 mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
   auto browser = base::Unretained(Browser::Get());
@@ -240,7 +251,8 @@ mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(
       .SetMethod("getPath", &App::GetPath)
       .SetMethod("resolveProxy", &App::ResolveProxy)
       .SetMethod("setDesktopName", &App::SetDesktopName)
-      .SetMethod("setAppUserModelId", &App::SetAppUserModelId);
+      .SetMethod("setAppUserModelId", &App::SetAppUserModelId)
+      .SetProperty("defaultSession", &App::DefaultSession);
 }
 
 // static

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -62,6 +62,9 @@ class App : public mate::EventEmitter,
   void ResolveProxy(const GURL& url, ResolveProxyCallback callback);
   void SetDesktopName(const std::string& desktop_name);
   void SetAppUserModelId(const std::string& app_id);
+  v8::Local<v8::Value> DefaultSession(v8::Isolate* isolate);
+
+  v8::Global<v8::Value> default_session_;
 
   DISALLOW_COPY_AND_ASSIGN(App);
 };

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -9,10 +9,7 @@
 
 #include "atom/browser/api/event_emitter.h"
 #include "atom/browser/browser_observer.h"
-#include "base/callback.h"
 #include "native_mate/handle.h"
-
-class GURL;
 
 namespace base {
 class FilePath;
@@ -29,8 +26,6 @@ namespace api {
 class App : public mate::EventEmitter,
             public BrowserObserver {
  public:
-  typedef base::Callback<void(std::string)> ResolveProxyCallback;
-
   static mate::Handle<App> Create(v8::Isolate* isolate);
 
  protected:
@@ -59,7 +54,6 @@ class App : public mate::EventEmitter,
                const std::string& name,
                const base::FilePath& path);
 
-  void ResolveProxy(const GURL& url, ResolveProxyCallback callback);
   void SetDesktopName(const std::string& desktop_name);
   void SetAppUserModelId(const std::string& app_id);
   v8::Local<v8::Value> DefaultSession(v8::Isolate* isolate);

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -5,7 +5,7 @@
 #include "atom/browser/api/atom_api_session.h"
 
 #include "atom/browser/api/atom_api_cookies.h"
-#include "content/public/browser/browser_context.h"
+#include "atom/browser/atom_browser_context.h"
 #include "native_mate/callback.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
@@ -16,8 +16,8 @@ namespace atom {
 
 namespace api {
 
-Session::Session(content::BrowserContext* browser_context):
-  browser_context_(browser_context) {
+Session::Session(AtomBrowserContext* browser_context)
+    : browser_context_(browser_context) {
 }
 
 Session::~Session() {
@@ -40,7 +40,7 @@ mate::ObjectTemplateBuilder Session::GetObjectTemplateBuilder(
 // static
 mate::Handle<Session> Session::Create(
     v8::Isolate* isolate,
-    content::BrowserContext* browser_context) {
+    AtomBrowserContext* browser_context) {
   return mate::CreateHandle(isolate, new Session(browser_context));
 }
 

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -4,11 +4,17 @@
 
 #include "atom/browser/api/atom_api_session.h"
 
+#include <string>
+
 #include "atom/browser/api/atom_api_cookies.h"
 #include "atom/browser/atom_browser_context.h"
+#include "atom/common/native_mate_converters/gurl_converter.h"
 #include "native_mate/callback.h"
-#include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
+#include "net/base/load_flags.h"
+#include "net/proxy/proxy_service.h"
+#include "net/url_request/url_request_context.h"
+#include "net/url_request/url_request_context_getter.h"
 
 #include "atom/common/node_includes.h"
 
@@ -16,11 +22,59 @@ namespace atom {
 
 namespace api {
 
+namespace {
+
+class ResolveProxyHelper {
+ public:
+  ResolveProxyHelper(AtomBrowserContext* browser_context,
+                     const GURL& url,
+                     Session::ResolveProxyCallback callback)
+      : callback_(callback) {
+    net::ProxyService* proxy_service = browser_context->
+        url_request_context_getter()->GetURLRequestContext()->proxy_service();
+
+    // Start the request.
+    int result = proxy_service->ResolveProxy(
+        url, net::LOAD_NORMAL, &proxy_info_,
+        base::Bind(&ResolveProxyHelper::OnResolveProxyCompleted,
+                   base::Unretained(this)),
+        &pac_req_, nullptr, net::BoundNetLog());
+
+    // Completed synchronously.
+    if (result != net::ERR_IO_PENDING)
+      OnResolveProxyCompleted(result);
+  }
+
+  void OnResolveProxyCompleted(int result) {
+    std::string proxy;
+    if (result == net::OK)
+      proxy = proxy_info_.ToPacString();
+    callback_.Run(proxy);
+
+    delete this;
+  }
+
+ private:
+  Session::ResolveProxyCallback callback_;
+  net::ProxyInfo proxy_info_;
+  net::ProxyService::PacRequest* pac_req_;
+
+  DISALLOW_COPY_AND_ASSIGN(ResolveProxyHelper);
+};
+
+
+
+}  // namespace
+
 Session::Session(AtomBrowserContext* browser_context)
     : browser_context_(browser_context) {
 }
 
 Session::~Session() {
+}
+
+void Session::ResolveProxy(const GURL& url, ResolveProxyCallback callback) {
+  new ResolveProxyHelper(browser_context_, url, callback);
 }
 
 v8::Local<v8::Value> Session::Cookies(v8::Isolate* isolate) {
@@ -34,6 +88,7 @@ v8::Local<v8::Value> Session::Cookies(v8::Isolate* isolate) {
 mate::ObjectTemplateBuilder Session::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
   return mate::ObjectTemplateBuilder(isolate)
+      .SetMethod("resolveProxy", &Session::ResolveProxy)
       .SetProperty("cookies", &Session::Cookies);
 }
 

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -5,8 +5,13 @@
 #ifndef ATOM_BROWSER_API_ATOM_API_SESSION_H_
 #define ATOM_BROWSER_API_ATOM_API_SESSION_H_
 
+#include <string>
+
+#include "base/callback.h"
 #include "native_mate/handle.h"
 #include "native_mate/wrappable.h"
+
+class GURL;
 
 namespace atom {
 
@@ -16,6 +21,8 @@ namespace api {
 
 class Session: public mate::Wrappable {
  public:
+  using ResolveProxyCallback = base::Callback<void(std::string)>;
+
   static mate::Handle<Session> Create(v8::Isolate* isolate,
                                       AtomBrowserContext* browser_context);
 
@@ -28,6 +35,7 @@ class Session: public mate::Wrappable {
       v8::Isolate* isolate) override;
 
  private:
+  void ResolveProxy(const GURL& url, ResolveProxyCallback callback);
   v8::Local<v8::Value> Cookies(v8::Isolate* isolate);
 
   v8::Global<v8::Value> cookies_;

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -8,21 +8,19 @@
 #include "native_mate/handle.h"
 #include "native_mate/wrappable.h"
 
-namespace content {
-class BrowserContext;
-}
-
 namespace atom {
+
+class AtomBrowserContext;
 
 namespace api {
 
 class Session: public mate::Wrappable {
  public:
   static mate::Handle<Session> Create(v8::Isolate* isolate,
-                                      content::BrowserContext* browser_context);
+                                      AtomBrowserContext* browser_context);
 
  protected:
-  explicit Session(content::BrowserContext* browser_context);
+  explicit Session(AtomBrowserContext* browser_context);
   ~Session();
 
   // mate::Wrappable implementations:
@@ -34,8 +32,7 @@ class Session: public mate::Wrappable {
 
   v8::Global<v8::Value> cookies_;
 
-  // The webContents which owns the Sesssion.
-  content::BrowserContext* browser_context_;
+  AtomBrowserContext* browser_context_;  // weak ref
 
   DISALLOW_COPY_AND_ASSIGN(Session);
 };

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -608,7 +608,9 @@ void WebContents::InspectServiceWorker() {
 
 v8::Local<v8::Value> WebContents::Session(v8::Isolate* isolate) {
   if (session_.IsEmpty()) {
-    auto handle = Session::Create(isolate, web_contents()->GetBrowserContext());
+    mate::Handle<api::Session> handle = Session::Create(
+        isolate,
+        static_cast<AtomBrowserContext*>(web_contents()->GetBrowserContext()));
     session_.Reset(isolate, handle.ToV8());
   }
   return v8::Local<v8::Value>::New(isolate, session_);

--- a/atom/browser/api/lib/app.coffee
+++ b/atom/browser/api/lib/app.coffee
@@ -26,12 +26,13 @@ if process.platform is 'darwin'
     setMenu: bindings.dockSetMenu
 
 # Be compatible with old API.
-app.once 'ready', -> app.emit 'finish-launching'
+app.once 'ready', -> @emit 'finish-launching'
 app.terminate = app.quit
 app.exit = process.exit
-app.getHomeDir = -> app.getPath 'home'
-app.getDataPath = -> app.getPath 'userData'
-app.setDataPath = (path) -> app.setPath 'userData', path
+app.getHomeDir = -> @getPath 'home'
+app.getDataPath = -> @getPath 'userData'
+app.setDataPath = (path) -> @setPath 'userData', path
+app.resolveProxy = -> @defaultSession.resolveProxy.apply @defaultSession, arguments
 
 # Only one App object pemitted.
 module.exports = app


### PR DESCRIPTION
Makes the global BrowserContext visible with `app.defaultSession`, and it will be used as default session for modules like WebContents and protocol.

Refs #959.