### PR TITLE
Contents/MacOS/Electron should not be renamed

### DIFF
--- a/docs/tutorial/application-distribution.md
+++ b/docs/tutorial/application-distribution.md
@@ -83,7 +83,7 @@ The structure of a renamed app would be like:
 MyApp.app/Contents
 ├── Info.plist
 ├── MacOS/
-│   └── MyApp
+│   └── Electron
 └── Frameworks/
     ├── MyApp Helper EH.app
     |   ├── Info.plist


### PR DESCRIPTION
I renamed Contents/MacOS/Electron to match the name of my app and when I launched it I got an error saying the app was damaged or incomplete. This corrects the example in the docs so people know to leave the file untouched.