### PR TITLE
Track native JS objects in C++

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -133,6 +133,14 @@ void App::OnWillFinishLaunching() {
 }
 
 void App::OnFinishLaunching() {
+  // Create the defaultSession.
+  v8::Locker locker(isolate());
+  v8::HandleScope handle_scope(isolate());
+  auto browser_context = static_cast<AtomBrowserContext*>(
+      AtomBrowserMainParts::Get()->browser_context());
+  auto handle = Session::CreateFrom(isolate(), browser_context);
+  default_session_.Reset(isolate(), handle.ToV8());
+
   Emit("ready");
 }
 
@@ -173,13 +181,10 @@ void App::SetAppUserModelId(const std::string& app_id) {
 }
 
 v8::Local<v8::Value> App::DefaultSession(v8::Isolate* isolate) {
-  if (default_session_.IsEmpty()) {
-    auto browser_context = static_cast<AtomBrowserContext*>(
-        AtomBrowserMainParts::Get()->browser_context());
-    auto handle = Session::CreateFrom(isolate, browser_context);
-    default_session_.Reset(isolate, handle.ToV8());
-  }
-  return v8::Local<v8::Value>::New(isolate, default_session_);
+  if (default_session_.IsEmpty())
+    return v8::Null(isolate);
+  else
+    return v8::Local<v8::Value>::New(isolate, default_session_);
 }
 
 mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -176,7 +176,7 @@ v8::Local<v8::Value> App::DefaultSession(v8::Isolate* isolate) {
   if (default_session_.IsEmpty()) {
     auto browser_context = static_cast<AtomBrowserContext*>(
         AtomBrowserMainParts::Get()->browser_context());
-    auto handle = Session::Create(isolate, browser_context);
+    auto handle = Session::CreateFrom(isolate, browser_context);
     default_session_.Reset(isolate, handle.ToV8());
   }
   return v8::Local<v8::Value>::New(isolate, default_session_);

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -68,6 +68,7 @@ class ResolveProxyHelper {
 
 Session::Session(AtomBrowserContext* browser_context)
     : browser_context_(browser_context) {
+  AttachAsUserData(browser_context);
 }
 
 Session::~Session() {
@@ -93,9 +94,13 @@ mate::ObjectTemplateBuilder Session::GetObjectTemplateBuilder(
 }
 
 // static
-mate::Handle<Session> Session::Create(
+mate::Handle<Session> Session::CreateFrom(
     v8::Isolate* isolate,
     AtomBrowserContext* browser_context) {
+  auto existing = TrackableObject::FromWrappedClass(isolate, browser_context);
+  if (existing)
+    return mate::CreateHandle(isolate, static_cast<Session*>(existing));
+
   return mate::CreateHandle(isolate, new Session(browser_context));
 }
 

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -19,7 +19,7 @@ class AtomBrowserContext;
 
 namespace api {
 
-class Session: public mate::TrackableObject {
+class Session: public mate::TrackableObject<Session> {
  public:
   using ResolveProxyCallback = base::Callback<void(std::string)>;
 

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -7,9 +7,9 @@
 
 #include <string>
 
+#include "atom/browser/api/trackable_object.h"
 #include "base/callback.h"
 #include "native_mate/handle.h"
-#include "native_mate/wrappable.h"
 
 class GURL;
 
@@ -19,12 +19,13 @@ class AtomBrowserContext;
 
 namespace api {
 
-class Session: public mate::Wrappable {
+class Session: public mate::TrackableObject {
  public:
   using ResolveProxyCallback = base::Callback<void(std::string)>;
 
-  static mate::Handle<Session> Create(v8::Isolate* isolate,
-                                      AtomBrowserContext* browser_context);
+  // Gets or creates Session from the |browser_context|.
+  static mate::Handle<Session> CreateFrom(
+      v8::Isolate* isolate, AtomBrowserContext* browser_context);
 
  protected:
   explicit Session(AtomBrowserContext* browser_context);

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -424,6 +424,7 @@ void WebContents::WebContentsDestroyed() {
   // The RenderViewDeleted was not called when the WebContents is destroyed.
   RenderViewDeleted(web_contents()->GetRenderViewHost());
   Emit("destroyed");
+  RemoveFromWeakMap();
 }
 
 void WebContents::NavigationEntryCommitted(

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -155,6 +155,7 @@ WebContents::WebContents(content::WebContents* web_contents)
       auto_size_enabled_(false),
       is_full_page_plugin_(false),
       inspectable_web_contents_(nullptr) {
+  AttachAsUserData(web_contents);
 }
 
 WebContents::WebContents(const mate::Dictionary& options)
@@ -176,6 +177,7 @@ WebContents::WebContents(const mate::Dictionary& options)
   if (options.Get("embedder", &embedder) && embedder)
     owner_window = NativeWindow::FromWebContents(embedder->web_contents());
 
+  AttachAsUserData(web_contents);
   InitWithWebContents(web_contents, owner_window);
   inspectable_web_contents_ = managed_web_contents();
 
@@ -608,7 +610,7 @@ void WebContents::InspectServiceWorker() {
 
 v8::Local<v8::Value> WebContents::Session(v8::Isolate* isolate) {
   if (session_.IsEmpty()) {
-    mate::Handle<api::Session> handle = Session::Create(
+    mate::Handle<api::Session> handle = Session::CreateFrom(
         isolate,
         static_cast<AtomBrowserContext*>(web_contents()->GetBrowserContext()));
     session_.Reset(isolate, handle.ToV8());
@@ -782,11 +784,6 @@ void WebContents::SetAllowTransparency(bool allow) {
 
 bool WebContents::IsGuest() const {
   return is_guest();
-}
-
-void WebContents::AfterInit(v8::Isolate* isolate) {
-  mate::TrackableObject::AfterInit(isolate);
-  AttachAsUserData(web_contents());
 }
 
 mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -784,6 +784,11 @@ bool WebContents::IsGuest() const {
   return is_guest();
 }
 
+void WebContents::AfterInit(v8::Isolate* isolate) {
+  mate::TrackableObject::AfterInit(isolate);
+  AttachAsUserData(web_contents());
+}
+
 mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
   if (template_.IsEmpty())
@@ -873,6 +878,13 @@ gfx::Size WebContents::GetDefaultSize() const {
 // static
 mate::Handle<WebContents> WebContents::CreateFrom(
     v8::Isolate* isolate, brightray::InspectableWebContents* web_contents) {
+  // We have an existing WebContents object in JS.
+  auto existing = TrackableObject::FromWrappedClass(
+      isolate, web_contents->GetWebContents());
+  if (existing)
+    return mate::CreateHandle(isolate, static_cast<WebContents*>(existing));
+
+  // Otherwise create a new WebContents wrapper object.
   auto handle = mate::CreateHandle(isolate, new WebContents(web_contents));
   g_wrap_web_contents.Run(handle.ToV8());
   return handle;
@@ -881,6 +893,12 @@ mate::Handle<WebContents> WebContents::CreateFrom(
 // static
 mate::Handle<WebContents> WebContents::CreateFrom(
     v8::Isolate* isolate, content::WebContents* web_contents) {
+  // We have an existing WebContents object in JS.
+  auto existing = TrackableObject::FromWrappedClass(isolate, web_contents);
+  if (existing)
+    return mate::CreateHandle(isolate, static_cast<WebContents*>(existing));
+
+  // Otherwise create a new WebContents wrapper object.
   auto handle = mate::CreateHandle(isolate, new WebContents(web_contents));
   g_wrap_web_contents.Run(handle.ToV8());
   return handle;

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -8,7 +8,7 @@
 #include <string>
 #include <vector>
 
-#include "atom/browser/api/event_emitter.h"
+#include "atom/browser/api/trackable_object.h"
 #include "atom/browser/common_web_contents_delegate.h"
 #include "content/public/browser/browser_plugin_guest_delegate.h"
 #include "content/public/common/favicon_url.h"
@@ -46,7 +46,7 @@ struct SetSizeParams {
   scoped_ptr<gfx::Size> normal_size;
 };
 
-class WebContents : public mate::EventEmitter,
+class WebContents : public mate::TrackableObject,
                     public content::BrowserPluginGuestDelegate,
                     public CommonWebContentsDelegate,
                     public content::WebContentsObserver,

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -142,7 +142,6 @@ class WebContents : public mate::TrackableObject,
   ~WebContents();
 
   // mate::Wrappable:
-  void AfterInit(v8::Isolate* isolate);
   mate::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;
 
@@ -240,7 +239,6 @@ class WebContents : public mate::TrackableObject,
 
   // Returns the default size of the guestview.
   gfx::Size GetDefaultSize() const;
-
 
   v8::Global<v8::Value> session_;
 

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -46,7 +46,7 @@ struct SetSizeParams {
   scoped_ptr<gfx::Size> normal_size;
 };
 
-class WebContents : public mate::TrackableObject,
+class WebContents : public mate::TrackableObject<WebContents>,
                     public content::BrowserPluginGuestDelegate,
                     public CommonWebContentsDelegate,
                     public content::WebContentsObserver,

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -142,6 +142,7 @@ class WebContents : public mate::TrackableObject,
   ~WebContents();
 
   // mate::Wrappable:
+  void AfterInit(v8::Isolate* isolate);
   mate::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;
 

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -49,6 +49,13 @@ Window::~Window() {
     Destroy();
 }
 
+void Window::AfterInit(v8::Isolate* isolate) {
+  mate::TrackableObject<Window>::AfterInit(isolate);
+  auto web_contents = window_->managed_web_contents();
+  auto handle = WebContents::CreateFrom(isolate, web_contents);
+  web_contents_.Reset(isolate, handle.ToV8());
+}
+
 void Window::OnPageTitleUpdated(bool* prevent_default,
                                 const std::string& title) {
   *prevent_default = Emit("page-title-updated", title);
@@ -441,12 +448,10 @@ int32_t Window::ID() const {
 }
 
 v8::Local<v8::Value> Window::WebContents(v8::Isolate* isolate) {
-  if (web_contents_.IsEmpty()) {
-    auto handle =
-        WebContents::CreateFrom(isolate, window_->managed_web_contents());
-    web_contents_.Reset(isolate, handle.ToV8());
-  }
-  return v8::Local<v8::Value>::New(isolate, web_contents_);
+  if (web_contents_.IsEmpty())
+    return v8::Null(isolate);
+  else
+    return v8::Local<v8::Value>::New(isolate, web_contents_);
 }
 
 v8::Local<v8::Value> Window::DevToolsWebContents(v8::Isolate* isolate) {

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -72,6 +72,7 @@ void Window::WillCloseWindow(bool* prevent_default) {
 void Window::OnWindowClosed() {
   Emit("closed");
 
+  RemoveFromWeakMap();
   window_->RemoveObserver(this);
 }
 
@@ -542,7 +543,10 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   v8::Local<v8::Function> constructor = mate::CreateConstructor<Window>(
       isolate, "BrowserWindow", base::Bind(&Window::New));
   mate::Dictionary browser_window(isolate, constructor);
-  browser_window.SetMethod("fromId", &mate::TrackableObject::FromWeakMapID);
+  browser_window.SetMethod("fromId",
+                           &mate::TrackableObject<Window>::FromWeakMapID);
+  browser_window.SetMethod("getAllWindows",
+                           &mate::TrackableObject<Window>::GetAll);
 
   mate::Dictionary dict(isolate, exports);
   dict.Set("BrowserWindow", browser_window);

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -435,6 +435,10 @@ bool Window::IsVisibleOnAllWorkspaces() {
   return window_->IsVisibleOnAllWorkspaces();
 }
 
+int32_t Window::ID() const {
+  return weak_map_id();
+}
+
 v8::Local<v8::Value> Window::WebContents(v8::Isolate* isolate) {
   if (web_contents_.IsEmpty()) {
     auto handle =
@@ -518,6 +522,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("showDefinitionForSelection",
                  &Window::ShowDefinitionForSelection)
 #endif
+      .SetProperty("id", &Window::ID)
       .SetProperty("webContents", &Window::WebContents)
       .SetProperty("devToolsWebContents", &Window::DevToolsWebContents);
 }
@@ -529,14 +534,18 @@ void Window::BuildPrototype(v8::Isolate* isolate,
 
 namespace {
 
+using atom::api::Window;
+
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context, void* priv) {
-  using atom::api::Window;
   v8::Isolate* isolate = context->GetIsolate();
   v8::Local<v8::Function> constructor = mate::CreateConstructor<Window>(
       isolate, "BrowserWindow", base::Bind(&Window::New));
+  mate::Dictionary browser_window(isolate, constructor);
+  browser_window.SetMethod("fromId", &mate::TrackableObject::FromWeakMapID);
+
   mate::Dictionary dict(isolate, exports);
-  dict.Set("BrowserWindow", static_cast<v8::Local<v8::Value>>(constructor));
+  dict.Set("BrowserWindow", browser_window);
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -10,8 +10,8 @@
 
 #include "base/memory/scoped_ptr.h"
 #include "ui/gfx/image/image.h"
+#include "atom/browser/api/trackable_object.h"
 #include "atom/browser/native_window_observer.h"
-#include "atom/browser/api/event_emitter.h"
 #include "native_mate/handle.h"
 
 class GURL;
@@ -37,7 +37,7 @@ namespace api {
 
 class WebContents;
 
-class Window : public mate::EventEmitter,
+class Window : public mate::TrackableObject,
                public NativeWindowObserver {
  public:
   static mate::Wrappable* New(v8::Isolate* isolate,
@@ -147,6 +147,7 @@ class Window : public mate::EventEmitter,
   void SetVisibleOnAllWorkspaces(bool visible);
   bool IsVisibleOnAllWorkspaces();
 
+  int32_t ID() const;
   v8::Local<v8::Value> WebContents(v8::Isolate* isolate);
   v8::Local<v8::Value> DevToolsWebContents(v8::Isolate* isolate);
 

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -37,7 +37,7 @@ namespace api {
 
 class WebContents;
 
-class Window : public mate::TrackableObject,
+class Window : public mate::TrackableObject<Window>,
                public NativeWindowObserver {
  public:
   static mate::Wrappable* New(v8::Isolate* isolate,

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -25,10 +25,6 @@ class Arguments;
 class Dictionary;
 }
 
-namespace ui {
-class SimpleMenuModel;
-}
-
 namespace atom {
 
 class NativeWindow;
@@ -137,7 +133,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetProgressBar(double progress);
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description);
-  void SetMenu(ui::SimpleMenuModel* menu);
+  void SetMenu(v8::Isolate* isolate, v8::Local<v8::Value> menu);
   void SetAutoHideMenuBar(bool auto_hide);
   bool IsMenuBarAutoHide();
   void SetMenuBarVisibility(bool visible);
@@ -156,6 +152,7 @@ class Window : public mate::TrackableObject<Window>,
 
   v8::Global<v8::Value> web_contents_;
   v8::Global<v8::Value> devtools_web_contents_;
+  v8::Global<v8::Value> menu_;
 
   scoped_ptr<NativeWindow> window_;
 

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -52,6 +52,9 @@ class Window : public mate::TrackableObject<Window>,
   explicit Window(const mate::Dictionary& options);
   virtual ~Window();
 
+  // mate::Wrappable:
+  void AfterInit(v8::Isolate* isolate) override;
+
   // NativeWindowObserver:
   void OnPageTitleUpdated(bool* prevent_default,
                           const std::string& title) override;

--- a/atom/browser/api/lib/browser-window.coffee
+++ b/atom/browser/api/lib/browser-window.coffee
@@ -1,5 +1,5 @@
 EventEmitter = require('events').EventEmitter
-IDWeakMap = require 'id-weak-map'
+IDWeakMap = process.atomBinding('id_weak_map').IDWeakMap
 app = require 'app'
 ipc = require 'ipc'
 

--- a/atom/browser/api/lib/browser-window.coffee
+++ b/atom/browser/api/lib/browser-window.coffee
@@ -42,10 +42,6 @@ BrowserWindow::setMenu = (menu) ->
   @menu = menu  # Keep a reference of menu in case of GC.
   @_setMenu menu
 
-BrowserWindow.getAllWindows = ->
-  windows = BrowserWindow.windows
-  windows.get key for key in windows.keys()
-
 BrowserWindow.getFocusedWindow = ->
   windows = BrowserWindow.getAllWindows()
   return window for window in windows when window.isFocused()

--- a/atom/browser/api/lib/browser-window.coffee
+++ b/atom/browser/api/lib/browser-window.coffee
@@ -1,13 +1,9 @@
 EventEmitter = require('events').EventEmitter
-IDWeakMap = process.atomBinding('id_weak_map').IDWeakMap
 app = require 'app'
 ipc = require 'ipc'
 
 BrowserWindow = process.atomBinding('window').BrowserWindow
 BrowserWindow::__proto__ = EventEmitter.prototype
-
-# Store all created windows in the weak map.
-BrowserWindow.windows = new IDWeakMap
 
 BrowserWindow::_init = ->
   # Simulate the application menu on platforms other than OS X.
@@ -30,11 +26,6 @@ BrowserWindow::_init = ->
     app.emit 'browser-window-blur', event, this
   @on 'focus', (event) =>
     app.emit 'browser-window-focus', event, this
-
-  # Remove the window from weak map immediately when it's destroyed, since we
-  # could be iterating windows before GC happened.
-  @once 'closed', =>
-    BrowserWindow.windows.remove @id if BrowserWindow.windows.has @id
 
 BrowserWindow::setMenu = (menu) ->
   throw new TypeError('Invalid menu') unless menu is null or menu?.constructor?.name is 'Menu'

--- a/atom/browser/api/lib/browser-window.coffee
+++ b/atom/browser/api/lib/browser-window.coffee
@@ -15,11 +15,6 @@ BrowserWindow::_init = ->
     menu = app.getApplicationMenu()
     @setMenu menu if menu?
 
-  # Remember the window ID.
-  Object.defineProperty this, 'id',
-    value: BrowserWindow.windows.add(this)
-    enumerable: true
-
   # Make new windows requested by links behave like "window.open"
   @on '-new-window', (event, url, frameName) =>
     event.sender = @webContents
@@ -62,9 +57,6 @@ BrowserWindow.fromWebContents = (webContents) ->
 BrowserWindow.fromDevToolsWebContents = (webContents) ->
   windows = BrowserWindow.getAllWindows()
   return window for window in windows when window.devToolsWebContents?.equal webContents
-
-BrowserWindow.fromId = (id) ->
-  BrowserWindow.windows.get id if BrowserWindow.windows.has id
 
 # Helpers.
 BrowserWindow::loadUrl = -> @webContents.loadUrl.apply @webContents, arguments

--- a/atom/browser/api/lib/browser-window.coffee
+++ b/atom/browser/api/lib/browser-window.coffee
@@ -27,12 +27,6 @@ BrowserWindow::_init = ->
   @on 'focus', (event) =>
     app.emit 'browser-window-focus', event, this
 
-BrowserWindow::setMenu = (menu) ->
-  throw new TypeError('Invalid menu') unless menu is null or menu?.constructor?.name is 'Menu'
-
-  @menu = menu  # Keep a reference of menu in case of GC.
-  @_setMenu menu
-
 BrowserWindow.getFocusedWindow = ->
   windows = BrowserWindow.getAllWindows()
   return window for window in windows when window.isFocused()

--- a/atom/browser/api/trackable_object.cc
+++ b/atom/browser/api/trackable_object.cc
@@ -1,0 +1,39 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/api/trackable_object.h"
+
+namespace mate {
+
+atom::IDWeakMap TrackableObject::weak_map_;
+
+// static
+TrackableObject* TrackableObject::FromWeakMapID(v8::Isolate* isolate,
+                                                int32_t id) {
+  v8::MaybeLocal<v8::Object> object = weak_map_.Get(isolate, id);
+  if (object.IsEmpty())
+    return nullptr;
+
+  TrackableObject* self = nullptr;
+  mate::ConvertFromV8(isolate, object.ToLocalChecked(), &self);
+  return self;
+}
+
+// static
+void TrackableObject::ReleaseAllWeakReferences() {
+  weak_map_.Clear();
+}
+
+TrackableObject::TrackableObject() : weak_map_id_(0) {
+}
+
+TrackableObject::~TrackableObject() {
+  weak_map_.Remove(weak_map_id_);
+}
+
+void TrackableObject::AfterInit(v8::Isolate* isolate) {
+  weak_map_id_ = weak_map_.Add(isolate, GetWrapper(isolate));
+}
+
+}  // namespace mate

--- a/atom/browser/api/trackable_object.cc
+++ b/atom/browser/api/trackable_object.cc
@@ -65,7 +65,7 @@ void TrackableObject::AfterInit(v8::Isolate* isolate) {
   weak_map_id_ = weak_map_.Add(isolate, GetWrapper(isolate));
 }
 
-void TrackableObject::Attach(base::SupportsUserData* wrapped) {
+void TrackableObject::AttachAsUserData(base::SupportsUserData* wrapped) {
   wrapped->SetUserData(kTrackedObjectKey, new IDUserData(weak_map_id_));
 }
 

--- a/atom/browser/api/trackable_object.h
+++ b/atom/browser/api/trackable_object.h
@@ -45,6 +45,7 @@ class TrackableObject : public mate::EventEmitter {
   static atom::IDWeakMap weak_map_;
 
   int32_t weak_map_id_;
+  base::SupportsUserData* wrapped_;
 
   DISALLOW_COPY_AND_ASSIGN(TrackableObject);
 };

--- a/atom/browser/api/trackable_object.h
+++ b/atom/browser/api/trackable_object.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_API_TRACKABLE_OBJECT_H_
+#define ATOM_BROWSER_API_TRACKABLE_OBJECT_H_
+
+#include "atom/browser/api/event_emitter.h"
+#include "atom/common/id_weak_map.h"
+
+namespace mate {
+
+// All instances of TrackableObject will be kept in a weak map and can be got
+// from its ID.
+class TrackableObject : public mate::EventEmitter {
+ public:
+  // Find out the TrackableObject from its ID in weak map:
+  static TrackableObject* FromWeakMapID(v8::Isolate* isolate, int32_t id);
+
+  // Releases all weak references in weak map, called when app is terminating.
+  static void ReleaseAllWeakReferences();
+
+  // mate::Wrappable:
+  void AfterInit(v8::Isolate* isolate) override;
+
+  // The ID in weak map.
+  int32_t weak_map_id() const { return weak_map_id_; }
+
+ protected:
+  TrackableObject();
+  ~TrackableObject() override;
+
+ private:
+  static atom::IDWeakMap weak_map_;
+
+  int32_t weak_map_id_;
+
+  DISALLOW_COPY_AND_ASSIGN(TrackableObject);
+};
+
+}  // namespace mate
+
+#endif  // ATOM_BROWSER_API_TRACKABLE_OBJECT_H_

--- a/atom/browser/api/trackable_object.h
+++ b/atom/browser/api/trackable_object.h
@@ -39,7 +39,7 @@ class TrackableObject : public mate::EventEmitter {
   ~TrackableObject() override;
 
   // Wrap TrackableObject into a class that SupportsUserData.
-  void Attach(base::SupportsUserData* wrapped);
+  void AttachAsUserData(base::SupportsUserData* wrapped);
 
  private:
   static atom::IDWeakMap weak_map_;

--- a/atom/browser/api/trackable_object.h
+++ b/atom/browser/api/trackable_object.h
@@ -8,14 +8,22 @@
 #include "atom/browser/api/event_emitter.h"
 #include "atom/common/id_weak_map.h"
 
+namespace base {
+class SupportsUserData;
+}
+
 namespace mate {
 
 // All instances of TrackableObject will be kept in a weak map and can be got
 // from its ID.
 class TrackableObject : public mate::EventEmitter {
  public:
-  // Find out the TrackableObject from its ID in weak map:
+  // Find out the TrackableObject from its ID in weak map.
   static TrackableObject* FromWeakMapID(v8::Isolate* isolate, int32_t id);
+
+  // Find out the TrackableObject from the class it wraps.
+  static TrackableObject* FromWrappedClass(
+      v8::Isolate* isolate, base::SupportsUserData* wrapped);
 
   // Releases all weak references in weak map, called when app is terminating.
   static void ReleaseAllWeakReferences();
@@ -29,6 +37,9 @@ class TrackableObject : public mate::EventEmitter {
  protected:
   TrackableObject();
   ~TrackableObject() override;
+
+  // Wrap TrackableObject into a class that SupportsUserData.
+  void Attach(base::SupportsUserData* wrapped);
 
  private:
   static atom::IDWeakMap weak_map_;

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -4,6 +4,7 @@
 
 #include "atom/browser/atom_browser_main_parts.h"
 
+#include "atom/browser/api/trackable_object.h"
 #include "atom/browser/atom_browser_client.h"
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/browser.h"
@@ -36,6 +37,7 @@ AtomBrowserMainParts::AtomBrowserMainParts()
 }
 
 AtomBrowserMainParts::~AtomBrowserMainParts() {
+  mate::TrackableObject::ReleaseAllWeakReferences();
 }
 
 // static

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -37,13 +37,19 @@ AtomBrowserMainParts::AtomBrowserMainParts()
 }
 
 AtomBrowserMainParts::~AtomBrowserMainParts() {
-  mate::TrackableObject::ReleaseAllWeakReferences();
+  for (const auto& callback : destruction_callbacks_)
+    callback.Run();
 }
 
 // static
 AtomBrowserMainParts* AtomBrowserMainParts::Get() {
   DCHECK(self_);
   return self_;
+}
+
+void AtomBrowserMainParts::RegisterDestructionCallback(
+    const base::Closure& callback) {
+  destruction_callbacks_.push_back(callback);
 }
 
 brightray::BrowserContext* AtomBrowserMainParts::CreateBrowserContext() {

--- a/atom/browser/atom_browser_main_parts.h
+++ b/atom/browser/atom_browser_main_parts.h
@@ -5,6 +5,9 @@
 #ifndef ATOM_BROWSER_ATOM_BROWSER_MAIN_PARTS_H_
 #define ATOM_BROWSER_ATOM_BROWSER_MAIN_PARTS_H_
 
+#include <list>
+
+#include "base/callback.h"
 #include "base/timer/timer.h"
 #include "brightray/browser/browser_main_parts.h"
 
@@ -23,6 +26,10 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
   virtual ~AtomBrowserMainParts();
 
   static AtomBrowserMainParts* Get();
+
+  // Register a callback that should be destroyed before JavaScript environment
+  // gets destroyed.
+  void RegisterDestructionCallback(const base::Closure& callback);
 
   Browser* browser() { return browser_.get(); }
 
@@ -52,6 +59,9 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
   scoped_ptr<AtomBindings> atom_bindings_;
 
   base::Timer gc_timer_;
+
+  // List of callbacks should be executed before destroying JS env.
+  std::list<base::Closure> destruction_callbacks_;
 
   static AtomBrowserMainParts* self_;
 

--- a/atom/browser/lib/guest-window-manager.coffee
+++ b/atom/browser/lib/guest-window-manager.coffee
@@ -48,17 +48,14 @@ ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPEN', (event, args...) ->
     event.returnValue = createGuest event.sender, args...
 
 ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', (event, guestId) ->
-  return unless BrowserWindow.windows.has guestId
-  BrowserWindow.windows.get(guestId).destroy()
+  BrowserWindow.fromId(guestId)?.destroy()
 
 ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', (event, guestId, method, args...) ->
-  return unless BrowserWindow.windows.has guestId
-  BrowserWindow.windows.get(guestId)[method] args...
+  BrowserWindow.fromId(guestId)?[method] args...
 
 ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', (event, guestId, message, targetOrigin) ->
-  return unless BrowserWindow.windows.has guestId
-  guestContents = BrowserWindow.windows.get(guestId).webContents
-  if guestContents.getUrl().indexOf(targetOrigin) is 0 or targetOrigin is '*'
+  guestContents = BrowserWindow.fromId(guestId)?.webContents
+  if guestContents?.getUrl().indexOf(targetOrigin) is 0 or targetOrigin is '*'
     guestContents.send 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', message, targetOrigin
 
 ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', (event, message, targetOrigin) ->
@@ -67,5 +64,4 @@ ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', (event, mess
     embedder.send 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', message, targetOrigin
 
 ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', (event, guestId, method, args...) ->
-  return unless BrowserWindow.windows.has guestId
-  BrowserWindow.windows.get(guestId).webContents?[method] args...
+  BrowserWindow.fromId(guestId)?.webContents?[method] args...

--- a/atom/browser/lib/objects-registry.coffee
+++ b/atom/browser/lib/objects-registry.coffee
@@ -1,5 +1,5 @@
 EventEmitter = require('events').EventEmitter
-IDWeakMap = require 'id-weak-map'
+IDWeakMap = process.atomBinding('id_weak_map').IDWeakMap
 v8Util = process.atomBinding 'v8_util'
 
 # Class to reference all objects.

--- a/atom/common/api/atom_api_id_weak_map.h
+++ b/atom/common/api/atom_api_id_weak_map.h
@@ -6,11 +6,9 @@
 #ifndef ATOM_COMMON_API_ATOM_API_ID_WEAK_MAP_H_
 #define ATOM_COMMON_API_ATOM_API_ID_WEAK_MAP_H_
 
-#include <map>
 #include <vector>
 
-#include "base/basictypes.h"
-#include "native_mate/scoped_persistent.h"
+#include "atom/common/id_weak_map.h"
 #include "native_mate/wrappable.h"
 
 namespace atom {
@@ -33,16 +31,8 @@ class IDWeakMap : public mate::Wrappable {
   bool Has(int32_t key) const;
   std::vector<int32_t> Keys() const;
   void Remove(int32_t key);
-  int GetNextID();
 
-  static void WeakCallback(
-      const v8::WeakCallbackData<v8::Object, IDWeakMap>& data);
-
-  int32_t next_id_;
-
-  typedef scoped_refptr<mate::RefCountedPersistent<v8::Object> >
-      RefCountedV8Object;
-  std::map<int32_t, RefCountedV8Object> map_;
+  atom::IDWeakMap map_;
 
   DISALLOW_COPY_AND_ASSIGN(IDWeakMap);
 };

--- a/atom/common/api/lib/id-weak-map.coffee
+++ b/atom/common/api/lib/id-weak-map.coffee
@@ -1,3 +1,0 @@
-IDWeakMap = process.atomBinding('id_weak_map').IDWeakMap
-
-module.exports = IDWeakMap

--- a/atom/common/id_weak_map.cc
+++ b/atom/common/id_weak_map.cc
@@ -1,0 +1,70 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/common/id_weak_map.h"
+
+#include <utility>
+
+#include "native_mate/converter.h"
+
+namespace atom {
+
+IDWeakMap::IDWeakMap() : next_id_(0) {
+}
+
+IDWeakMap::~IDWeakMap() {
+}
+
+int32_t IDWeakMap::Add(v8::Isolate* isolate, v8::Local<v8::Object> object) {
+  int32_t id = GetNextID();
+  object->SetHiddenValue(mate::StringToSymbol(isolate, "IDWeakMapKey"),
+                         mate::Converter<int32_t>::ToV8(isolate, id));
+
+  auto global = make_linked_ptr(new v8::Global<v8::Object>(isolate, object));
+  global->SetWeak(this, &WeakCallback);
+  map_.emplace(id, global);
+  return id;
+}
+
+v8::MaybeLocal<v8::Object> IDWeakMap::Get(v8::Isolate* isolate, int32_t id) {
+  auto iter = map_.find(id);
+  if (iter == map_.end())
+    return v8::MaybeLocal<v8::Object>();
+  else
+    return v8::Local<v8::Object>::New(isolate, *iter->second);
+}
+
+bool IDWeakMap::Has(int32_t id) const {
+  return map_.find(id) != map_.end();
+}
+
+std::vector<int32_t> IDWeakMap::Keys() const {
+  std::vector<int32_t> keys;
+  keys.reserve(map_.size());
+  for (const auto& iter : map_)
+    keys.emplace_back(iter.first);
+  return keys;
+}
+
+void IDWeakMap::Remove(int32_t id) {
+  auto iter = map_.find(id);
+  if (iter == map_.end())
+    LOG(WARNING) << "Removing unexist object with ID " << id;
+  else
+    map_.erase(iter);
+}
+
+int IDWeakMap::GetNextID() {
+  return ++next_id_;
+}
+
+// static
+void IDWeakMap::WeakCallback(
+    const v8::WeakCallbackData<v8::Object, IDWeakMap>& data) {
+  int32_t id = data.GetValue()->GetHiddenValue(
+      mate::StringToV8(data.GetIsolate(), "IDWeakMapKey"))->Int32Value();
+  data.GetParameter()->Remove(id);
+}
+
+}  // namespace atom

--- a/atom/common/id_weak_map.cc
+++ b/atom/common/id_weak_map.cc
@@ -55,6 +55,10 @@ void IDWeakMap::Remove(int32_t id) {
     map_.erase(iter);
 }
 
+void IDWeakMap::Clear() {
+  map_.clear();
+}
+
 int32_t IDWeakMap::GetNextID() {
   return ++next_id_;
 }

--- a/atom/common/id_weak_map.cc
+++ b/atom/common/id_weak_map.cc
@@ -47,6 +47,14 @@ std::vector<int32_t> IDWeakMap::Keys() const {
   return keys;
 }
 
+std::vector<v8::Local<v8::Object>> IDWeakMap::Values(v8::Isolate* isolate) {
+  std::vector<v8::Local<v8::Object>> keys;
+  keys.reserve(map_.size());
+  for (const auto& iter : map_)
+    keys.emplace_back(v8::Local<v8::Object>::New(isolate, *iter.second));
+  return keys;
+}
+
 void IDWeakMap::Remove(int32_t id) {
   auto iter = map_.find(id);
   if (iter == map_.end())

--- a/atom/common/id_weak_map.cc
+++ b/atom/common/id_weak_map.cc
@@ -55,7 +55,7 @@ void IDWeakMap::Remove(int32_t id) {
     map_.erase(iter);
 }
 
-int IDWeakMap::GetNextID() {
+int32_t IDWeakMap::GetNextID() {
   return ++next_id_;
 }
 

--- a/atom/common/id_weak_map.h
+++ b/atom/common/id_weak_map.h
@@ -34,6 +34,9 @@ class IDWeakMap {
   // Remove object with |id| in the WeakMap.
   void Remove(int32_t key);
 
+  // Clears the weak map.
+  void Clear();
+
  private:
   // Returns next available ID.
   int32_t GetNextID();

--- a/atom/common/id_weak_map.h
+++ b/atom/common/id_weak_map.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_COMMON_ID_WEAK_MAP_H_
+#define ATOM_COMMON_ID_WEAK_MAP_H_
+
+#include <unordered_map>
+#include <vector>
+
+#include "base/memory/linked_ptr.h"
+#include "v8/include/v8.h"
+
+namespace atom {
+
+// Like ES6's WeakMap, but the key is Integer and the value is Weak Pointer.
+class IDWeakMap {
+ public:
+  IDWeakMap();
+  ~IDWeakMap();
+
+  // Adds |object| to WeakMap and returns its allocated |id|.
+  int32_t Add(v8::Isolate* isolate, v8::Local<v8::Object> object);
+
+  // Gets the object from WeakMap by its |id|.
+  v8::MaybeLocal<v8::Object> Get(v8::Isolate* isolate, int32_t id);
+
+  // Whethere there is an object with |id| in this WeakMap.
+  bool Has(int32_t id) const;
+
+  // Returns IDs of all available objects.
+  std::vector<int32_t> Keys() const;
+
+  // Remove object with |id| in the WeakMap.
+  void Remove(int32_t key);
+
+ private:
+  // Returns next available ID.
+  int GetNextID();
+
+  static void WeakCallback(
+      const v8::WeakCallbackData<v8::Object, IDWeakMap>& data);
+
+  // ID of next stored object.
+  int32_t next_id_;
+
+  // Map of stored objects.
+  std::unordered_map<int32_t, linked_ptr<v8::Global<v8::Object>>> map_;
+
+  DISALLOW_COPY_AND_ASSIGN(IDWeakMap);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_COMMON_ID_WEAK_MAP_H_

--- a/atom/common/id_weak_map.h
+++ b/atom/common/id_weak_map.h
@@ -36,7 +36,7 @@ class IDWeakMap {
 
  private:
   // Returns next available ID.
-  int GetNextID();
+  int32_t GetNextID();
 
   static void WeakCallback(
       const v8::WeakCallbackData<v8::Object, IDWeakMap>& data);

--- a/atom/common/id_weak_map.h
+++ b/atom/common/id_weak_map.h
@@ -31,6 +31,9 @@ class IDWeakMap {
   // Returns IDs of all available objects.
   std::vector<int32_t> Keys() const;
 
+  // Returns all objects.
+  std::vector<v8::Local<v8::Object>> Values(v8::Isolate* isolate);
+
   // Remove object with |id| in the WeakMap.
   void Remove(int32_t key);
 

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -254,6 +254,8 @@
       'atom/common/event_emitter_caller.cc',
       'atom/common/event_emitter_caller.h',
       'atom/common/google_api_key.h',
+      'atom/common/id_weak_map.cc',
+      'atom/common/id_weak_map.h',
       'atom/common/linux/application_info.cc',
       'atom/common/native_mate_converters/accelerator_converter.cc',
       'atom/common/native_mate_converters/accelerator_converter.h',

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -33,7 +33,6 @@
       'atom/common/api/lib/callbacks-registry.coffee',
       'atom/common/api/lib/clipboard.coffee',
       'atom/common/api/lib/crash-reporter.coffee',
-      'atom/common/api/lib/id-weak-map.coffee',
       'atom/common/api/lib/native-image.coffee',
       'atom/common/api/lib/shell.coffee',
       'atom/common/lib/init.coffee',

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -96,6 +96,8 @@
       'atom/browser/api/event.h',
       'atom/browser/api/event_emitter.cc',
       'atom/browser/api/event_emitter.h',
+      'atom/browser/api/trackable_object.cc',
+      'atom/browser/api/trackable_object.h',
       'atom/browser/auto_updater.cc',
       'atom/browser/auto_updater.h',
       'atom/browser/auto_updater_delegate.h',


### PR DESCRIPTION
This PR transfer most native JS objects' lifetime management from JS to C++, so we can easily manipulate JS objects in C++.

Refs #959.