### PR TITLE
Move gpu-crashed event to app

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -24,6 +24,7 @@
 #include "base/path_service.h"
 #include "brightray/browser/brightray_paths.h"
 #include "content/public/browser/client_certificate_delegate.h"
+#include "content/public/browser/gpu_data_manager.h"
 #include "native_mate/callback.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
@@ -135,10 +136,12 @@ void OnClientCertificateSelected(
 
 App::App() {
   Browser::Get()->AddObserver(this);
+  content::GpuDataManager::GetInstance()->AddObserver(this);
 }
 
 App::~App() {
   Browser::Get()->RemoveObserver(this);
+  content::GpuDataManager::GetInstance()->RemoveObserver(this);
 }
 
 void App::OnBeforeQuit(bool* prevent_default) {
@@ -204,6 +207,10 @@ void App::OnSelectCertificate(
   if (!prevent_default)
     shared_delegate->ContinueWithCertificate(
         cert_request_info->client_certs[0].get());
+}
+
+void App::OnGpuProcessCrashed(base::TerminationStatus exit_code) {
+  Emit("gpu-crashed");
 }
 
 base::FilePath App::GetPath(mate::Arguments* args, const std::string& name) {

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -210,7 +210,7 @@ void App::OnSelectCertificate(
 }
 
 void App::OnGpuProcessCrashed(base::TerminationStatus exit_code) {
-  Emit("gpu-crashed");
+  Emit("gpu-process-crashed");
 }
 
 base::FilePath App::GetPath(mate::Arguments* args, const std::string& name) {

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -9,6 +9,7 @@
 
 #include "atom/browser/api/event_emitter.h"
 #include "atom/browser/browser_observer.h"
+#include "content/public/browser/gpu_data_manager_observer.h"
 #include "native_mate/handle.h"
 
 namespace base {
@@ -24,7 +25,8 @@ namespace atom {
 namespace api {
 
 class App : public mate::EventEmitter,
-            public BrowserObserver {
+            public BrowserObserver,
+            public content::GpuDataManagerObserver {
  public:
   static mate::Handle<App> Create(v8::Isolate* isolate);
 
@@ -46,6 +48,9 @@ class App : public mate::EventEmitter,
       content::WebContents* web_contents,
       net::SSLCertRequestInfo* cert_request_info,
       scoped_ptr<content::ClientCertificateDelegate> delegate) override;
+
+  // content::GpuDataManagerObserver:
+  void OnGpuProcessCrashed(base::TerminationStatus exit_code) override;
 
   // mate::Wrappable:
   mate::ObjectTemplateBuilder GetObjectTemplateBuilder(

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -328,11 +328,6 @@ void WebContents::PluginCrashed(const base::FilePath& plugin_path,
   Emit("plugin-crashed", info.name, info.version);
 }
 
-void WebContents::OnGpuProcessCrashed(base::TerminationStatus exit_code) {
-  if (exit_code == base::TERMINATION_STATUS_PROCESS_CRASHED)
-    Emit("gpu-crashed");
-}
-
 void WebContents::DocumentLoadedInFrame(
     content::RenderFrameHost* render_frame_host) {
   if (!render_frame_host->GetParent())

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -12,7 +12,6 @@
 #include "atom/browser/common_web_contents_delegate.h"
 #include "content/public/common/favicon_url.h"
 #include "content/public/browser/web_contents_observer.h"
-#include "content/public/browser/gpu_data_manager_observer.h"
 #include "native_mate/handle.h"
 #include "ui/gfx/image/image.h"
 
@@ -34,8 +33,7 @@ namespace api {
 
 class WebContents : public mate::TrackableObject<WebContents>,
                     public CommonWebContentsDelegate,
-                    public content::WebContentsObserver,
-                    public content::GpuDataManagerObserver {
+                    public content::WebContentsObserver {
  public:
   // For node.js callback function type: function(error, buffer)
   typedef base::Callback<void(v8::Local<v8::Value>, v8::Local<v8::Value>)>
@@ -184,9 +182,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
       const std::vector<content::FaviconURL>& urls) override;
   void PluginCrashed(const base::FilePath& plugin_path,
                      base::ProcessId plugin_pid) override;
-
-  // content::GpuDataManagerObserver:
-  void OnGpuProcessCrashed(base::TerminationStatus exit_code) override;
 
  private:
   enum Type {

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -125,7 +125,7 @@ app.on('select-certificate', function(event, host, url, list, callback) {
 `event.preventDefault()` prevents from using the first certificate from
 the store.
 
-### Event: 'gpu-crashed'
+### Event: 'gpu-process-crashed'
 
 Emitted when the gpu process is crashed.
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -125,6 +125,10 @@ app.on('select-certificate', function(event, host, url, list, callback) {
 `event.preventDefault()` prevents from using the first certificate from
 the store.
 
+### Event: 'gpu-crashed'
+
+Emitted when the gpu process is crashed.
+
 ## app.quit()
 
 Try to close all windows. The `before-quit` event will first be emitted. If all

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -757,10 +757,6 @@ Calling `event.preventDefault()` can prevent the navigation.
 
 Emitted when the renderer process is crashed.
 
-### Event: 'gpu-crashed'
-
-Emitted when the gpu process is crashed.
-
 ### Event: 'plugin-crashed'
 
 * `event` Event


### PR DESCRIPTION
Since there is only one GPU process it is more suitable to put `gpu-crashed` event in `app`, otherwise once GPU process crashes this event would be pushed to every WebContents.

I'm not going to keep compatibility with old API though, since the original implementation didn't call `GpuDataManager::AddObserver` and it never worked.