### PR TITLE
:bug: Solves issue #2047 [Windows fullscreen bug]

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -418,17 +418,19 @@ bool NativeWindowViews::IsMinimized() {
 }
 
 void NativeWindowViews::SetFullScreen(bool fullscreen) {
+#if defined(OS_WIN)
+  // There is no native fullscreen state on Windows.
+  window_->SetFullscreen(fullscreen);
+  if (fullscreen)
+    NotifyWindowEnterFullScreen();
+  else
+    NotifyWindowLeaveFullScreen();
+#else
   if (IsVisible())
     window_->SetFullscreen(fullscreen);
   else
     window_->native_widget_private()->ShowWithWindowState(
         ui::SHOW_STATE_FULLSCREEN);
-#if defined(OS_WIN)
-  // There is no native fullscreen state on Windows.
-  if (fullscreen)
-    NotifyWindowEnterFullScreen();
-  else
-    NotifyWindowLeaveFullScreen();
 #endif
 }
 


### PR DESCRIPTION
The bug is discussed in #2047. When the fullscreen flag is set in an app, it fails to go to the fullscreen state in Windows OS. This is due to the reason that Windows has no support for SHOW_STATE_FULLSCREEN state in chromium as mentioned on https://codereview.chromium.org/1138383008.

This is solved by selectively calling SHOW_STATE_FULLSCREEN state for other operating systems expect Windows. Windows fullscreen state is achieved by default SetFullscreen method in all cases.

I have built from latest source (v0.28.3) with these changes and tested this on Windows 7 (x64). It works as expected now. Since, the code for other OS is not changed, it would work for other OS as well.