### PR TITLE
Fix `window.open` with wrong name

### DIFF
--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -45,7 +45,7 @@ window.open = (url, frameName='', features='') ->
         value
   options.x ?= options.left if options.left
   options.y ?= options.top if options.top
-  options.title ?= name
+  options.title ?= frameName
   options.width ?= 800
   options.height ?= 600
 


### PR DESCRIPTION
When calling `window.open` the newly created window would have the name of the last option in the `features` argument as the title. I think it's supposed to be pointed to `frameName`.