### PR TITLE
plugin: dont check renderer flags for adding pepper browser host filters

### DIFF
--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -215,11 +215,8 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
 
 void AtomBrowserClient::DidCreatePpapiPlugin(
     content::BrowserPpapiHost* host) {
-  auto command_line = base::CommandLine::ForCurrentProcess();
-  if (command_line->HasSwitch(switches::kEnablePlugins)) {
-    host->GetPpapiHost()->AddHostFactoryFilter(
-        make_scoped_ptr(new chrome::ChromeBrowserPepperHostFactory(host)));
-  }
+  host->GetPpapiHost()->AddHostFactoryFilter(
+      make_scoped_ptr(new chrome::ChromeBrowserPepperHostFactory(host)));
 }
 
 content::QuotaPermissionContext*


### PR DESCRIPTION
Fixes #1784 

