### PR TITLE
Allow downloading prebuilt libchromiumcontent binaries from mirror

### DIFF
--- a/docs/development/build-system-overview.md
+++ b/docs/development/build-system-overview.md
@@ -30,10 +30,17 @@ library versions, so we can have the best possible binary size and performance.
 
 ## Minimal bootstrapping
 
-All of Chromium's prebuilt binaries are downloaded when running the bootstrap
-script. By default both static libraries and shared libraries will be
-downloaded and the final size should be between 800MB and 2GB according to the
-platform.
+All of Chromium's prebuilt binaries(libchromiumcontent) are downloaded when
+running the bootstrap script. By default both static libraries and shared
+libraries will be downloaded and the final size should be between 800MB and 2GB
+according to the platform.
+
+By default, libchromiumcontent is downloaded from Amazon Web Services.
+If the `LIBCHROMIUMCONTENT_MIRROR` environment variable is set, bootrstrap
+script will download from it.
+[libchromiumcontent-qiniu-mirror](https://github.com/hokein/libchromiumcontent-qiniu-mirror)
+is a mirror for libchromiumcontent. If you have trouble in accessing AWS, you can
+switch download address to it via `export LIBCHROMIUMCONTENT_MIRROR=http://7xk3d2.dl1.z0.glb.clouddn.com/`
 
 If you only want to build Electron quickly for testing or development, you
 can only download the shared library versions by passing the `--dev` parameter:

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -6,7 +6,8 @@ import platform
 import sys
 
 
-BASE_URL = 'http://gh-contractor-zcbenz.s3.amazonaws.com/libchromiumcontent'
+BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
+    'http://gh-contractor-zcbenz.s3.amazonaws.com/libchromiumcontent'
 LIBCHROMIUMCONTENT_COMMIT = 'a4410de75315f3ecc00db2314bfab184dcd914f8'
 
 PLATFORM = {


### PR DESCRIPTION
This PR allows developers to set a mirror for the prebuilt libchromiumcontent binaries(such as
https://github.com/hokein/libchromiumcontent-qiniu-mirror).