### PR TITLE
fix bootstrap error in verbose mode

### DIFF
--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -109,7 +109,7 @@ def update_node_modules(dirname, env=None):
   with scoped_cwd(dirname):
     args = [NPM, 'install']
     if is_verbose_mode():
-      args += '--verbose'
+      args.append('--verbose')
     # Ignore npm install errors when running in CI.
     if os.environ.has_key('CI'):
       try:


### PR DESCRIPTION
Fixes the following error

```
npm.cmd install - - v e r b o s e     #got '- - v e r b o s e' instead of 'verbose'
npm ERR! 404 Not Found

npm ERR! System Windows_NT 6.1.7601
npm ERR! command "C:\\Program Files\\nodejs\\\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "install" "-" "-" "v" "e" "r" "b" "o" "s" "e"
npm ERR! cwd D:\Dev\tmp\electron
npm ERR! node -v v0.10.38
npm ERR! npm -v 1.4.28
npm ERR! code E404
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     D:\Dev\tmp\electron\npm-debug.log
npm ERR! not ok code 0
None
Traceback (most recent call last):
  File "D:\Dev\tmp\electron\script\bootstrap.py", line 182, in <module>
    sys.exit(main())
  File "D:\Dev\tmp\electron\script\bootstrap.py", line 40, in main
    update_node_modules('.')
  File "D:\Dev\tmp\electron\script\bootstrap.py", line 120, in update_node_modules
    execute_stdout(args, env)
  File "D:\Dev\tmp\electron\script\lib\util.py", line 177, in execute_stdout
    raise e
subprocess.CalledProcessError: Command '['npm.cmd', 'install', '-', '-', 'v', 'e', 'r', 'b', 'o', 's', 'e']' returned non-zero exit status 1
```