### PR TITLE
doc: linux troubleshooting libtinfo.so.5 not found

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -96,6 +96,15 @@ $ ./script/clean.py
 
 Make sure you have installed all the build dependencies.
 
+### error while loading shared libraries: libtinfo.so.5
+
+Prebulit `clang` will try to link to `libtinfo.so.5`. Depending on the host architecture,
+symlink to appropirate `libncurses`
+
+```bash
+$ sudo ln -s /usr/lib/libncurses.so.5 /usr/lib/libtinfo.so.5
+```
+
 ## Tests
 
 ```bash


### PR DESCRIPTION
```bash
(py27)shell git:linux_doc_patch  ❯ ldd ./vendor/llvm-build/Release+Asserts/bin/clang
	linux-vdso.so.1 (0x00007ffee9f8d000)
	librt.so.1 => /usr/lib/librt.so.1 (0x00007ff821f9d000)
	libdl.so.2 => /usr/lib/libdl.so.2 (0x00007ff821d99000)
	libtinfo.so.5 => /usr/lib/libtinfo.so.5 (0x00007ff821b43000)
	libz.so.1 => /usr/lib/libz.so.1 (0x00007ff82192d000)
	libm.so.6 => /usr/lib/libm.so.6 (0x00007ff821628000)
	libstdc++.so.6 => /home/robo/github/shell/vendor/llvm-build/Release+Asserts/bin/../lib/libstdc++.so.6 (0x00007ff821325000)
	libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007ff82110f000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007ff820d6c000)
	libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007ff820b4f000)
	/lib64/ld-linux-x86-64.so.2 (0x00007ff8221a5000)

```