### PR TITLE
protocol: cleanup

### DIFF
--- a/atom/browser/api/lib/protocol.coffee
+++ b/atom/browser/api/lib/protocol.coffee
@@ -6,6 +6,29 @@ EventEmitter = require('events').EventEmitter
 
 protocol.__proto__ = EventEmitter.prototype
 
+GetWrappedCallback = (scheme, callback, notification) ->
+  wrappedCallback = (error) ->
+    if not callback?
+      if error
+        throw error
+      else
+        protocol.emit notification, scheme
+    else
+      callback error, scheme
+
+# Compatibility with old api.
+protocol.registerProtocol = (scheme, handler, callback) ->
+  protocol._registerProtocol scheme, handler, GetWrappedCallback(scheme, callback, 'registered')
+
+protocol.unregisterProtocol = (scheme, callback) ->
+  protocol._unregisterProtocol scheme, GetWrappedCallback(scheme, callback, 'unregistered')
+
+protocol.interceptProtocol = (scheme, handler, callback) ->
+  protocol._interceptProtocol scheme, handler, GetWrappedCallback(scheme, callback, 'intercepted')
+
+protocol.uninterceptProtocol = (scheme, callback) ->
+  protocol._uninterceptProtocol scheme, GetWrappedCallback(scheme, callback, 'unintercepted')
+
 protocol.RequestStringJob =
 class RequestStringJob
   constructor: ({mimeType, charset, data}) ->

--- a/atom/browser/net/atom_url_request_job_factory.h
+++ b/atom/browser/net/atom_url_request_job_factory.h
@@ -56,11 +56,9 @@ class AtomURLRequestJobFactory : public net::URLRequestJobFactory {
   bool IsSafeRedirectTarget(const GURL& location) const override;
 
  private:
-  typedef std::map<std::string, ProtocolHandler*> ProtocolHandlerMap;
+  using ProtocolHandlerMap = std::map<std::string, ProtocolHandler*>;
 
   ProtocolHandlerMap protocol_handler_map_;
-
-  mutable base::Lock lock_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomURLRequestJobFactory);
 };

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -28,7 +28,7 @@ was emitted.
 * `handler` Function
 
 Registers a custom protocol of `scheme`, the `handler` would be called with
-`handler(request)` when the a request with registered `scheme` is made.
+`handler(error, request)` when the a request with registered `scheme` is made.
 
 You need to return a request job in the `handler` to specify which type of
 response you would like to send.
@@ -45,11 +45,12 @@ Unregisters the custom protocol of `scheme`.
 
 `value` is an array of custom schemes to be registered to the standard.
 
-## protocol.isHandledProtocol(scheme)
+## protocol.isHandledProtocol(scheme, callback)
 
 * `scheme` String
+* `callback` Function
 
-Returns whether the `scheme` can be handled already.
+`callback` returns a boolean whether the `scheme` can be handled already.
 
 ## protocol.interceptProtocol(scheme, handler)
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -15,6 +15,9 @@ app.on('ready', function() {
     protocol.registerProtocol('atom', function(request) {
       var url = request.url.substr(7)
       return new protocol.RequestFileJob(path.normalize(__dirname + '/' + url));
+    }, function (error, scheme) {
+      if (!error)
+        console.log(scheme, ' registered successfully')
     });
 });
 ```
@@ -22,20 +25,22 @@ app.on('ready', function() {
 **Note:** This module can only be used after the `ready` event
 was emitted.
 
-## protocol.registerProtocol(scheme, handler)
+## protocol.registerProtocol(scheme, handler, callback)
 
 * `scheme` String
 * `handler` Function
+* `callback` Function
 
 Registers a custom protocol of `scheme`, the `handler` would be called with
-`handler(error, request)` when the a request with registered `scheme` is made.
+`handler(request)` when the a request with registered `scheme` is made.
 
 You need to return a request job in the `handler` to specify which type of
 response you would like to send.
 
-## protocol.unregisterProtocol(scheme)
+## protocol.unregisterProtocol(scheme, callback)
 
 * `scheme` String
+* `callback` Function
 
 Unregisters the custom protocol of `scheme`.
 
@@ -52,17 +57,19 @@ Unregisters the custom protocol of `scheme`.
 
 `callback` returns a boolean whether the `scheme` can be handled already.
 
-## protocol.interceptProtocol(scheme, handler)
+## protocol.interceptProtocol(scheme, handler, callback)
 
 * `scheme` String
 * `handler` Function
+* `callback` Function
 
 Intercepts an existing protocol with `scheme`, returning `null` or `undefined`
 in `handler` would use the original protocol handler to handle the request.
 
-## protocol.uninterceptProtocol(scheme)
+## protocol.uninterceptProtocol(scheme, callback)
 
 * `scheme` String
+* `callback` Function
 
 Unintercepts a protocol.
 

--- a/spec/api-protocol-spec.coffee
+++ b/spec/api-protocol-spec.coffee
@@ -28,8 +28,10 @@ describe 'protocol module', ->
 
   describe 'protocol.unregisterProtocol', ->
     it 'throws error when scheme does not exist', ->
-      unregister = -> protocol.unregisterProtocol 'test3'
-      assert.throws unregister, /The Scheme has not been registered/
+      protocol.unregisterProtocol 'test3', (->), (error, scheme) ->
+        if (error)
+          assert.equal scheme, 'test3'
+          done()
 
   describe 'registered protocol callback', ->
     it 'returns string should send the string as request content', (done) ->


### PR DESCRIPTION
Fixes #182 

- [x] need to convert `JsProtocolHandler -> (error, request)` which would get rid of those `node::ThrowError` and have uniform async api, will have a wrappedCallback to avoid breaking existing api.