### PR TITLE
Implment app.getAppPath API.

### DIFF
--- a/atom/browser/api/lib/app.coffee
+++ b/atom/browser/api/lib/app.coffee
@@ -25,6 +25,13 @@ if process.platform is 'darwin'
     show: bindings.dockShow
     setMenu: bindings.dockSetMenu
 
+appPath = null
+app.setAppPath = (path) ->
+  appPath = path
+
+app.getAppPath = ->
+  appPath
+
 # Be compatible with old API.
 app.once 'ready', -> @emit 'finish-launching'
 app.terminate = app.quit

--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -291,6 +291,7 @@ if (option.file && !option.webdriver) {
         app.setName(packageJson.name);
       app.setPath('userData', path.join(app.getPath('appData'), app.getName()));
       app.setPath('userCache', path.join(app.getPath('cache'), app.getName()));
+      app.setAppPath(packagePath);
     }
 
     // Run the app.

--- a/atom/browser/lib/init.coffee
+++ b/atom/browser/lib/init.coffee
@@ -87,6 +87,7 @@ app.commandLine.appendSwitch 'enable-npapi'
 # Set the user path according to application's name.
 app.setPath 'userData', path.join(app.getPath('appData'), app.getName())
 app.setPath 'userCache', path.join(app.getPath('cache'), app.getName())
+app.setAppPath packagePath
 
 # Load the chrome extension support.
 require './chrome-extension'

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -139,6 +139,10 @@ This method guarantees all `beforeunload` and `unload` handlers are correctly
 executed. It is possible that a window cancels the quitting by returning
 `false` in `beforeunload` handler.
 
+## app.getAppPath()
+
+Returns the current application directory.
+
 ## app.getPath(name)
 
 * `name` String


### PR DESCRIPTION
Potential fixes #2127.

There is not a decent way to implement `app.getPath('app')` since we handle the app launching logic in JS part and `app.getPath` only gets the `PathService` constants. Instead, this PR implements `app.getAppPath` API in JS part. 

