### PR TITLE
Document `process.platform` check in example

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -82,6 +82,8 @@ var mainWindow = null;
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function() {
+  // On OSX it is common for applications and their menu bar 
+  // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform != 'darwin') {
     app.quit();
   }


### PR DESCRIPTION
This was strange to me when I was first learning Electron, and I assumed it was a cross-platform quirk needed for everything to shut down correctly.

In fact, it is more of a usability thing, and dependent on the app. For example, Chrome and iTunes stay active in the background even if you close all windows. On the other hand, iPhoto, System Preferences, and several other apps quit when all windows are closed, since they have nothing left to do.

Hopefully this comment will shed a bit more light on the matter.