### PR TITLE
Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ editor](https://github.com/atom/atom).
 Follow [@ElectronJS](https://twitter.com/electronjs) on Twitter for important
 announcements.
 
+This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
+[code-of-conduct]: http://todogroup.org/opencodeofconduct/#Electron/opensource@github.com
+
 ## Downloads
 
 Prebuilt binaries and debug symbols of Electron for Linux, Windows and Mac can


### PR DESCRIPTION
We are intending to adopt the soon-to-be-announced [Open Code of Conduct](http://todogroup.org/opencodeofconduct) for @atom. This adds it to the README. https://github.com/atom/electron/commit/078bd7fb5b3a98abffcbb7ed95334c63248683ed added it to the contributing guidelines. Let me know if you have any questions or concerns.

/cc https://github.com/atom/atom/pull/7797