### PR TITLE
Add a test to verify the WebView close event

### DIFF
--- a/spec/fixtures/pages/close.html
+++ b/spec/fixtures/pages/close.html
@@ -1,0 +1,9 @@
+<html>
+<link rel="icon" type="image/png" href="/favicon.png"/>
+<link rel="icon" type="image/png" href="http://test.com/favicon.png"/>
+<body>
+<script type="text/javascript" charset="utf-8">
+	window.close();
+</script>
+</body>
+</html>

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -191,6 +191,14 @@ describe '<webview> tag', ->
       webview.src = "file://#{fixtures}/pages/a.html"
       document.body.appendChild webview
 
+  describe 'close event', ->
+    it 'should fire when interior page calls window.close', ->
+      webview.addEventListener 'close', ->
+        done()
+
+      webview.src = "file://#{fixtures}/pages/close.html"
+      document.body.appendChild webview
+
   describe '<webview>.reload()', ->
     it 'should emit beforeunload handler', (done) ->
       listener = (e) ->
@@ -217,6 +225,6 @@ describe '<webview> tag', ->
         webview.removeEventListener 'ipc-message', listener
         done()
       webview.addEventListener 'ipc-message', listener
-      webview.setAttribute 'nodeintegration', 'on'      
+      webview.setAttribute 'nodeintegration', 'on'
       webview.src = "file://#{fixtures}/pages/history.html"
       document.body.appendChild webview


### PR DESCRIPTION
This PR adds a spec to ensure the WebView's `close` event fires when a page calls `close`