### PR TITLE
Propagate App Model User ID on Windows

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -8,6 +8,10 @@
 #include <utility>
 #include <vector>
 
+#if defined(OS_WIN)
+#include <shlobj.h>
+#endif
+
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/atom_browser_main_parts.h"
 #include "atom/browser/browser.h"
@@ -50,7 +54,6 @@
 
 #if defined(OS_WIN)
 #include "ui/gfx/switches.h"
-#include <shlobj.h>
 #endif
 
 using content::NavigationEntry;

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -50,6 +50,7 @@
 
 #if defined(OS_WIN)
 #include "ui/gfx/switches.h"
+#include <shlobj.h>
 #endif
 
 using content::NavigationEntry;
@@ -387,6 +388,16 @@ void NativeWindow::AppendExtraCommandLineSwitches(
   if (zoom_factor_ != 1.0)
     command_line->AppendSwitchASCII(switches::kZoomFactor,
                                     base::DoubleToString(zoom_factor_));
+
+#if defined(OS_WIN)
+  PWSTR explicit_app_id;
+
+  if (SUCCEEDED(GetCurrentProcessExplicitAppUserModelID(&explicit_app_id))) {
+    base::string16 appId = base::string16(explicit_app_id);
+    command_line->AppendSwitchNative(switches::kAppUserModelId, appId);
+    CoTaskMemFree(explicit_app_id);
+  }
+#endif
 
   if (web_preferences_.IsEmpty())
     return;

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -107,6 +107,9 @@ const char kDisableHttpCache[] = "disable-http-cache";
 // Register schemes to standard.
 const char kRegisterStandardSchemes[] = "register-standard-schemes";
 
+// The browser process app model ID
+const char kAppUserModelId[] = "app-user-model-id";
+
 }  // namespace switches
 
 }  // namespace atom

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -58,6 +58,8 @@ extern const char kPageVisibility[];
 extern const char kDisableHttpCache[];
 extern const char kRegisterStandardSchemes[];
 
+extern const char kAppUserModelId[];
+
 }  // namespace switches
 
 }  // namespace atom

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -92,8 +92,10 @@ void AtomRendererClient::WebKitInitialized() {
   blink::WebCustomElement::addEmbedderCustomElementName("browserplugin");
 
 #if defined(OS_WIN)
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  base::string16 explicit_app_id = command_line->GetSwitchValueNative(switches::kAppUserModelId);
+  base::CommandLine* command_line =
+    base::CommandLine::ForCurrentProcess();
+  base::string16 explicit_app_id =
+    command_line->GetSwitchValueNative(switches::kAppUserModelId);
 
   if (explicit_app_id.length() > 0) {
     SetCurrentProcessExplicitAppUserModelID(explicit_app_id.c_str());

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -27,6 +27,10 @@
 
 #include "atom/common/node_includes.h"
 
+#if defined(OS_WIN)
+#include <shlobj.h>
+#endif
+
 namespace atom {
 
 namespace {
@@ -86,6 +90,15 @@ void AtomRendererClient::WebKitInitialized() {
 
   blink::WebCustomElement::addEmbedderCustomElementName("webview");
   blink::WebCustomElement::addEmbedderCustomElementName("browserplugin");
+
+#if defined(OS_WIN)
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  base::string16 explicit_app_id = command_line->GetSwitchValueNative(switches::kAppUserModelId);
+
+  if (explicit_app_id.length() > 0) {
+    SetCurrentProcessExplicitAppUserModelID(explicit_app_id.c_str());
+  }
+#endif
 
   node_bindings_->Initialize();
   node_bindings_->PrepareMessageLoop();


### PR DESCRIPTION
This PR ensures that all of our processes that might create windows have the same [AppUserModelID](https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx) which should help with some of the pinning woes that we're seeing. 