### PR TITLE
WebView.getGuestInstanceId

### DIFF
--- a/atom/renderer/lib/web-view/web-view.coffee
+++ b/atom/renderer/lib/web-view/web-view.coffee
@@ -245,10 +245,17 @@ registerWebViewElement = ->
   proto.attachedCallback = ->
     internal = v8Util.getHiddenValue this, 'internal'
     return unless internal
+    
     unless internal.elementAttached
       guestViewInternal.registerEvents internal, internal.viewInstanceId
       internal.elementAttached = true
       internal.attributes[webViewConstants.ATTRIBUTE_SRC].parse()
+      
+  proto.getGuestInstanceId = ->
+    internal = v8Util.getHiddenValue this, 'internal'
+    return unless internal
+    
+    internal.guestInstanceId;
 
   # Public-facing API methods.
   methods = [

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -326,6 +326,12 @@ page can handle it by listening to the `channel` event of `ipc` module.
 See [WebContents.send](browser-window.md#webcontentssendchannel-args) for
 examples.
 
+### `<webview`.getGuestInstanceId()
+
+Returns a unique identifier representing the WebView on the page, which can be
+useful for routing IPC replies to messages sent from the WebView to the
+Browser process.
+
 ## DOM events
 
 ### did-finish-load

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -220,3 +220,12 @@ describe '<webview> tag', ->
       webview.setAttribute 'nodeintegration', 'on'      
       webview.src = "file://#{fixtures}/pages/history.html"
       document.body.appendChild webview
+
+  describe '<webview>.getGuestInstanceId()', ->
+    it 'should be non-zero when the webview is attached', (done) ->
+      webview.addEventListener 'did-finish-load', (e) ->
+        assert not isNaN(webview.getGuestInstanceId())
+        done()
+        
+      document.body.appendChild webview
+      webview.src = "file://#{fixtures}/pages/a.html"


### PR DESCRIPTION
Expose the guest instance ID as a unique identifier for a WebView, which since it is both accessible in the host via this method, and in the guest via `process.guestInstanceId`, can be used to route replies to IPC messages to the browser - i.e:

1. WebView sends async IPC to browser
1. Browser wants to send a reply back, but who to send to???
1. WebView included both the guest instance ID as well as its hosting browserWindowId in the message! 
1. Browser process uses `browserWindowId` to route to renderer
1. Renderer grabs message, uses `guestInstanceId` to route to calling WebView