### PR TITLE
emit error object on process.on('uncaughtException') in renderer

### DIFF
--- a/atom/renderer/lib/init.coffee
+++ b/atom/renderer/lib/init.coffee
@@ -77,7 +77,7 @@ if nodeIntegration in ['true', 'all', 'except-iframe', 'manual-enable-iframe']
     global.__dirname = __dirname
 
   # Redirect window.onerror to uncaughtException.
-  window.onerror = (error) ->
+  window.onerror = (message, filename, lineno, colno, error) ->
     if global.process.listeners('uncaughtException').length > 0
       global.process.emit 'uncaughtException', error
       true


### PR DESCRIPTION
Chromium added the actual `error` object to the 5th parameter in `window.onerror`. This should be emitted as opposed to the `errorMsg` string. Worse yet, since `errorMsg` wasn't an instance of `Error`, any code that assumes this in any `process.on('uncaughtException')` handler would fail. Also, correctly emitting the error provides the stack trace.

This is now an HTML5 standard.

Sources:
- https://html.spec.whatwg.org/multipage/webappapis.html#errorevent
- https://mikewest.org/2013/08/debugging-runtime-errors-with-window-onerror
- https://code.google.com/p/chromium/issues/detail?id=147127