### PR TITLE
Fix docs typo

### DIFF
--- a/docs/api/browser-window-ko.md
+++ b/docs/api/browser-window-ko.md
@@ -1059,7 +1059,7 @@ app.on('ready', function() {
 
 The `cookies` gives you ability to query and modify cookies, an example is:
 
-```javascipt
+```javascript
 var BrowserWindow = require('browser-window');
 
 var win = new BrowserWindow({ width: 800, height: 600 });

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1059,7 +1059,7 @@ app.on('ready', function() {
 
 The `cookies` gives you ability to query and modify cookies, an example is:
 
-```javascipt
+```javascript
 var BrowserWindow = require('browser-window');
 
 var win = new BrowserWindow({ width: 800, height: 600 });


### PR DESCRIPTION
Super small PR to fix a typo (javascipt -> javascript) on a code block language that was breaking the docs site Pages build :computer: 