### PR TITLE
Don't expose "global" when node integration is off

### DIFF
--- a/atom/renderer/lib/init.coffee
+++ b/atom/renderer/lib/init.coffee
@@ -93,6 +93,7 @@ else
     delete global.process
     delete global.setImmediate
     delete global.clearImmediate
+    delete global.global
 
 # Load the script specfied by the "preload" attribute.
 if preloadScript

--- a/spec/fixtures/pages/c.html
+++ b/spec/fixtures/pages/c.html
@@ -1,7 +1,7 @@
 <html>
 <body>
 <script type="text/javascript" charset="utf-8">
-  console.log([typeof require, typeof module, typeof process].join(' '));
+  console.log([typeof require, typeof module, typeof process, typeof global].join(' '));
 </script>
 </body>
 </html>

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -34,7 +34,7 @@ describe '<webview> tag', ->
   describe 'nodeintegration attribute', ->
     it 'inserts no node symbols when not set', (done) ->
       webview.addEventListener 'console-message', (e) ->
-        assert.equal e.message, 'undefined undefined undefined'
+        assert.equal e.message, 'undefined undefined undefined undefined'
         done()
       webview.src = "file://#{fixtures}/pages/c.html"
       document.body.appendChild webview


### PR DESCRIPTION
Fix #2183.