### PR TITLE
valid example json, fix https://github.com/atom/electron/issues/2228

### DIFF
--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -85,7 +85,7 @@ to the update request provided:
   "url": "http://mycompany.com/myapp/releases/myrelease",
   "name": "My Release Name",
   "notes": "Theses are some release notes innit",
-  "pub_date": "2013-09-18T12:29:53+01:00",
+  "pub_date": "2013-09-18T12:29:53+01:00"
 }
 ```
 


### PR DESCRIPTION
Remove the trailing comma so that the example is valid json. Otherwise the auto updater will throw an error saying `Unexpected token '{'`.