### PR TITLE
mac: Always call SetSize for frameless window

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -512,6 +512,9 @@ void NativeWindowMac::SetContentSize(const gfx::Size& size) {
 }
 
 gfx::Size NativeWindowMac::GetContentSize() {
+  if (!has_frame_)
+    return GetSize();
+
   NSRect bounds = [[window_ contentView] bounds];
   return gfx::Size(bounds.size.width, bounds.size.height);
 }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -357,7 +357,7 @@ NativeWindowMac::NativeWindowMac(
   // On OS X the initial window size doesn't include window frame.
   bool use_content_size = false;
   options.Get(switches::kUseContentSize, &use_content_size);
-  if (has_frame_ && !use_content_size)
+  if (!has_frame_ || !use_content_size)
     SetSize(gfx::Size(width, height));
 
   // Enable the NSView to accept first mouse event.
@@ -494,6 +494,11 @@ gfx::Rect NativeWindowMac::GetBounds() {
 }
 
 void NativeWindowMac::SetContentSize(const gfx::Size& size) {
+  if (!has_frame_) {
+    SetSize(size);
+    return;
+  }
+
   NSRect frame_nsrect = [window_ frame];
   NSSize frame = frame_nsrect.size;
   NSSize content = [window_ contentRectForFrameRect:frame_nsrect].size;

--- a/spec/api-browser-window-spec.coffee
+++ b/spec/api-browser-window-spec.coffee
@@ -117,6 +117,15 @@ describe 'browser-window module', ->
       assert.equal after[0], size[0]
       assert.equal after[1], size[1]
 
+    it 'works for framless window', ->
+      w.destroy()
+      w = new BrowserWindow(show: false, frame: false, width: 400, height: 400)
+      size = [400, 400]
+      w.setContentSize size[0], size[1]
+      after = w.getContentSize()
+      assert.equal after[0], size[0]
+      assert.equal after[1], size[1]
+
   describe 'BrowserWindow.fromId(id)', ->
     it 'returns the window with id', ->
       assert.equal w.id, BrowserWindow.fromId(w.id).id
@@ -130,6 +139,16 @@ describe 'browser-window module', ->
       assert.equal contentSize[1], 400
 
     it 'make window created with window size when not used', ->
+      size = w.getSize()
+      assert.equal size[0], 400
+      assert.equal size[1], 400
+
+    it 'works for framless window', ->
+      w.destroy()
+      w = new BrowserWindow(show: false, frame: false, width: 400, height: 400, 'use-content-size': true)
+      contentSize = w.getContentSize()
+      assert.equal contentSize[0], 400
+      assert.equal contentSize[1], 400
       size = w.getSize()
       assert.equal size[0], 400
       assert.equal size[1], 400


### PR DESCRIPTION
This PR fixes `BrowserWindow.setContentSize` not working on Mac, closes #1024.