### PR TITLE
Make hidden window shows when calling `maximize`, `mimizie`,`unmaximize`, `restore` APIs.

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -434,10 +434,14 @@ bool NativeWindowMac::IsVisible() {
 }
 
 void NativeWindowMac::Maximize() {
+  if (!IsVisible())
+    Show();
   [window_ zoom:nil];
 }
 
 void NativeWindowMac::Unmaximize() {
+  if (!IsVisible())
+    Show();
   [window_ zoom:nil];
 }
 
@@ -446,10 +450,14 @@ bool NativeWindowMac::IsMaximized() {
 }
 
 void NativeWindowMac::Minimize() {
+  if (!IsVisible())
+    Show();
   [window_ miniaturize:nil];
 }
 
 void NativeWindowMac::Restore() {
+  if (!IsVisible())
+    Show();
   [window_ deminiaturize:nil];
 }
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -393,14 +393,14 @@ bool NativeWindowViews::IsVisible() {
 }
 
 void NativeWindowViews::Maximize() {
-  if (IsVisible())
-    window_->Maximize();
-  else
-    window_->native_widget_private()->ShowWithWindowState(
-        ui::SHOW_STATE_MAXIMIZED);
+  if (!IsVisible())
+    Show();
+  window_->Maximize();
 }
 
 void NativeWindowViews::Unmaximize() {
+  if (!IsVisible())
+    Show();
   window_->Restore();
 }
 
@@ -409,14 +409,14 @@ bool NativeWindowViews::IsMaximized() {
 }
 
 void NativeWindowViews::Minimize() {
-  if (IsVisible())
-    window_->Minimize();
-  else
-    window_->native_widget_private()->ShowWithWindowState(
-        ui::SHOW_STATE_MINIMIZED);
+  if (!IsVisible())
+    Show();
+  window_->Minimize();
 }
 
 void NativeWindowViews::Restore() {
+  if (!IsVisible())
+    Show();
   window_->Restore();
 }
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -330,9 +330,13 @@ Returns whether the window is visible to the user.
 
 Maximizes the window.
 
+__Note__: A hidden window will show after calling the API.
+
 ### BrowserWindow.unmaximize()
 
 Unmaximizes the window.
+
+__Note__: A hidden window will show after calling the API.
 
 ### BrowserWindow.isMaximized()
 
@@ -343,9 +347,13 @@ Returns whether the window is maximized.
 Minimizes the window. On some platforms the minimized window will be shown in
 the Dock.
 
+__Note__: A hidden window will show after calling the API.
+
 ### BrowserWindow.restore()
 
 Restores the window from minimized state to its previous state.
+
+__Note__: A hidden window will show after calling the API.
 
 ### BrowserWindow.isMinimized()
 


### PR DESCRIPTION
Related to #1418, #2262.

Currently, the `maximize`, `mimizie`,`unmaximize`, `restore`  APIs don't have a consitent behavior on three platforms, this PR make them align with the current Windows platform's(The hidden window will show when calling these APIs).