### PR TITLE
Fix app-command event always return 'unknown'.

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -929,7 +929,7 @@ bool NativeWindowViews::ExecuteWindowsCommand(int command_id) {
   } else if ((command_id & sc_mask) == SC_MAXIMIZE) {
     NotifyWindowMaximize();
   } else {
-    std::string command = AppCommandToString(command_id & sc_mask);
+    std::string command = AppCommandToString(command_id);
     FOR_EACH_OBSERVER(NativeWindowObserver,
                       observers_,
                       OnExecuteWindowsCommand(command));


### PR DESCRIPTION
Fixes #2306 .

No need to mask the command id for appcommand message. Having test with media key on keyboard.