### PR TITLE
Focus on WebContents when we load url in BrowserWindow for the first time

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -733,6 +733,14 @@ void WebContents::ReplaceMisspelling(const base::string16& word) {
   web_contents()->ReplaceMisspelling(word);
 }
 
+void WebContents::Focus() {
+  web_contents()->Focus();
+}
+
+void WebContents::TabTraverse(bool reverse) {
+  web_contents()->FocusThroughTabTraversal(reverse);
+}
+
 bool WebContents::SendIPCMessage(const base::string16& channel,
                                  const base::ListValue& args) {
   return Send(new AtomViewMsg_Message(routing_id(), channel, args));
@@ -792,6 +800,8 @@ mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
         .SetMethod("unselect", &WebContents::Unselect)
         .SetMethod("replace", &WebContents::Replace)
         .SetMethod("replaceMisspelling", &WebContents::ReplaceMisspelling)
+        .SetMethod("focus", &WebContents::Focus)
+        .SetMethod("tabTraverse", &WebContents::TabTraverse)
         .SetMethod("_send", &WebContents::SendIPCMessage, true)
         .SetMethod("setSize", &WebContents::SetSize)
         .SetMethod("setAllowTransparency", &WebContents::SetAllowTransparency)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -96,6 +96,10 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void Replace(const base::string16& word);
   void ReplaceMisspelling(const base::string16& word);
 
+  // Focus.
+  void Focus();
+  void TabTraverse(bool reverse);
+
   // Sending messages to browser.
   bool SendIPCMessage(const base::string16& channel,
                       const base::ListValue& args);

--- a/atom/browser/api/lib/browser-window.coffee
+++ b/atom/browser/api/lib/browser-window.coffee
@@ -30,6 +30,15 @@ BrowserWindow::_init = ->
   @webContents.on 'crashed', =>
     @emit 'crashed'
 
+  # Sometimes the webContents doesn't get focus when window is shown, so we have
+  # to force focusing on webContents in this case. The safest way is to focus it
+  # when we first start to load URL, if we do it earlier it won't have effect,
+  # if we do it later we might move focus in the page.
+  # Though this hack is only needed on OS X when the app is launched from
+  # Finder, we still do it on all platforms in case of other bugs we don't know.
+  @webContents.once 'load-url', ->
+    @focus()
+
   # Redirect focus/blur event to app instance too.
   @on 'blur', (event) =>
     app.emit 'browser-window-blur', event, this

--- a/atom/browser/api/lib/navigation-controller.coffee
+++ b/atom/browser/api/lib/navigation-controller.coffee
@@ -40,6 +40,7 @@ class NavigationController
   loadUrl: (url, options={}) ->
     @pendingIndex = -1
     @webContents._loadUrl url, options
+    @webContents.emit 'load-url', url, options
 
   getUrl: ->
     if @currentIndex is -1


### PR DESCRIPTION
Sometimes the webContents doesn't get focus when window is shown, so we have to force focusing on webContents in this case. The safest way is to focus it when we first start to load URL, if we do it earlier it won't have effect, if we do it later we might move focus in the page.

Though this hack is only needed on OS X when the app is launched from Finder, we still do it on all platforms in case of other bugs we don't know.

Fixes #2317.