### PR TITLE
linux: Fix min/max size not working

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -36,6 +36,7 @@
 #include "atom/browser/browser.h"
 #include "atom/browser/ui/views/global_menu_bar_x11.h"
 #include "atom/browser/ui/views/frameless_view.h"
+#include "atom/browser/ui/views/native_frame_view.h"
 #include "atom/browser/ui/x/window_state_watcher.h"
 #include "atom/browser/ui/x/x_window_utils.h"
 #include "base/environment.h"
@@ -491,14 +492,6 @@ gfx::Size NativeWindowViews::GetContentSize() {
 
 void NativeWindowViews::SetMinimumSize(const gfx::Size& size) {
   minimum_size_ = size;
-
-#if defined(USE_X11)
-  XSizeHints size_hints;
-  size_hints.flags = PMinSize;
-  size_hints.min_width = size.width();
-  size_hints.min_height = size.height();
-  XSetWMNormalHints(gfx::GetXDisplay(), GetAcceleratedWidget(), &size_hints);
-#endif
 }
 
 gfx::Size NativeWindowViews::GetMinimumSize() {
@@ -507,14 +500,6 @@ gfx::Size NativeWindowViews::GetMinimumSize() {
 
 void NativeWindowViews::SetMaximumSize(const gfx::Size& size) {
   maximum_size_ = size;
-
-#if defined(USE_X11)
-  XSizeHints size_hints;
-  size_hints.flags = PMaxSize;
-  size_hints.max_width = size.width();
-  size_hints.max_height = size.height();
-  XSetWMNormalHints(gfx::GetXDisplay(), GetAcceleratedWidget(), &size_hints);
-#endif
 }
 
 gfx::Size NativeWindowViews::GetMaximumSize() {
@@ -899,7 +884,7 @@ views::NonClientFrameView* NativeWindowViews::CreateNonClientFrameView(
   return frame_view;
 #else
   if (has_frame_) {
-    return new views::NativeFrameView(widget);
+    return new NativeFrameView(this, widget);
   } else {
     FramelessView* frame_view = new FramelessView;
     frame_view->Init(this, widget);

--- a/atom/browser/ui/views/native_frame_view.cc
+++ b/atom/browser/ui/views/native_frame_view.cc
@@ -1,0 +1,35 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/ui/views/native_frame_view.h"
+
+#include "atom/browser/native_window_views.h"
+
+namespace atom {
+
+namespace {
+
+const char kViewClassName[] = "AtomNativeFrameView";
+
+}  // namespace
+
+NativeFrameView::NativeFrameView(NativeWindowViews* window,
+                                 views::Widget* widget)
+    : views::NativeFrameView(widget),
+      window_(window) {
+}
+
+gfx::Size NativeFrameView::GetMinimumSize() const {
+  return window_->GetMinimumSize();
+}
+
+gfx::Size NativeFrameView::GetMaximumSize() const {
+  return window_->GetMaximumSize();
+}
+
+const char* NativeFrameView::GetClassName() const {
+  return kViewClassName;
+}
+
+}  // namespace atom

--- a/atom/browser/ui/views/native_frame_view.h
+++ b/atom/browser/ui/views/native_frame_view.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_UI_VIEWS_NATIVE_FRAME_VIEW_H_
+#define ATOM_BROWSER_UI_VIEWS_NATIVE_FRAME_VIEW_H_
+
+#include "ui/views/window/native_frame_view.h"
+
+namespace atom {
+
+class NativeWindowViews;
+
+// Like the views::NativeFrameView, but returns the min/max size from the
+// NativeWindowViews.
+class NativeFrameView : public views::NativeFrameView {
+ public:
+  NativeFrameView(NativeWindowViews* window, views::Widget* widget);
+
+ protected:
+  // views::View:
+  gfx::Size GetMinimumSize() const override;
+  gfx::Size GetMaximumSize() const override;
+  const char* GetClassName() const override;
+
+ private:
+  NativeWindowViews* window_;  // weak ref.
+
+  DISALLOW_COPY_AND_ASSIGN(NativeFrameView);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_UI_VIEWS_NATIVE_FRAME_VIEW_H_

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -196,6 +196,8 @@
       'atom/browser/ui/views/menu_delegate.h',
       'atom/browser/ui/views/menu_layout.cc',
       'atom/browser/ui/views/menu_layout.h',
+      'atom/browser/ui/views/native_frame_view.cc',
+      'atom/browser/ui/views/native_frame_view.h',
       'atom/browser/ui/views/submenu_button.cc',
       'atom/browser/ui/views/submenu_button.h',
       'atom/browser/ui/views/win_frame_view.cc',


### PR DESCRIPTION
Previously we have been manually keeping the WMNormalHints ourselves because Chromium was not doing that, but since recent Chromium can handle min/max size on Linux correctly this PR changes to rely on Chromium to set min/max size, and it also fixes some conflicts when setting WMNormalHints.

Fix #1610
Fix #953
Fix #1664