### PR TITLE
Send bounding Rect on tray double click events

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -44,8 +44,8 @@ void Tray::OnClicked(const gfx::Rect& bounds) {
   Emit("clicked", bounds);
 }
 
-void Tray::OnDoubleClicked() {
-  Emit("double-clicked");
+void Tray::OnDoubleClicked(const gfx::Rect& bounds) {
+  Emit("double-clicked", bounds);
 }
 
 void Tray::OnBalloonShow() {

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -43,7 +43,7 @@ class Tray : public mate::EventEmitter,
 
   // TrayIconObserver:
   void OnClicked(const gfx::Rect& bounds) override;
-  void OnDoubleClicked() override;
+  void OnDoubleClicked(const gfx::Rect& bounds) override;
   void OnBalloonShow() override;
   void OnBalloonClicked() override;
   void OnBalloonClosed() override;

--- a/atom/browser/ui/tray_icon.cc
+++ b/atom/browser/ui/tray_icon.cc
@@ -33,8 +33,8 @@ void TrayIcon::NotifyClicked(const gfx::Rect& bounds) {
   FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnClicked(bounds));
 }
 
-void TrayIcon::NotifyDoubleClicked() {
-  FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnDoubleClicked());
+void TrayIcon::NotifyDoubleClicked(const gfx::Rect& bounds) {
+  FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnDoubleClicked(bounds));
 }
 
 void TrayIcon::NotifyBalloonShow() {

--- a/atom/browser/ui/tray_icon.h
+++ b/atom/browser/ui/tray_icon.h
@@ -55,7 +55,7 @@ class TrayIcon {
   void AddObserver(TrayIconObserver* obs) { observers_.AddObserver(obs); }
   void RemoveObserver(TrayIconObserver* obs) { observers_.RemoveObserver(obs); }
   void NotifyClicked(const gfx::Rect& = gfx::Rect());
-  void NotifyDoubleClicked();
+  void NotifyDoubleClicked(const gfx::Rect& = gfx::Rect());
   void NotifyBalloonShow();
   void NotifyBalloonClicked();
   void NotifyBalloonClosed();

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -156,7 +156,7 @@ const CGFloat kMargin = 3;
   }
 
   if (event.clickCount == 2 && !menuController_) {
-    trayIcon_->NotifyDoubleClicked();
+    trayIcon_->NotifyDoubleClicked([self getBoundsFromEvent:event]);
   }
   [self setNeedsDisplay:YES];
 }

--- a/atom/browser/ui/tray_icon_observer.h
+++ b/atom/browser/ui/tray_icon_observer.h
@@ -17,7 +17,7 @@ namespace atom {
 class TrayIconObserver {
  public:
   virtual void OnClicked(const gfx::Rect& bounds) {}
-  virtual void OnDoubleClicked() {}
+  virtual void OnDoubleClicked(const gfx::Rect& bounds) {}
   virtual void OnBalloonShow() {}
   virtual void OnBalloonClicked() {}
   virtual void OnBalloonClosed() {}

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -76,6 +76,13 @@ will be emitted if the tray icon has context menu.
 
 Emitted when the tray icon is double clicked.
 
+* `event`
+* `bounds` Object - the bounds of tray icon
+  * `x` Integer
+  * `y` Integer
+  * `width` Integer
+  * `height` Integer
+  
 __Note:__ This is only implemented on OS X.
 
 ### Event: 'balloon-show'


### PR DESCRIPTION
Double click events on a tray item will now send the bounding rect as payload with the "double-clicked" notification — matching the existing behavior in "click" and "right-click".