### PR TITLE
Implement setDownloadPath API.

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -10,8 +10,11 @@
 #include "atom/browser/api/atom_api_cookies.h"
 #include "atom/browser/atom_browser_context.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
-#include "base/thread_task_runner_handle.h"
+#include "base/files/file_path.h"
+#include "base/prefs/pref_service.h"
 #include "base/strings/string_util.h"
+#include "base/thread_task_runner_handle.h"
+#include "chrome/common/pref_names.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/storage_partition.h"
 #include "native_mate/callback.h"
@@ -251,6 +254,11 @@ void Session::SetProxy(const std::string& proxy,
       base::Bind(&SetProxyInIO, base::Unretained(getter), proxy, callback));
 }
 
+void Session::SetDownloadPath(const std::string& path) {
+  browser_context_->prefs()->SetFilePath(prefs::kDownloadDefaultDirectory,
+                                         base::FilePath(path));
+}
+
 v8::Local<v8::Value> Session::Cookies(v8::Isolate* isolate) {
   if (cookies_.IsEmpty()) {
     auto handle = atom::api::Cookies::Create(isolate, browser_context_);
@@ -266,6 +274,7 @@ mate::ObjectTemplateBuilder Session::GetObjectTemplateBuilder(
       .SetMethod("clearCache", &Session::ClearCache)
       .SetMethod("clearStorageData", &Session::ClearStorageData)
       .SetMethod("setProxy", &Session::SetProxy)
+      .SetMethod("setDownloadPath", &Session::SetDownloadPath)
       .SetProperty("cookies", &Session::Cookies);
 }
 

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -46,6 +46,7 @@ class Session: public mate::TrackableObject<Session> {
   void ClearCache(const net::CompletionCallback& callback);
   void ClearStorageData(mate::Arguments* args);
   void SetProxy(const std::string& proxy, const base::Closure& callback);
+  void SetDownloadPath(const std::string& path);
   v8::Local<v8::Value> Cookies(v8::Isolate* isolate);
 
   v8::Global<v8::Value> cookies_;

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -15,10 +15,13 @@
 #include "atom/common/chrome_version.h"
 #include "atom/common/options_switches.h"
 #include "base/command_line.h"
+#include "base/files/file_path.h"
+#include "base/prefs/pref_registry_simple.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "base/threading/sequenced_worker_pool.h"
 #include "base/threading/worker_pool.h"
+#include "chrome/common/pref_names.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/common/url_constants.h"
 #include "content/public/common/user_agent.h"
@@ -144,6 +147,11 @@ content::BrowserPluginGuestManager* AtomBrowserContext::GetGuestManager() {
   if (!guest_manager_)
     guest_manager_.reset(new WebViewManager(this));
   return guest_manager_.get();
+}
+
+void AtomBrowserContext::RegisterPrefs(PrefRegistrySimple* pref_registry) {
+  pref_registry->RegisterFilePathPref(prefs::kSelectFileLastDirectory,
+                                      base::FilePath());
 }
 
 }  // namespace atom

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -152,6 +152,8 @@ content::BrowserPluginGuestManager* AtomBrowserContext::GetGuestManager() {
 void AtomBrowserContext::RegisterPrefs(PrefRegistrySimple* pref_registry) {
   pref_registry->RegisterFilePathPref(prefs::kSelectFileLastDirectory,
                                       base::FilePath());
+  pref_registry->RegisterFilePathPref(prefs::kDownloadDefaultDirectory,
+                                      base::FilePath());
 }
 
 }  // namespace atom

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -31,6 +31,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
   // content::BrowserContext:
   content::DownloadManagerDelegate* GetDownloadManagerDelegate() override;
   content::BrowserPluginGuestManager* GetGuestManager() override;
+  void RegisterPrefs(PrefRegistrySimple* pref_registry) override;
 
   AtomURLRequestJobFactory* job_factory() const { return job_factory_; }
 

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -31,6 +31,8 @@ class AtomBrowserContext : public brightray::BrowserContext {
   // content::BrowserContext:
   content::DownloadManagerDelegate* GetDownloadManagerDelegate() override;
   content::BrowserPluginGuestManager* GetGuestManager() override;
+
+  // brightray::BrowserContext::
   void RegisterPrefs(PrefRegistrySimple* pref_registry) override;
 
   AtomURLRequestJobFactory* job_factory() const { return job_factory_; }

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -32,7 +32,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
   content::DownloadManagerDelegate* GetDownloadManagerDelegate() override;
   content::BrowserPluginGuestManager* GetGuestManager() override;
 
-  // brightray::BrowserContext::
+  // brightray::BrowserContext:
   void RegisterPrefs(PrefRegistrySimple* pref_registry) override;
 
   AtomURLRequestJobFactory* job_factory() const { return job_factory_; }

--- a/atom/browser/atom_download_manager_delegate.cc
+++ b/atom/browser/atom_download_manager_delegate.cc
@@ -102,12 +102,12 @@ bool AtomDownloadManagerDelegate::DetermineDownloadTarget(
 
   AtomBrowserContext* browser_context = static_cast<AtomBrowserContext*>(
       download_manager_->GetBrowserContext());
-  default_download_path_ = browser_context->prefs()->GetFilePath(
+  base::FilePath default_download_path = browser_context->prefs()->GetFilePath(
       prefs::kDownloadDefaultDirectory);
   // If users didn't set download path, use 'Downloads' directory by default.
-  if (default_download_path_.empty()) {
+  if (default_download_path.empty()) {
     auto path = download_manager_->GetBrowserContext()->GetPath();
-    default_download_path_ = path.Append(FILE_PATH_LITERAL("Downloads"));
+    default_download_path = path.Append(FILE_PATH_LITERAL("Downloads"));
   }
 
   if (!download->GetForcedFilePath().empty()) {
@@ -131,7 +131,7 @@ bool AtomDownloadManagerDelegate::DetermineDownloadTarget(
                  download->GetContentDisposition(),
                  download->GetSuggestedFilename(),
                  download->GetMimeType(),
-                 default_download_path_,
+                 default_download_path,
                  download_path_callback));
   return true;
 }

--- a/atom/browser/atom_download_manager_delegate.h
+++ b/atom/browser/atom_download_manager_delegate.h
@@ -47,7 +47,6 @@ class AtomDownloadManagerDelegate : public content::DownloadManagerDelegate {
 
  private:
   content::DownloadManager* download_manager_;
-  base::FilePath default_download_path_;
   base::WeakPtrFactory<AtomDownloadManagerDelegate> weak_ptr_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomDownloadManagerDelegate);

--- a/atom/browser/web_dialog_helper.cc
+++ b/atom/browser/web_dialog_helper.cc
@@ -15,6 +15,7 @@
 #include "base/files/file_path.h"
 #include "base/prefs/pref_service.h"
 #include "base/strings/utf_string_conversions.h"
+#include "chrome/common/pref_names.h"
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/file_chooser_file_info.h"
@@ -22,8 +23,6 @@
 #include "ui/shell_dialogs/selected_file_info.h"
 
 namespace {
-
-const char kSelectFileLastDirectory[] = "selectfile.last_directory";
 
 file_dialog::Filters GetFileTypesFromAcceptType(
     const std::vector<base::string16>& accept_types) {
@@ -111,7 +110,7 @@ void WebDialogHelper::RunFileChooser(content::WebContents* web_contents,
     AtomBrowserContext* browser_context = static_cast<AtomBrowserContext*>(
         window_->web_contents()->GetBrowserContext());
     base::FilePath default_file_path = browser_context->prefs()->GetFilePath(
-        kSelectFileLastDirectory).Append(params.default_file_name);
+        prefs::kSelectFileLastDirectory).Append(params.default_file_name);
     if (file_dialog::ShowOpenDialog(window_,
                                     base::UTF16ToUTF8(params.title),
                                     default_file_path,
@@ -125,7 +124,7 @@ void WebDialogHelper::RunFileChooser(content::WebContents* web_contents,
         result.push_back(info);
       }
       if (!paths.empty()) {
-        browser_context->prefs()->SetFilePath(kSelectFileLastDirectory,
+        browser_context->prefs()->SetFilePath(prefs::kSelectFileLastDirectory,
                                               paths[0].DirName());
       }
     }

--- a/chromium_src/chrome/common/pref_names.cc
+++ b/chromium_src/chrome/common/pref_names.cc
@@ -7,5 +7,6 @@
 namespace prefs {
 
 const char kSelectFileLastDirectory[] = "selectfile.last_directory";
+const char kDownloadDefaultDirectory[] = "download.default_directory";
 
 }  // namespace prefs

--- a/chromium_src/chrome/common/pref_names.cc
+++ b/chromium_src/chrome/common/pref_names.cc
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Constants for the names of various preferences, for easier changing.
+#include "chrome/common/pref_names.h"
 
 namespace prefs {
 
-extern const char kSelectFileLastDirectory[];
+const char kSelectFileLastDirectory[] = "selectfile.last_directory";
 
 }  // namespace prefs

--- a/chromium_src/chrome/common/pref_names.h
+++ b/chromium_src/chrome/common/pref_names.h
@@ -7,5 +7,6 @@
 namespace prefs {
 
 extern const char kSelectFileLastDirectory[];
+extern const char kDownloadDefaultDirectory[];
 
 }  // namespace prefs

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1224,3 +1224,6 @@ proxy-uri = [<proxy-scheme>"://"]<proxy-host>[":"<proxy-port>]
 ### Session.setDownloadPath(path)
 
 * `path` String - The download location
+
+Sets download saving directory. By default, the download directory will be the
+`Downloads` under the respective app folder.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1220,3 +1220,7 @@ proxy-uri = [<proxy-scheme>"://"]<proxy-host>[":"<proxy-port>]
                                       and use socks4://foopy2 for all other
                                       URLs.
 ```
+
+### Session.setDownloadPath(path)
+
+* `path` String - The download location

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -364,6 +364,8 @@
       'chromium_src/chrome/browser/ui/views/frame/global_menu_bar_registrar_x11.cc',
       'chromium_src/chrome/browser/ui/views/frame/global_menu_bar_registrar_x11.h',
       'chromium_src/chrome/common/chrome_utility_messages.h',
+      'chromium_src/chrome/common/pref_names.cc',
+      'chromium_src/chrome/common/pref_names.h',
       'chromium_src/chrome/common/print_messages.cc',
       'chromium_src/chrome/common/print_messages.h',
       'chromium_src/chrome/common/tts_messages.h',


### PR DESCRIPTION
This PR :
* Fixes the last used directory of `input` label doesn't work on OS X. The prefs' key need to be registered before used.
* Add `session.setDownloadPath` API, fixes #2121.

cc @deepak1556 