### PR TITLE
protocol: fix request headers in urlRequestFetchJob

### DIFF
--- a/atom/browser/net/url_request_fetch_job.cc
+++ b/atom/browser/net/url_request_fetch_job.cc
@@ -107,10 +107,7 @@ URLRequestFetchJob::URLRequestFetchJob(
   }
 
   // Use |request|'s headers.
-  net::HttpRequestHeaders headers;
-  if (request->GetFullRequestHeaders(&headers)) {
-    fetcher_->SetExtraRequestHeaders(headers.ToString());
-  }
+  fetcher_->SetExtraRequestHeaders(request->extra_request_headers().ToString());
 }
 
 net::URLRequestContextGetter* URLRequestFetchJob::GetRequestContext() {

--- a/spec/api-protocol-spec.coffee
+++ b/spec/api-protocol-spec.coffee
@@ -81,6 +81,7 @@ describe 'protocol module', ->
 
     it 'returns RequestHttpJob should send respone', (done) ->
       server = http.createServer (req, res) ->
+        assert.notEqual req.headers.accept, ''
         res.writeHead(200, {'Content-Type': 'text/plain'})
         res.end('hello')
         server.close()


### PR DESCRIPTION
Fixes #2345 

`GetFullRequestHeaders` is not available before response starts, so using default getter for headers from `URLRequest`.