### PR TITLE
Add NativeImage.isTemplateImage method

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -44,8 +44,8 @@ void Tray::OnClicked(const gfx::Rect& bounds) {
   Emit("clicked", bounds);
 }
 
-void Tray::OnDoubleClicked() {
-  Emit("double-clicked");
+void Tray::OnDoubleClicked(const gfx::Rect& bounds) {
+  Emit("double-clicked", bounds);
 }
 
 void Tray::OnBalloonShow() {

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -43,7 +43,7 @@ class Tray : public mate::EventEmitter,
 
   // TrayIconObserver:
   void OnClicked(const gfx::Rect& bounds) override;
-  void OnDoubleClicked() override;
+  void OnDoubleClicked(const gfx::Rect& bounds) override;
   void OnBalloonShow() override;
   void OnBalloonClicked() override;
   void OnBalloonClosed() override;

--- a/atom/browser/ui/tray_icon.cc
+++ b/atom/browser/ui/tray_icon.cc
@@ -33,8 +33,8 @@ void TrayIcon::NotifyClicked(const gfx::Rect& bounds) {
   FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnClicked(bounds));
 }
 
-void TrayIcon::NotifyDoubleClicked() {
-  FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnDoubleClicked());
+void TrayIcon::NotifyDoubleClicked(const gfx::Rect& bounds) {
+  FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnDoubleClicked(bounds));
 }
 
 void TrayIcon::NotifyBalloonShow() {

--- a/atom/browser/ui/tray_icon.h
+++ b/atom/browser/ui/tray_icon.h
@@ -55,7 +55,7 @@ class TrayIcon {
   void AddObserver(TrayIconObserver* obs) { observers_.AddObserver(obs); }
   void RemoveObserver(TrayIconObserver* obs) { observers_.RemoveObserver(obs); }
   void NotifyClicked(const gfx::Rect& = gfx::Rect());
-  void NotifyDoubleClicked();
+  void NotifyDoubleClicked(const gfx::Rect& = gfx::Rect());
   void NotifyBalloonShow();
   void NotifyBalloonClicked();
   void NotifyBalloonClosed();

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -156,7 +156,7 @@ const CGFloat kMargin = 3;
   }
 
   if (event.clickCount == 2 && !menuController_) {
-    trayIcon_->NotifyDoubleClicked();
+    trayIcon_->NotifyDoubleClicked([self getBoundsFromEvent:event]);
   }
   [self setNeedsDisplay:YES];
 }

--- a/atom/browser/ui/tray_icon_observer.h
+++ b/atom/browser/ui/tray_icon_observer.h
@@ -17,7 +17,7 @@ namespace atom {
 class TrayIconObserver {
  public:
   virtual void OnClicked(const gfx::Rect& bounds) {}
-  virtual void OnDoubleClicked() {}
+  virtual void OnDoubleClicked(const gfx::Rect& bounds) {}
   virtual void OnBalloonShow() {}
   virtual void OnBalloonClicked() {}
   virtual void OnBalloonClosed() {}

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -113,7 +113,7 @@ bool PopulateImageSkiaRepsFromPath(gfx::ImageSkia* image,
 }
 
 #if defined(OS_MACOSX)
-bool IsTemplateImage(const base::FilePath& path) {
+bool IsTemplateFilename(const base::FilePath& path) {
   return (MatchPattern(path.value(), "*Template.*") ||
           MatchPattern(path.value(), "*Template@*x.*"));
 }
@@ -139,6 +139,7 @@ mate::ObjectTemplateBuilder NativeImage::GetObjectTemplateBuilder(
         .SetMethod("isEmpty", &NativeImage::IsEmpty)
         .SetMethod("getSize", &NativeImage::GetSize)
         .SetMethod("setTemplateImage", &NativeImage::SetTemplateImage)
+        .SetMethod("isTemplateImage", &NativeImage::IsTemplateImage)
         .Build());
 
   return mate::ObjectTemplateBuilder(
@@ -180,6 +181,8 @@ gfx::Size NativeImage::GetSize() {
 #if !defined(OS_MACOSX)
 void NativeImage::SetTemplateImage(bool setAsTemplate) {
 }
+bool NativeImage::IsTemplateImage() {
+}
 #endif
 
 // static
@@ -217,7 +220,7 @@ mate::Handle<NativeImage> NativeImage::CreateFromPath(
   gfx::Image image(image_skia);
   mate::Handle<NativeImage> handle = Create(isolate, image);
 #if defined(OS_MACOSX)
-  if (IsTemplateImage(path))
+  if (IsTemplateFilename(path))
     handle->SetTemplateImage(true);
 #endif
   return handle;

--- a/atom/common/api/atom_api_native_image.h
+++ b/atom/common/api/atom_api_native_image.h
@@ -67,6 +67,8 @@ class NativeImage : public mate::Wrappable {
 
   // Mark the image as template image.
   void SetTemplateImage(bool setAsTemplate);
+  // Determine if the image is a template image.
+  bool IsTemplateImage();
 
   gfx::Image image_;
 

--- a/atom/common/api/atom_api_native_image_mac.mm
+++ b/atom/common/api/atom_api_native_image_mac.mm
@@ -14,6 +14,10 @@ void NativeImage::SetTemplateImage(bool setAsTemplate) {
   [image_.AsNSImage() setTemplate:setAsTemplate];
 }
 
+bool NativeImage::IsTemplateImage() {
+    return [image_.AsNSImage() isTemplate];
+}
+
 }  // namespace api
 
 }  // namespace atom

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -132,6 +132,10 @@ Returns the size of the image.
 
 [buffer]: https://iojs.org/api/buffer.html#buffer_class_buffer
 
+### NativeImage.isTemplateImage()
+
+Returns whether the image is a template image.
+
 ### NativeImage.setTemplateImage(option)
 
 * `option` Boolean

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -76,6 +76,13 @@ will be emitted if the tray icon has context menu.
 
 Emitted when the tray icon is double clicked.
 
+* `event`
+* `bounds` Object - the bounds of tray icon
+  * `x` Integer
+  * `y` Integer
+  * `width` Integer
+  * `height` Integer
+  
 __Note:__ This is only implemented on OS X.
 
 ### Event: 'balloon-show'


### PR DESCRIPTION
* Add the new `isTemplateImage` method
* Appropriately rename an internally-used function of the same name, which is used to determine if a image file path matches the template image naming pattern.
* Update docs