### PR TITLE
Add NativeImage.isTemplateImage method

### DIFF
--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -113,7 +113,7 @@ bool PopulateImageSkiaRepsFromPath(gfx::ImageSkia* image,
 }
 
 #if defined(OS_MACOSX)
-bool IsTemplateImage(const base::FilePath& path) {
+bool IsTemplateFilename(const base::FilePath& path) {
   return (MatchPattern(path.value(), "*Template.*") ||
           MatchPattern(path.value(), "*Template@*x.*"));
 }
@@ -139,6 +139,7 @@ mate::ObjectTemplateBuilder NativeImage::GetObjectTemplateBuilder(
         .SetMethod("isEmpty", &NativeImage::IsEmpty)
         .SetMethod("getSize", &NativeImage::GetSize)
         .SetMethod("setTemplateImage", &NativeImage::SetTemplateImage)
+        .SetMethod("isTemplateImage", &NativeImage::IsTemplateImage)
         .Build());
 
   return mate::ObjectTemplateBuilder(
@@ -180,6 +181,8 @@ gfx::Size NativeImage::GetSize() {
 #if !defined(OS_MACOSX)
 void NativeImage::SetTemplateImage(bool setAsTemplate) {
 }
+bool NativeImage::IsTemplateImage() {
+}
 #endif
 
 // static
@@ -217,7 +220,7 @@ mate::Handle<NativeImage> NativeImage::CreateFromPath(
   gfx::Image image(image_skia);
   mate::Handle<NativeImage> handle = Create(isolate, image);
 #if defined(OS_MACOSX)
-  if (IsTemplateImage(path))
+  if (IsTemplateFilename(path))
     handle->SetTemplateImage(true);
 #endif
   return handle;

--- a/atom/common/api/atom_api_native_image.h
+++ b/atom/common/api/atom_api_native_image.h
@@ -67,6 +67,8 @@ class NativeImage : public mate::Wrappable {
 
   // Mark the image as template image.
   void SetTemplateImage(bool setAsTemplate);
+  // Determine if the image is a template image.
+  bool IsTemplateImage();
 
   gfx::Image image_;
 

--- a/atom/common/api/atom_api_native_image_mac.mm
+++ b/atom/common/api/atom_api_native_image_mac.mm
@@ -14,6 +14,10 @@ void NativeImage::SetTemplateImage(bool setAsTemplate) {
   [image_.AsNSImage() setTemplate:setAsTemplate];
 }
 
+bool NativeImage::IsTemplateImage() {
+    return [image_.AsNSImage() isTemplate];
+}
+
 }  // namespace api
 
 }  // namespace atom

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -132,6 +132,10 @@ Returns the size of the image.
 
 [buffer]: https://iojs.org/api/buffer.html#buffer_class_buffer
 
+### NativeImage.isTemplateImage()
+
+Returns whether the image is a template image.
+
 ### NativeImage.setTemplateImage(option)
 
 * `option` Boolean


### PR DESCRIPTION
* Add the new isTemplateImage method
* Appropriately rename an internally-used function of the same name, which is used to determine if a image file path matches the template image naming pattern.
* Update docs