### PR TITLE
Add keyboard modifiers payload to tray click events, resolves #2336

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -44,8 +44,8 @@ void Tray::OnClicked(const gfx::Rect& bounds) {
   Emit("clicked", bounds);
 }
 
-void Tray::OnDoubleClicked() {
-  Emit("double-clicked");
+void Tray::OnDoubleClicked(const gfx::Rect& bounds) {
+  Emit("double-clicked", bounds);
 }
 
 void Tray::OnBalloonShow() {

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -40,12 +40,12 @@ mate::Wrappable* Tray::New(v8::Isolate* isolate, const gfx::Image& image) {
   return new Tray(image);
 }
 
-void Tray::OnClicked(const gfx::Rect& bounds) {
-  Emit("clicked", bounds);
+void Tray::OnClicked(const gfx::Rect& bounds, int modifiers) {
+  Emit("clicked", bounds, modifiers);
 }
 
-void Tray::OnDoubleClicked(const gfx::Rect& bounds) {
-  Emit("double-clicked", bounds);
+void Tray::OnDoubleClicked(const gfx::Rect& bounds, int modifiers) {
+  Emit("double-clicked", bounds, modifiers);
 }
 
 void Tray::OnBalloonShow() {
@@ -60,8 +60,8 @@ void Tray::OnBalloonClosed() {
   Emit("balloon-closed");
 }
 
-void Tray::OnRightClicked(const gfx::Rect& bounds) {
-  Emit("right-clicked", bounds);
+void Tray::OnRightClicked(const gfx::Rect& bounds, int modifiers) {
+  Emit("right-clicked", bounds, modifiers);
 }
 
 void Tray::OnDropFiles(const std::vector<std::string>& files) {

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -42,12 +42,12 @@ class Tray : public mate::EventEmitter,
   virtual ~Tray();
 
   // TrayIconObserver:
-  void OnClicked(const gfx::Rect& bounds) override;
-  void OnDoubleClicked(const gfx::Rect& bounds) override;
+  void OnClicked(const gfx::Rect& bounds, int modifiers) override;
+  void OnDoubleClicked(const gfx::Rect& bounds, int modifiers) override;
   void OnBalloonShow() override;
   void OnBalloonClicked() override;
   void OnBalloonClosed() override;
-  void OnRightClicked(const gfx::Rect& bounds) override;
+  void OnRightClicked(const gfx::Rect& bounds, int modifiers) override;
   void OnDropFiles(const std::vector<std::string>& files) override;
 
   // mate::Wrappable:

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -43,7 +43,7 @@ class Tray : public mate::EventEmitter,
 
   // TrayIconObserver:
   void OnClicked(const gfx::Rect& bounds) override;
-  void OnDoubleClicked() override;
+  void OnDoubleClicked(const gfx::Rect& bounds) override;
   void OnBalloonShow() override;
   void OnBalloonClicked() override;
   void OnBalloonClosed() override;

--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -4,6 +4,7 @@
 // found in the LICENSE file.
 
 #import "atom/browser/ui/cocoa/atom_menu_controller.h"
+#import "atom/browser/ui/event_util.h"
 
 #include "base/logging.h"
 #include "base/strings/sys_string_conversions.h"
@@ -12,53 +13,6 @@
 #include "ui/base/l10n/l10n_util_mac.h"
 #include "ui/base/models/simple_menu_model.h"
 #include "ui/gfx/image/image.h"
-
-namespace {
-
-bool isLeftButtonEvent(NSEvent* event) {
-  NSEventType type = [event type];
-  return type == NSLeftMouseDown ||
-    type == NSLeftMouseDragged ||
-    type == NSLeftMouseUp;
-}
-
-bool isRightButtonEvent(NSEvent* event) {
-  NSEventType type = [event type];
-  return type == NSRightMouseDown ||
-    type == NSRightMouseDragged ||
-    type == NSRightMouseUp;
-}
-
-bool isMiddleButtonEvent(NSEvent* event) {
-  if ([event buttonNumber] != 2)
-    return false;
-
-  NSEventType type = [event type];
-  return type == NSOtherMouseDown ||
-    type == NSOtherMouseDragged ||
-    type == NSOtherMouseUp;
-}
-
-int EventFlagsFromNSEventWithModifiers(NSEvent* event, NSUInteger modifiers) {
-  int flags = 0;
-  flags |= (modifiers & NSAlphaShiftKeyMask) ? ui::EF_CAPS_LOCK_DOWN : 0;
-  flags |= (modifiers & NSShiftKeyMask) ? ui::EF_SHIFT_DOWN : 0;
-  flags |= (modifiers & NSControlKeyMask) ? ui::EF_CONTROL_DOWN : 0;
-  flags |= (modifiers & NSAlternateKeyMask) ? ui::EF_ALT_DOWN : 0;
-  flags |= (modifiers & NSCommandKeyMask) ? ui::EF_COMMAND_DOWN : 0;
-  flags |= isLeftButtonEvent(event) ? ui::EF_LEFT_MOUSE_BUTTON : 0;
-  flags |= isRightButtonEvent(event) ? ui::EF_RIGHT_MOUSE_BUTTON : 0;
-  flags |= isMiddleButtonEvent(event) ? ui::EF_MIDDLE_MOUSE_BUTTON : 0;
-  return flags;
-}
-
-// Retrieves a bitsum of ui::EventFlags from NSEvent.
-int EventFlagsFromNSEvent(NSEvent* event) {
-  NSUInteger modifiers = [event modifierFlags];
-  return EventFlagsFromNSEventWithModifiers(event, modifiers);
-}
-
-}  // namespace
 
 @interface AtomMenuController (Private)
 - (void)addSeparatorToMenu:(NSMenu*)menu
@@ -246,7 +200,7 @@ int EventFlagsFromNSEvent(NSEvent* event) {
           [[sender representedObject] pointerValue]);
   DCHECK(model);
   if (model) {
-    int event_flags = EventFlagsFromNSEvent([NSApp currentEvent]);
+    int event_flags = event_util::EventFlagsFromNSEvent([NSApp currentEvent]);
     model->ActivatedAt(modelIndex, event_flags);
   }
 }

--- a/atom/browser/ui/event_util.h
+++ b/atom/browser/ui/event_util.h
@@ -1,0 +1,17 @@
+#ifndef ATOM_BROWSER_UI_EVENT_UTIL_H_
+#define ATOM_BROWSER_UI_EVENT_UTIL_H_
+
+#import <Cocoa/Cocoa.h>
+
+namespace event_util {
+
+bool isLeftButtonEvent(NSEvent* event);
+bool isRightButtonEvent(NSEvent* event);
+bool isMiddleButtonEvent(NSEvent* event);
+
+// Retrieves a bitsum of ui::EventFlags from NSEvent.
+int EventFlagsFromNSEvent(NSEvent* event);
+
+} // namespace event_util
+
+#endif // ATOM_BROWSER_UI_EVENT_UTIL_H_

--- a/atom/browser/ui/event_util.h
+++ b/atom/browser/ui/event_util.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
 #ifndef ATOM_BROWSER_UI_EVENT_UTIL_H_
 #define ATOM_BROWSER_UI_EVENT_UTIL_H_
 
@@ -15,6 +19,6 @@ int EventFlagsFromNSEvent(NSEvent* event);
 
 gfx::Rect GetBoundsFromEvent(NSEvent* event);
 
-} // namespace event_util
+}  // namespace event_util
 
-#endif // ATOM_BROWSER_UI_EVENT_UTIL_H_
+#endif  // ATOM_BROWSER_UI_EVENT_UTIL_H_

--- a/atom/browser/ui/event_util.h
+++ b/atom/browser/ui/event_util.h
@@ -2,15 +2,18 @@
 #define ATOM_BROWSER_UI_EVENT_UTIL_H_
 
 #import <Cocoa/Cocoa.h>
+#include "ui/gfx/geometry/rect.h"
 
 namespace event_util {
 
-bool isLeftButtonEvent(NSEvent* event);
-bool isRightButtonEvent(NSEvent* event);
-bool isMiddleButtonEvent(NSEvent* event);
+bool IsLeftButtonEvent(NSEvent* event);
+bool IsRightButtonEvent(NSEvent* event);
+bool IsMiddleButtonEvent(NSEvent* event);
 
 // Retrieves a bitsum of ui::EventFlags from NSEvent.
 int EventFlagsFromNSEvent(NSEvent* event);
+
+gfx::Rect GetBoundsFromEvent(NSEvent* event);
 
 } // namespace event_util
 

--- a/atom/browser/ui/event_util_mac.mm
+++ b/atom/browser/ui/event_util_mac.mm
@@ -1,0 +1,47 @@
+#include "atom/browser/ui/event_util.h"
+#include "ui/base/accelerators/accelerator.h"
+
+namespace event_util {
+    bool isLeftButtonEvent(NSEvent* event) {
+      NSEventType type = [event type];
+      return type == NSLeftMouseDown ||
+        type == NSLeftMouseDragged ||
+        type == NSLeftMouseUp;
+    }
+
+    bool isRightButtonEvent(NSEvent* event) {
+      NSEventType type = [event type];
+      return type == NSRightMouseDown ||
+        type == NSRightMouseDragged ||
+        type == NSRightMouseUp;
+    }
+
+    bool isMiddleButtonEvent(NSEvent* event) {
+      if ([event buttonNumber] != 2)
+        return false;
+
+      NSEventType type = [event type];
+      return type == NSOtherMouseDown ||
+        type == NSOtherMouseDragged ||
+        type == NSOtherMouseUp;
+    }
+
+    int EventFlagsFromNSEventWithModifiers(NSEvent* event, NSUInteger modifiers) {
+      int flags = 0;
+      flags |= (modifiers & NSAlphaShiftKeyMask) ? ui::EF_CAPS_LOCK_DOWN : 0;
+      flags |= (modifiers & NSShiftKeyMask) ? ui::EF_SHIFT_DOWN : 0;
+      flags |= (modifiers & NSControlKeyMask) ? ui::EF_CONTROL_DOWN : 0;
+      flags |= (modifiers & NSAlternateKeyMask) ? ui::EF_ALT_DOWN : 0;
+      flags |= (modifiers & NSCommandKeyMask) ? ui::EF_COMMAND_DOWN : 0;
+      flags |= isLeftButtonEvent(event) ? ui::EF_LEFT_MOUSE_BUTTON : 0;
+      flags |= isRightButtonEvent(event) ? ui::EF_RIGHT_MOUSE_BUTTON : 0;
+      flags |= isMiddleButtonEvent(event) ? ui::EF_MIDDLE_MOUSE_BUTTON : 0;
+      return flags;
+    }
+
+    // Retrieves a bitsum of ui::EventFlags from NSEvent.
+    int EventFlagsFromNSEvent(NSEvent* event) {
+      NSUInteger modifiers = [event modifierFlags];
+      return EventFlagsFromNSEventWithModifiers(event, modifiers);
+    }
+} // namespace event_util

--- a/atom/browser/ui/event_util_mac.mm
+++ b/atom/browser/ui/event_util_mac.mm
@@ -1,22 +1,24 @@
 #include "atom/browser/ui/event_util.h"
-#include "ui/base/accelerators/accelerator.h"
+
+#include "ui/events/event_constants.h"
 
 namespace event_util {
-    bool isLeftButtonEvent(NSEvent* event) {
+
+    bool IsLeftButtonEvent(NSEvent* event) {
       NSEventType type = [event type];
       return type == NSLeftMouseDown ||
         type == NSLeftMouseDragged ||
         type == NSLeftMouseUp;
     }
 
-    bool isRightButtonEvent(NSEvent* event) {
+    bool IsRightButtonEvent(NSEvent* event) {
       NSEventType type = [event type];
       return type == NSRightMouseDown ||
         type == NSRightMouseDragged ||
         type == NSRightMouseUp;
     }
 
-    bool isMiddleButtonEvent(NSEvent* event) {
+    bool IsMiddleButtonEvent(NSEvent* event) {
       if ([event buttonNumber] != 2)
         return false;
 
@@ -33,9 +35,9 @@ namespace event_util {
       flags |= (modifiers & NSControlKeyMask) ? ui::EF_CONTROL_DOWN : 0;
       flags |= (modifiers & NSAlternateKeyMask) ? ui::EF_ALT_DOWN : 0;
       flags |= (modifiers & NSCommandKeyMask) ? ui::EF_COMMAND_DOWN : 0;
-      flags |= isLeftButtonEvent(event) ? ui::EF_LEFT_MOUSE_BUTTON : 0;
-      flags |= isRightButtonEvent(event) ? ui::EF_RIGHT_MOUSE_BUTTON : 0;
-      flags |= isMiddleButtonEvent(event) ? ui::EF_MIDDLE_MOUSE_BUTTON : 0;
+      flags |= IsLeftButtonEvent(event) ? ui::EF_LEFT_MOUSE_BUTTON : 0;
+      flags |= IsRightButtonEvent(event) ? ui::EF_RIGHT_MOUSE_BUTTON : 0;
+      flags |= IsMiddleButtonEvent(event) ? ui::EF_MIDDLE_MOUSE_BUTTON : 0;
       return flags;
     }
 
@@ -44,4 +46,20 @@ namespace event_util {
       NSUInteger modifiers = [event modifierFlags];
       return EventFlagsFromNSEventWithModifiers(event, modifiers);
     }
+
+    gfx::Rect GetBoundsFromEvent(NSEvent* event) {
+        NSRect frame = event.window.frame;
+
+        gfx::Rect bounds(
+            frame.origin.x,
+            0,
+            NSWidth(frame),
+            NSHeight(frame)
+        );
+
+        NSScreen* screen = [[NSScreen screens] objectAtIndex:0];
+        bounds.set_y(NSHeight([screen frame]) - NSMaxY(frame));
+        return bounds;
+    }
+
 } // namespace event_util

--- a/atom/browser/ui/tray_icon.cc
+++ b/atom/browser/ui/tray_icon.cc
@@ -29,12 +29,14 @@ void TrayIcon::DisplayBalloon(const gfx::Image& icon,
 void TrayIcon::PopContextMenu(const gfx::Point& pos) {
 }
 
-void TrayIcon::NotifyClicked(const gfx::Rect& bounds) {
-  FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnClicked(bounds));
+void TrayIcon::NotifyClicked(const gfx::Rect& bounds, int modifiers) {
+  FOR_EACH_OBSERVER(TrayIconObserver, observers_,
+    OnClicked(bounds, modifiers));
 }
 
-void TrayIcon::NotifyDoubleClicked(const gfx::Rect& bounds) {
-  FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnDoubleClicked(bounds));
+void TrayIcon::NotifyDoubleClicked(const gfx::Rect& bounds, int modifiers) {
+  FOR_EACH_OBSERVER(TrayIconObserver, observers_,
+    OnDoubleClicked(bounds, modifiers));
 }
 
 void TrayIcon::NotifyBalloonShow() {
@@ -49,8 +51,9 @@ void TrayIcon::NotifyBalloonClosed() {
   FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnBalloonClosed());
 }
 
-void TrayIcon::NotifyRightClicked(const gfx::Rect& bounds) {
-  FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnRightClicked(bounds));
+void TrayIcon::NotifyRightClicked(const gfx::Rect& bounds, int modifiers) {
+  FOR_EACH_OBSERVER(TrayIconObserver, observers_,
+    OnRightClicked(bounds, modifiers));
 }
 
 void TrayIcon::NotfiyDropFiles(const std::vector<std::string>& files) {

--- a/atom/browser/ui/tray_icon.cc
+++ b/atom/browser/ui/tray_icon.cc
@@ -33,8 +33,8 @@ void TrayIcon::NotifyClicked(const gfx::Rect& bounds) {
   FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnClicked(bounds));
 }
 
-void TrayIcon::NotifyDoubleClicked() {
-  FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnDoubleClicked());
+void TrayIcon::NotifyDoubleClicked(const gfx::Rect& bounds) {
+  FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnDoubleClicked(bounds));
 }
 
 void TrayIcon::NotifyBalloonShow() {

--- a/atom/browser/ui/tray_icon.h
+++ b/atom/browser/ui/tray_icon.h
@@ -54,12 +54,13 @@ class TrayIcon {
 
   void AddObserver(TrayIconObserver* obs) { observers_.AddObserver(obs); }
   void RemoveObserver(TrayIconObserver* obs) { observers_.RemoveObserver(obs); }
-  void NotifyClicked(const gfx::Rect& = gfx::Rect());
-  void NotifyDoubleClicked(const gfx::Rect& = gfx::Rect());
+  void NotifyClicked(const gfx::Rect& = gfx::Rect(), int modifiers = 0);
+  void NotifyDoubleClicked(const gfx::Rect& = gfx::Rect(), int modifiers = 0);
   void NotifyBalloonShow();
   void NotifyBalloonClicked();
   void NotifyBalloonClosed();
-  void NotifyRightClicked(const gfx::Rect& bounds = gfx::Rect());
+  void NotifyRightClicked(const gfx::Rect& bounds = gfx::Rect(),
+    int modifiers = 0);
   void NotfiyDropFiles(const std::vector<std::string>& files);
 
  protected:

--- a/atom/browser/ui/tray_icon.h
+++ b/atom/browser/ui/tray_icon.h
@@ -55,7 +55,7 @@ class TrayIcon {
   void AddObserver(TrayIconObserver* obs) { observers_.AddObserver(obs); }
   void RemoveObserver(TrayIconObserver* obs) { observers_.RemoveObserver(obs); }
   void NotifyClicked(const gfx::Rect& = gfx::Rect());
-  void NotifyDoubleClicked();
+  void NotifyDoubleClicked(const gfx::Rect& = gfx::Rect());
   void NotifyBalloonShow();
   void NotifyBalloonClicked();
   void NotifyBalloonClosed();

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -156,7 +156,7 @@ const CGFloat kMargin = 3;
   }
 
   if (event.clickCount == 2 && !menuController_) {
-    trayIcon_->NotifyDoubleClicked();
+    trayIcon_->NotifyDoubleClicked([self getBoundsFromEvent:event]);
   }
   [self setNeedsDisplay:YES];
 }

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -5,6 +5,7 @@
 #include "atom/browser/ui/tray_icon_cocoa.h"
 
 #include "atom/browser/ui/cocoa/atom_menu_controller.h"
+#include "atom/browser/ui/event_util.h"
 #include "base/strings/sys_string_conversions.h"
 #include "ui/gfx/image/image.h"
 #include "ui/gfx/screen.h"
@@ -147,16 +148,21 @@ const CGFloat kMargin = 3;
      return;
   }
   inMouseEventSequence_ = NO;
+
+  // Single click
   if (event.clickCount == 1) {
     if (menuController_) {
       [statusItem_ popUpStatusItemMenu:[menuController_ menu]];
     }
 
-    trayIcon_->NotifyClicked([self getBoundsFromEvent:event]);
+    trayIcon_->NotifyClicked(event_util::GetBoundsFromEvent(event),
+      event_util::EventFlagsFromNSEvent(event));
   }
 
+  // Double click
   if (event.clickCount == 2 && !menuController_) {
-    trayIcon_->NotifyDoubleClicked([self getBoundsFromEvent:event]);
+    trayIcon_->NotifyDoubleClicked(event_util::GetBoundsFromEvent(event),
+      event_util::EventFlagsFromNSEvent(event));
   }
   [self setNeedsDisplay:YES];
 }
@@ -173,7 +179,8 @@ const CGFloat kMargin = 3;
 }
 
 - (void)rightMouseUp:(NSEvent*)event {
-  trayIcon_->NotifyRightClicked([self getBoundsFromEvent:event]);
+  trayIcon_->NotifyRightClicked(event_util::GetBoundsFromEvent(event),
+    event_util::EventFlagsFromNSEvent(event));
 }
 
 - (NSDragOperation)draggingEntered:(id <NSDraggingInfo>)sender {
@@ -199,13 +206,6 @@ const CGFloat kMargin = 3;
   return isHighlightEnable_ && (inMouseEventSequence_ || is_menu_open);
 }
 
-- (gfx::Rect)getBoundsFromEvent:(NSEvent*)event {
-  NSRect frame = event.window.frame;
-  gfx::Rect bounds(frame.origin.x, 0, NSWidth(frame), NSHeight(frame));
-  NSScreen* screen = [[NSScreen screens] objectAtIndex:0];
-  bounds.set_y(NSHeight([screen frame]) - NSMaxY(frame));
-  return bounds;
-}
 @end
 
 namespace atom {

--- a/atom/browser/ui/tray_icon_observer.h
+++ b/atom/browser/ui/tray_icon_observer.h
@@ -17,7 +17,7 @@ namespace atom {
 class TrayIconObserver {
  public:
   virtual void OnClicked(const gfx::Rect& bounds) {}
-  virtual void OnDoubleClicked() {}
+  virtual void OnDoubleClicked(const gfx::Rect& bounds) {}
   virtual void OnBalloonShow() {}
   virtual void OnBalloonClicked() {}
   virtual void OnBalloonClosed() {}

--- a/atom/browser/ui/tray_icon_observer.h
+++ b/atom/browser/ui/tray_icon_observer.h
@@ -16,12 +16,12 @@ namespace atom {
 
 class TrayIconObserver {
  public:
-  virtual void OnClicked(const gfx::Rect& bounds) {}
-  virtual void OnDoubleClicked(const gfx::Rect& bounds) {}
+  virtual void OnClicked(const gfx::Rect& bounds, int modifiers) {}
+  virtual void OnDoubleClicked(const gfx::Rect& bounds, int modifiers) {}
   virtual void OnBalloonShow() {}
   virtual void OnBalloonClicked() {}
   virtual void OnBalloonClosed() {}
-  virtual void OnRightClicked(const gfx::Rect& bounds) {}
+  virtual void OnRightClicked(const gfx::Rect& bounds, int modifiers) {}
   virtual void OnDropFiles(const std::vector<std::string>& files) {}
 
  protected:

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -53,6 +53,7 @@ Creates a new tray icon associated with the `image`.
   * `y` Integer
   * `width` Integer
   * `height` Integer
+* [`modifiers`](https://code.google.com/p/chromium/codesearch#chromium/src/ui/events/event_constants.h&l=77) number - bitsum of keyboard modifiers and mouse keys
 
 Emitted when the tray icon is clicked.
 
@@ -66,6 +67,7 @@ __Note:__ The `bounds` payload is only implemented on OS X and Windows 7 or newe
   * `y` Integer
   * `width` Integer
   * `height` Integer
+* [`modifiers`](https://code.google.com/p/chromium/codesearch#chromium/src/ui/events/event_constants.h&l=77) number - bitsum of keyboard modifiers and mouse keys
 
 Emitted when the tray icon is right clicked.
 
@@ -82,7 +84,8 @@ Emitted when the tray icon is double clicked.
   * `y` Integer
   * `width` Integer
   * `height` Integer
-  
+* [`modifiers`](https://code.google.com/p/chromium/codesearch#chromium/src/ui/events/event_constants.h&l=77) number - bitsum of keyboard modifiers and mouse keys
+
 __Note:__ This is only implemented on OS X.
 
 ### Event: 'balloon-show'

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -76,6 +76,13 @@ will be emitted if the tray icon has context menu.
 
 Emitted when the tray icon is double clicked.
 
+* `event`
+* `bounds` Object - the bounds of tray icon
+  * `x` Integer
+  * `y` Integer
+  * `width` Integer
+  * `height` Integer
+  
 __Note:__ This is only implemented on OS X.
 
 ### Event: 'balloon-show'

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -170,6 +170,8 @@
       'atom/browser/ui/cocoa/atom_menu_controller.mm',
       'atom/browser/ui/cocoa/event_processing_window.h',
       'atom/browser/ui/cocoa/event_processing_window.mm',
+      'atom/browser/ui/event_util.h',
+      'atom/browser/ui/event_util_mac.mm',
       'atom/browser/ui/file_dialog.h',
       'atom/browser/ui/file_dialog_gtk.cc',
       'atom/browser/ui/file_dialog_mac.mm',


### PR DESCRIPTION
* Add keyboard and mouse button bitsum to Tray click events payload
* Move `getBoundsFromRect`: to common `event_util_mac` file
* Update documentation
* and commits from #2337 . 

Resolves issue #2336 

Tested
- [x] Mac
- [ ] Windows
- [ ] Linux