### PR TITLE
Replaced 'browser' with 'main'

### DIFF
--- a/atom/browser/api/lib/browser-window.coffee
+++ b/atom/browser/api/lib/browser-window.coffee
@@ -26,6 +26,10 @@ BrowserWindow::_init = ->
     if process.platform isnt 'darwin' and @isMenuBarAutoHide() and @isMenuBarVisible()
       @setMenuBarVisibility false
 
+  # Forward the crashed event.
+  @webContents.on 'crashed', =>
+    @emit 'crashed'
+
   # Redirect focus/blur event to app instance too.
   @on 'blur', (event) =>
     app.emit 'browser-window-blur', event, this


### PR DESCRIPTION
New terminology for processes. The error 'A JavaScript error occured in the browser process' pops up often and is confusing.