### PR TITLE
 Add missing dependency for ubuntu build

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -17,7 +17,7 @@ On Ubuntu, install the following libraries:
 $ sudo apt-get install build-essential clang libdbus-1-dev libgtk2.0-dev \
                        libnotify-dev libgnome-keyring-dev libgconf2-dev \
                        libasound2-dev libcap-dev libcups2-dev libxtst-dev \
-                       libxss1 gcc-multilib g++-multilib
+                       libxss1 libnss3-dev gcc-multilib g++-multilib
 ```
 
 Other distributions may offer similar packages for installation via package


### PR DESCRIPTION
I tried to follow the document to build electron on a fresh clean built Ubuntu 15.04.
I encountered the following error message when trying to run `./script/bootstrap.py -v`

```bash
Package nss was not found in the pkg-config search path. 
Perhaps you should add the directory containing `nss.pc' 
to the PKG_CONFIG_PATH environment variable 
No package 'nss' found 
```

After installing libnss3-dev, the build can pass.