### PR TITLE
Fix a bug calling setResizable multiple times will take no effect on OS X.

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -589,7 +589,7 @@ void NativeWindowMac::SetResizable(bool resizable) {
     [window_ setStyleMask:[window_ styleMask] | NSResizableWindowMask];
   } else {
     [[window_ standardWindowButton:NSWindowZoomButton] setEnabled:NO];
-    [window_ setStyleMask:[window_ styleMask] ^ NSResizableWindowMask];
+    [window_ setStyleMask:[window_ styleMask] & (~NSResizableWindowMask)];
   }
 }
 


### PR DESCRIPTION
Fix browser window will be resiable when calling `window.setResizable(false)` twice due to wrong usage of mask.