### PR TITLE
Support Promise over remote objects

### DIFF
--- a/atom/browser/lib/rpc-server.coffee
+++ b/atom/browser/lib/rpc-server.coffee
@@ -10,6 +10,7 @@ valueToMeta = (sender, value) ->
   meta.type = 'buffer' if Buffer.isBuffer value
   meta.type = 'value' if value is null
   meta.type = 'array' if Array.isArray value
+  meta.type = 'promise' if Promise.resolve(value) == value
 
   # Treat the arguments object as array.
   meta.type = 'array' if meta.type is 'object' and value.callee? and value.length?
@@ -29,6 +30,8 @@ valueToMeta = (sender, value) ->
     meta.members.push {name: prop, type: typeof field} for prop, field of value
   else if meta.type is 'buffer'
     meta.value = Array::slice.call value, 0
+  else if meta.type is 'promise'
+    meta.then = valueToMeta(sender, value.then.bind(value))
   else
     meta.type = 'value'
     meta.value = value

--- a/atom/browser/lib/rpc-server.coffee
+++ b/atom/browser/lib/rpc-server.coffee
@@ -10,7 +10,7 @@ valueToMeta = (sender, value) ->
   meta.type = 'buffer' if Buffer.isBuffer value
   meta.type = 'value' if value is null
   meta.type = 'array' if Array.isArray value
-  meta.type = 'promise' if Promise.resolve(value) == value
+  meta.type = 'promise' if value? and value.constructor.name is 'Promise'
 
   # Treat the arguments object as array.
   meta.type = 'array' if meta.type is 'object' and value.callee? and value.length?

--- a/atom/browser/lib/rpc-server.coffee
+++ b/atom/browser/lib/rpc-server.coffee
@@ -50,6 +50,7 @@ unwrapArgs = (sender, args) ->
       when 'remote-object' then objectsRegistry.get meta.id
       when 'array' then unwrapArgs sender, meta.value
       when 'buffer' then new Buffer(meta.value)
+      when 'promise' then Promise.resolve(then: metaToValue(meta.then))
       when 'object'
         ret = v8Util.createObjectWithName meta.name
         for member in meta.members

--- a/atom/renderer/api/lib/remote.coffee
+++ b/atom/renderer/api/lib/remote.coffee
@@ -44,6 +44,7 @@ metaToValue = (meta) ->
     when 'value' then meta.value
     when 'array' then (metaToValue(el) for el in meta.members)
     when 'buffer' then new Buffer(meta.value)
+    when 'promise' then Promise.resolve(then: metaToValue(meta.then))
     when 'error'
       throw new Error("#{meta.message}\n#{meta.stack}")
     else

--- a/atom/renderer/api/lib/remote.coffee
+++ b/atom/renderer/api/lib/remote.coffee
@@ -20,6 +20,8 @@ wrapArgs = (args, visited=[]) ->
       type: 'array', value: wrapArgs(value, visited)
     else if Buffer.isBuffer value
       type: 'buffer', value: Array::slice.call(value, 0)
+    else if Promise.resolve(value) == value
+      type: 'promise', then: valueToMeta(value.then.bind(value))
     else if value? and typeof value is 'object' and v8Util.getHiddenValue value, 'atomId'
       type: 'remote-object', id: v8Util.getHiddenValue value, 'atomId'
     else if value? and typeof value is 'object'

--- a/atom/renderer/api/lib/remote.coffee
+++ b/atom/renderer/api/lib/remote.coffee
@@ -20,7 +20,7 @@ wrapArgs = (args, visited=[]) ->
       type: 'array', value: wrapArgs(value, visited)
     else if Buffer.isBuffer value
       type: 'buffer', value: Array::slice.call(value, 0)
-    else if Promise.resolve(value) == value
+    else if value? and value.constructor.name is 'Promise'
       type: 'promise', then: valueToMeta(value.then.bind(value))
     else if value? and typeof value is 'object' and v8Util.getHiddenValue value, 'atomId'
       type: 'remote-object', id: v8Util.getHiddenValue value, 'atomId'

--- a/spec/api-ipc-spec.coffee
+++ b/spec/api-ipc-spec.coffee
@@ -52,11 +52,10 @@ describe 'ipc module', ->
       print_name = remote.require path.join(fixtures, 'module', 'print_name.js')
       assert.equal print_name.print(buf), 'Buffer'
 
-  describe 'remote promise in renderer', ->
-    it 'can be used as promise', (done) ->
+  describe 'remote promise', ->
+    it 'can be used as promise in each side', (done) ->
       promise = remote.require path.join(fixtures, 'module', 'promise.js')
-      promise.toPromise(1234)
-        .then (value) => value * 2
+      promise.twicePromise(Promise.resolve(1234))
         .then (value) =>
           assert.equal value, 2468
           done()

--- a/spec/api-ipc-spec.coffee
+++ b/spec/api-ipc-spec.coffee
@@ -52,6 +52,15 @@ describe 'ipc module', ->
       print_name = remote.require path.join(fixtures, 'module', 'print_name.js')
       assert.equal print_name.print(buf), 'Buffer'
 
+  describe 'remote promise in renderer', ->
+    it 'can be used as promise', (done) ->
+      promise = remote.require path.join(fixtures, 'module', 'promise.js')
+      promise.toPromise(1234)
+        .then (value) => value * 2
+        .then (value) =>
+          assert.equal value, 2468
+          done()
+
   describe 'ipc.sender.send', ->
     it 'should work when sending an object containing id property', (done) ->
       obj = id: 1, name: 'ly'

--- a/spec/fixtures/module/promise.js
+++ b/spec/fixtures/module/promise.js
@@ -1,0 +1,3 @@
+exports.toPromise = function (value) {
+  return Promise.resolve(value);
+};

--- a/spec/fixtures/module/promise.js
+++ b/spec/fixtures/module/promise.js
@@ -1,3 +1,5 @@
-exports.toPromise = function (value) {
-  return Promise.resolve(value);
-};
+exports.twicePromise = function (promise) {
+  return promise.then(function (value) {
+    return value * 2;
+  });
+}


### PR DESCRIPTION
Hi,

I found this example using Promise doesn't work in current Electron:

#### sleep.js
```js
module.exports = function (ms) {
  return new Promise(function (resolve) {
    setTimeout(resolve, ms);
  });
};
```

#### In renderer

```js
var remote = require("remote");
var sleep = remote.require("./sleep");

var promise = sleep(1000);
console.log(promise); //=> "[object Promise]"
promise.then(function () { // "promise.then is not a function" error
  console.log("slept 1s");
});
```

This PR adds support to pass ES6 `Promise` between remote and browser over `remote` and fix this problem.