### PR TITLE
Create builtin protocol handlers on AtomBrowserContext init

### DIFF
--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -10,6 +10,7 @@
 #include "atom/browser/net/atom_url_request_job_factory.h"
 #include "atom/browser/net/asar/asar_protocol_handler.h"
 #include "atom/browser/net/http_protocol_handler.h"
+#include "atom/browser/net/ftp_protocol_handler.h"
 #include "atom/browser/web_view_manager.h"
 #include "atom/common/atom_version.h"
 #include "atom/common/chrome_version.h"
@@ -151,16 +152,8 @@ AtomURLRequestJobFactory *AtomBrowserContext::CreateJobFactory() {
       url::kWsScheme, new HttpProtocolHandler(url::kWsScheme));
   job_factory->SetProtocolHandler(
       url::kWssScheme, new HttpProtocolHandler(url::kWssScheme));
-
-  // cannot get host_resolver on AtomBrowserContext init
-  /*
-  auto host_resolver = url_request_context_getter()
-                          ->GetURLRequestContext()
-                          ->host_resolver();
   job_factory->SetProtocolHandler(
-      url::kFtpScheme, new net::FtpProtocolHandler(
-          new net::FtpNetworkLayer(host_resolver)));
-  */
+      url::kFtpScheme, new FtpProtocolHandler());
 
   return job_factory;
 }

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -38,6 +38,8 @@ class AtomBrowserContext : public brightray::BrowserContext {
   AtomURLRequestJobFactory* job_factory() const { return job_factory_; }
 
  private:
+  AtomURLRequestJobFactory* CreateJobFactory();
+
   scoped_ptr<AtomDownloadManagerDelegate> download_manager_delegate_;
   scoped_ptr<WebViewManager> guest_manager_;
 

--- a/atom/browser/net/ftp_protocol_handler.cc
+++ b/atom/browser/net/ftp_protocol_handler.cc
@@ -1,0 +1,29 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/net/ftp_protocol_handler.h"
+
+#include "net/url_request/url_request_context.h"
+#include "net/ftp/ftp_network_layer.h"
+
+namespace atom {
+
+FtpProtocolHandler::FtpProtocolHandler() {
+}
+
+FtpProtocolHandler::~FtpProtocolHandler() {
+}
+
+net::URLRequestJob* FtpProtocolHandler::MaybeCreateJob(
+    net::URLRequest* request,
+    net::NetworkDelegate* network_delegate) const {
+  if (!orig_protocol_handler_) {
+    auto host_resolver = request->context()->host_resolver();
+    orig_protocol_handler_.reset(new net::FtpProtocolHandler(
+        new net::FtpNetworkLayer(host_resolver)));
+  }
+  return orig_protocol_handler_->MaybeCreateJob(request, network_delegate);
+}
+
+}  // namespace atom

--- a/atom/browser/net/ftp_protocol_handler.h
+++ b/atom/browser/net/ftp_protocol_handler.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_NET_FTP_PROTOCOL_HANDLER_H_
+#define ATOM_BROWSER_NET_FTP_PROTOCOL_HANDLER_H_
+
+#include <string>
+
+#include "net/url_request/url_request_job_factory.h"
+#include "net/url_request/ftp_protocol_handler.h"
+#include "base/memory/scoped_ptr.h"
+
+namespace atom {
+
+class FtpProtocolHandler : public net::URLRequestJobFactory::ProtocolHandler {
+ public:
+  FtpProtocolHandler();
+  virtual ~FtpProtocolHandler();
+
+  // net::URLRequestJobFactory::ProtocolHandler:
+  net::URLRequestJob* MaybeCreateJob(
+      net::URLRequest* request,
+      net::NetworkDelegate* network_delegate) const override;
+
+ private:
+  mutable scoped_ptr<net::FtpProtocolHandler> orig_protocol_handler_;
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_NET_FTP_PROTOCOL_HANDLER_H_

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -156,6 +156,8 @@
       'atom/browser/net/atom_url_request_job_factory.h',
       'atom/browser/net/http_protocol_handler.cc',
       'atom/browser/net/http_protocol_handler.h',
+      'atom/browser/net/ftp_protocol_handler.cc',
+      'atom/browser/net/ftp_protocol_handler.h',
       'atom/browser/net/url_request_string_job.cc',
       'atom/browser/net/url_request_string_job.h',
       'atom/browser/net/url_request_buffer_job.cc',


### PR DESCRIPTION
In #2384 , I found that `interceptProtocol` for builtin protocols only works after at least one `BrowserWindow` is created.

This PR fixes this, by moving initialization of protocol handlers into `AtomBrowserContext` constructor, instead of `AtomBrowserContext::CreateURLRequestJobFactory` (and adding `atom::FtpProtocolHandler`).