### PR TITLE
Add a comment to build instructions about cpplint

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -106,14 +106,22 @@ Make sure you have installed all the build dependencies.
 
 ### error while loading shared libraries: libtinfo.so.5
 
-Prebulit `clang` will try to link to `libtinfo.so.5`. Depending on the host architecture,
-symlink to appropirate `libncurses`
+Prebulit `clang` will try to link to `libtinfo.so.5`. Depending on the host
+architecture, symlink to appropriate `libncurses`
 
 ```bash
 $ sudo ln -s /usr/lib/libncurses.so.5 /usr/lib/libtinfo.so.5
 ```
 
 ## Tests
+
+Test your changes confirm to the project coding style using:
+
+```bash
+$ ./script/cpplint.py
+```
+
+Test functionality using:
 
 ```bash
 $ ./script/test.py

--- a/docs/development/build-instructions-mac.md
+++ b/docs/development/build-instructions-mac.md
@@ -51,6 +51,14 @@ support 32bit OS X in future.
 
 ## Tests
 
+Test your changes confirm to the project coding style using:
+
+```bash
+$ ./script/cpplint.py
+```
+
+Test functionality using:
+
 ```bash
 $ ./script/test.py
 ```

--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -67,6 +67,14 @@ The other building steps are exactly the same.
 
 ## Tests
 
+Test your changes confirm to the project coding style using:
+
+```powershell
+python script\cpplint.py
+```
+
+Test functionality using:
+
 ```powershell
 python script\test.py
 ```


### PR DESCRIPTION
I added a mention of `cpplint.py` in each build instructions.
The reason, is because it's easy to miss it's existence (I did). Even if you noticed it's mentioned in `coding-style.md` you might mistakenly think that `test.py` runs it, so it's better to be explicit about it. Hopefully it will reduce the number of commits with style issues.