### PR TITLE
Upload node headers with new filenames

### DIFF
--- a/script/upload-checksums.py
+++ b/script/upload-checksums.py
@@ -40,6 +40,7 @@ def get_files_list(version):
   return [
     'node-{0}.tar.gz'.format(version),
     'iojs-{0}.tar.gz'.format(version),
+    'iojs-{0}-headers.tar.gz'.format(version),
     'node.lib',
     'x64/node.lib',
     'win-x86/iojs.lib',

--- a/script/upload-node-headers.py
+++ b/script/upload-node-headers.py
@@ -40,11 +40,15 @@ def main():
   args = parse_args()
   node_headers_dir = os.path.join(DIST_DIR, 'node-{0}'.format(args.version))
   iojs_headers_dir = os.path.join(DIST_DIR, 'iojs-{0}'.format(args.version))
+  iojs2_headers_dir = os.path.join(DIST_DIR,
+                                   'iojs-{0}-headers'.format(args.version))
 
   copy_headers(node_headers_dir)
   create_header_tarball(node_headers_dir)
   copy_headers(iojs_headers_dir)
   create_header_tarball(iojs_headers_dir)
+  copy_headers(iojs2_headers_dir)
+  create_header_tarball(iojs2_headers_dir)
 
   # Upload node's headers to S3.
   bucket, access_key, secret_key = s3_config()


### PR DESCRIPTION
Now we upload:
* iojs-v0.30.3-headers.tar.gz
* iojs-v0.30.3.tar.gz
* node-v0.30.3.tar.gz
* node.lib
* x64/node.lib
* win-x86/iojs.lib
* win-x64/iojs.lib

to make all versions of npm and node-gyp happy. Will we have more in future?

Fixes https://github.com/atom/electron/issues/2430.