### PR TITLE
Delay the call of element resize callback to next tick

### DIFF
--- a/atom/renderer/guest_view_container.cc
+++ b/atom/renderer/guest_view_container.cc
@@ -7,6 +7,7 @@
 #include <map>
 
 #include "base/lazy_instance.h"
+#include "ui/gfx/geometry/size.h"
 
 namespace atom {
 
@@ -51,7 +52,9 @@ void GuestViewContainer::DidResizeElement(const gfx::Size& old_size,
   if (element_resize_callback_.is_null())
     return;
 
-  element_resize_callback_.Run(old_size, new_size);
+  base::MessageLoop::current()->PostTask(
+      FROM_HERE,
+      base::Bind(element_resize_callback_, old_size, new_size));
 }
 
 }  // namespace atom


### PR DESCRIPTION
Chromium explicitly disables running JavaScript when resizing a DOM node, previously we were violating this rule when calling the element resize callback, and we were fine because this rule was not strongly checked. But after we started to use `V8RecursionScope` Electron began to crash, since `V8RecursionScope` asserts whether JavaScript is disabled. 

The whole disabling JavaScript thing is blink-internal and not related to users' preferences, so simply avoiding calling element resize callback when DOM node is being resized is a fine fix here.

Fixes #2450.