### PR TITLE
Switch to Contributor Covenant from Open Code of Conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 :+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
 
-This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
-[code-of-conduct]: http://todogroup.org/opencodeofconduct/#Electron/opensource@github.com
+This project adheres to the [Contributor Covenant 1.2](http://contributor-covenant.org/version/1/2/0).
+By participating, you are expected to uphold this code. Please report unacceptable behavior to atom@github.com.
 
 The following is a set of guidelines for contributing to Electron.
 These are just guidelines, not rules, use your best judgment and feel free to

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ editor](https://github.com/atom/atom).
 Follow [@ElectronJS](https://twitter.com/electronjs) on Twitter for important
 announcements.
 
-This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
-[code-of-conduct]: http://todogroup.org/opencodeofconduct/#Electron/opensource@github.com
+This project adheres to the [Contributor Covenant 1.2](http://contributor-covenant.org/version/1/2/0).
+By participating, you are expected to uphold this code. Please report unacceptable behavior to atom@github.com.
 
 ## Downloads
 


### PR DESCRIPTION
Switch to the [Contributor Covenant](http://contributor-covenant.org/version/1/2/0/) from the [Open Code of Conduct](http://todogroup.org/opencodeofconduct).

See https://github.com/todogroup/opencodeofconduct/issues/84 for more details.

See [here](http://contributor-covenant.org/#who) for other projects using the Contributor Covenant.

Refs https://github.com/atom/atom/pull/8312