### PR TITLE
Fix printBackgrounds option name inconsistency

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -93,7 +93,7 @@ struct Converter<PrintSettings> {
     if (!ConvertFromV8(isolate, val, &dict))
       return false;
     dict.Get("silent", &(out->silent));
-    dict.Get("printBackground", &(out->print_background));
+    dict.Get("printBackgrounds", &(out->print_background));
     return true;
   }
 };

--- a/atom/browser/api/lib/web-contents.coffee
+++ b/atom/browser/api/lib/web-contents.coffee
@@ -98,7 +98,7 @@ wrapWebContents = (webContents) ->
     if options.printSelectionOnly
       printingSetting.shouldPrintSelectionOnly = options.printSelectionOnly
     if options.printBackgrounds
-      printingSetting.shouldPrintBackgrounds = options.printBackground
+      printingSetting.shouldPrintBackgrounds = options.printBackgrounds
 
     if options.pageSize and PDFPageSize[options.pageSize]
       printingSetting.mediaSize = PDFPageSize[options.pageSize]

--- a/docs/api/browser-window-ko.md
+++ b/docs/api/browser-window-ko.md
@@ -960,14 +960,14 @@ when the JS promise is rejected.
 
 * `options` Object
   * `silent` Boolean - Don't ask user for print settings, defaults to `false`
-  * `printBackground` Boolean - Also prints the background color and image of
+  * `printBackgrounds` Boolean - Also prints the background color and image of
     the web page, defaults to `false`.
 
 Prints window's web page. When `silent` is set to `false`, Electron will pick
 up system's default printer and default settings for printing.
 
 Calling `window.print()` in web page is equivalent to call
-`WebContents.print({silent: false, printBackground: false})`.
+`WebContents.print({silent: false, printBackgrounds: false})`.
 
 **Note:** On Windows, the print API relies on `pdf.dll`. If your application
 doesn't need print feature, you can safely remove `pdf.dll` in saving binary
@@ -980,7 +980,7 @@ size.
     * 0 - default
     * 1 - none
     * 2 - minimum
-  * `printBackground` Boolean - Whether to print CSS backgrounds.
+  * `printBackgrounds` Boolean - Whether to print CSS backgrounds.
   * `printSelectionOnly` Boolean - Whether to print selection only.
   * `landscape` Boolean - `true` for landscape, `false` for portrait.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1026,14 +1026,14 @@ when the JS promise is rejected.
 
 * `options` Object
   * `silent` Boolean - Don't ask user for print settings, defaults to `false`
-  * `printBackground` Boolean - Also prints the background color and image of
+  * `printBackgrounds` Boolean - Also prints the background color and image of
     the web page, defaults to `false`.
 
 Prints window's web page. When `silent` is set to `false`, Electron will pick
 up system's default printer and default settings for printing.
 
 Calling `window.print()` in web page is equivalent to call
-`WebContents.print({silent: false, printBackground: false})`.
+`WebContents.print({silent: false, printBackgrounds: false})`.
 
 **Note:** On Windows, the print API relies on `pdf.dll`. If your application
 doesn't need print feature, you can safely remove `pdf.dll` in saving binary
@@ -1052,7 +1052,7 @@ size.
     * `Legal`
     * `Letter`
     * `Tabloid`
-  * `printBackground` Boolean - Whether to print CSS backgrounds.
+  * `printBackgrounds` Boolean - Whether to print CSS backgrounds.
   * `printSelectionOnly` Boolean - Whether to print selection only.
   * `landscape` Boolean - `true` for landscape, `false` for portrait.
 


### PR DESCRIPTION
`printBackgrounds` was sometimes written with an `s` and sometimes not.