### PR TITLE
Update browser-window.md

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -141,7 +141,7 @@ window.onbeforeunload = function(e) {
   // prompted to confirm the page unload, Electron gives developers more options.
   // Returning empty string or false would prevent the unloading now.
   // You can also use the dialog API to let the user confirm closing the application.
-  return false;
+  e.returnValue = false;
 };
 ```
 


### PR DESCRIPTION
Update the `beforeunload` example to use `e.returnValue = false` instead of `return false`, since `e.returnValue` always works while the `return` works only in certain conditions. See #2481 for details.