### PR TITLE
webContents: exit tabbed fullscreen when esc key is pressed

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -277,7 +277,10 @@ bool WebContents::IsPopupOrPanel(const content::WebContents* source) const {
 void WebContents::HandleKeyboardEvent(
     content::WebContents* source,
     const content::NativeWebKeyboardEvent& event) {
-  if (type_ == BROWSER_WINDOW) {
+  if (event.windowsKeyCode == ui::VKEY_ESCAPE && is_html_fullscreen()) {
+    // Escape exits tabbed fullscreen mode.
+    ExitFullscreenModeForTab(source);
+  } else if (type_ == BROWSER_WINDOW) {
     owner_window()->HandleKeyboardEvent(source, event);
   } else if (type_ == WEB_VIEW && guest_delegate_) {
     // Send the unhandled keyboard events back to the embedder.

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -48,6 +48,8 @@ class CommonWebContentsDelegate
 
   NativeWindow* owner_window() const { return owner_window_.get(); }
 
+  bool is_html_fullscreen() const { return html_fullscreen_; }
+
  protected:
   // content::WebContentsDelegate:
   content::WebContents* OpenURLFromTab(


### PR DESCRIPTION
Fixes #2517 