### PR TITLE
Updating Browser Window Documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,8 @@ Modules for the main process:
 * [power-monitor](api/power-monitor.md)
 * [power-save-blocker](api/power-save-blocker.md)
 * [protocol](api/protocol.md)
+* [session](api/session.md)
+* [webContents](api/web-contents.md)
 * [tray](api/tray.md)
 
 Modules for the renderer process (web page):

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -117,6 +117,8 @@ Properties `width` and `height` are required.
 
 The `BrowserWindow` object emits the following events:
 
++**Note** Some events are only available on specific operating systems and are labeled as such.
+
 ### Event: 'page-title-updated'
 
 Returns:
@@ -289,6 +291,8 @@ Remove the devtools extension whose name is `name`.
 ## Instance Methods
 
 Objects created with `new BrowserWindow` have the following instance methods:
+
++**Note** Some methods are only available on specific operating systems and are labeled as such.
 
 ```javascript
 var BrowserWindow = require('browser-window');

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1,7 +1,6 @@
-# browser-window
+# BrowserWindow
 
-The `BrowserWindow` class gives you ability to create a browser window, an
-example is:
+The `BrowserWindow` class gives you the ability to create a browser window, for example:
 
 ```javascript
 var BrowserWindow = require('browser-window');
@@ -15,7 +14,7 @@ win.loadUrl('https://github.com');
 win.show();
 ```
 
-You can also create a window without chrome by using
+You can also create a window without Chrome by using
 [Frameless Window](frameless-window.md) API.
 
 ## Class: BrowserWindow
@@ -23,97 +22,103 @@ You can also create a window without chrome by using
 `BrowserWindow` is an
 [EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter).
 
-### new BrowserWindow(options)
+It creates a new `BrowserWindow` with native properties as set by the `options`.
+Properties `width` and `height` are required.
 
-* `options` Object
-  * `x` Integer - Window's left offset to screen
-  * `y` Integer - Window's top offset to screen
-  * `width` Integer - Window's width
-  * `height` Integer - Window's height
-  * `use-content-size` Boolean - The `width` and `height` would be used as web
-     page's size, which means the actual window's size will include window
-     frame's size and be slightly larger.
-  * `center` Boolean - Show window in the center of the screen
-  * `min-width` Integer - Minimum width
-  * `min-height` Integer - Minimum height
-  * `max-width` Integer - Maximum width
-  * `max-height` Integer - Maximum height
-  * `resizable` Boolean - Whether window is resizable
-  * `always-on-top` Boolean - Whether the window should always stay on top of
-     other windows
-  * `fullscreen` Boolean - Whether the window should show in fullscreen, when
-    set to `false` the fullscreen button would also be hidden on OS X
-  * `skip-taskbar` Boolean - Do not show window in taskbar
-  * `zoom-factor` Number - The default zoom factor of the page, zoom factor is
-    zoom percent / 100, so `3.0` represents `300%`
-  * `kiosk` Boolean - The kiosk mode
-  * `title` String - Default window title
-  * `icon` [NativeImage](native-image.md) - The window icon, when omitted on
-    Windows the executable's icon would be used as window icon
-  * `show` Boolean - Whether window should be shown when created
-  * `frame` Boolean - Specify `false` to create a
-    [Frameless Window](frameless-window.md)
-  * `node-integration` Boolean - Whether node integration is enabled, default
-    is `true`
-  * `accept-first-mouse` Boolean - Whether the web view accepts a single
-    mouse-down event that simultaneously activates the window
-  * `disable-auto-hide-cursor` Boolean - Do not hide cursor when typing
-  * `auto-hide-menu-bar` Boolean - Auto hide the menu bar unless the `Alt`
-    key is pressed.
-  * `enable-larger-than-screen` Boolean - Enable the window to be resized larger
-    than screen.
-  * `dark-theme` Boolean - Forces using dark theme for the window, only works on
-    some GTK+3 desktop environments
-  * `preload` String - Specifies a script that will be loaded before other
-    scripts run in the window. This script will always have access to node APIs
-    no matter whether node integration is turned on for the window, and the path
-    of `preload` script has to be absolute path.
-  * `transparent` Boolean - Makes the window [transparent](frameless-window.md)
-  * `type` String - Specifies the type of the window, possible types are
-    `desktop`, `dock`, `toolbar`, `splash`, `notification`. This only works on
-    Linux.
-  * `standard-window` Boolean - Uses the OS X's standard window instead of the
-    textured window. Defaults to `true`.
-  * `web-preferences` Object - Settings of web page's features
-    * `javascript` Boolean
-    * `web-security` Boolean - When setting `false`, it will disable the same-origin
-      policy(Usually using testing websites by people), and set `allow_displaying_insecure_content`
-      and `allow_running_insecure_content` to `true` if these two options are not
-      set by user.
-    * `allow-displaying-insecure-content` Boolean - Allow a https page to display
-      content like image from http URLs.
-    * `allow-running-insecure-content` Boolean - Allow a https page to run JavaScript,
-      CSS or plugins from http URLs.
-    * `images` Boolean
-    * `java` Boolean
-    * `text-areas-are-resizable` Boolean
-    * `webgl` Boolean
-    * `webaudio` Boolean
-    * `plugins` Boolean - Whether plugins should be enabled, currently only
-      `NPAPI` plugins are supported.
-    * `extra-plugin-dirs` Array - Array of paths that would be searched for
-      plugins. Note that if you want to add a directory under your app, you
-      should use `__dirname` or `process.resourcesPath` to join the paths to
-      make them absolute, using relative paths would make Electron search
-      under current working directory.
-    * `experimental-features` Boolean
-    * `experimental-canvas-features` Boolean
-    * `subpixel-font-scaling` Boolean
-    * `overlay-scrollbars` Boolean
-    * `overlay-fullscreen-video` Boolean
-    * `shared-worker` Boolean
-    * `direct-write` Boolean - Whether the DirectWrite font rendering system on
-       Windows is enabled
-    * `page-visibility` Boolean - Page would be forced to be always in visible
-       or hidden state once set, instead of reflecting current window's
-       visibility. Users can set it to `true` to prevent throttling of DOM
-       timers.
+### `new BrowserWindow(options)`
 
-Creates a new `BrowserWindow` with native properties set by the `options`.
-Usually you only need to set the `width` and `height`, other properties will
-have decent default values.
+`options` Object, properties:
+
+* `width` Integer **required** - Window's width.
+* `height` Integer **required** - Window's height.
+* `x` Integer - Window's left offset from screen.
+* `y` Integer - Window's top offset from screen.
+* `use-content-size` Boolean - The `width` and `height` would be used as web
+   page's size, which means the actual window's size will include window
+   frame's size and be slightly larger.
+* `center` Boolean - Show window in the center of the screen.
+* `min-width` Integer - Window's minimum width.
+* `min-height` Integer - Window's minimum height.
+* `max-width` Integer - Window's maximum width.
+* `max-height` Integer - Window's maximum height.
+* `resizable` Boolean - Whether window is resizable.
+* `always-on-top` Boolean - Whether the window should always stay on top of
+   other windows.
+* `fullscreen` Boolean - Whether the window should show in fullscreen. When
+  set to `false` the fullscreen button will also be hidden on OS X.
+* `skip-taskbar` Boolean - Whether to show the window in taskbar.
+* `zoom-factor` Number - The default zoom factor of the page, `3.0` represents
+`300%`.
+* `kiosk` Boolean - The kiosk mode.
+* `title` String - Default window title.
+* `icon` [NativeImage](native-image.md) - The window icon, when omitted on
+  Windows the executable's icon would be used as window icon.
+* `show` Boolean - Whether window should be shown when created.
+* `frame` Boolean - Specify `false` to create a
+[Frameless Window](frameless-window.md).
+* `node-integration` Boolean - Whether node integration is enabled. Default
+  is `true`.
+* `accept-first-mouse` Boolean - Whether the web view accepts a single
+  mouse-down event that simultaneously activates the window.
+* `disable-auto-hide-cursor` Boolean - Whether to hide cursor when typing.
+* `auto-hide-menu-bar` Boolean - Auto hide the menu bar unless the `Alt`
+  key is pressed.
+* `enable-larger-than-screen` Boolean - Enable the window to be resized larger
+  than screen.
+* `dark-theme` Boolean - Forces using dark theme for the window, only works on
+  some GTK+3 desktop environments.
+* `preload` String - Specifies a script that will be loaded before other
+  scripts run in the window. This script will always have access to node APIs
+  no matter whether node integration is turned on for the window, and the path
+  of `preload` script has to be absolute path.
+* `transparent` Boolean - Makes the window [transparent](frameless-window.md).
+* `type` String - Specifies the type of the window, possible types are
+  `desktop`, `dock`, `toolbar`, `splash`, `notification`. This only works on
+  Linux.
+* `standard-window` Boolean - Uses the OS X's standard window instead of the
+  textured window. Defaults to `true`.
+* `web-preferences` Object - Settings of web page's features, properties:
+  * `javascript` Boolean
+  * `web-security` Boolean - When setting `false`, it will disable the same-origin
+    policy (Usually using testing websites by people), and set `allow_displaying_insecure_content`
+    and `allow_running_insecure_content` to `true` if these two options are not
+    set by user.
+  * `allow-displaying-insecure-content` Boolean - Allow an https page to display
+    content like images from http URLs.
+  * `allow-running-insecure-content` Boolean - Allow a https page to run JavaScript,
+    CSS or plugins from http URLs.
+  * `images` Boolean
+  * `java` Boolean
+  * `text-areas-are-resizable` Boolean
+  * `webgl` Boolean
+  * `webaudio` Boolean
+  * `plugins` Boolean - Whether plugins should be enabled, currently only
+    `NPAPI` plugins are supported.
+  * `extra-plugin-dirs` Array - Array of paths that would be searched for
+    plugins. Note that if you want to add a directory under your app, you
+    should use `__dirname` or `process.resourcesPath` to join the paths to
+    make them absolute, using relative paths would make Electron search
+    under current working directory.
+  * `experimental-features` Boolean
+  * `experimental-canvas-features` Boolean
+  * `subpixel-font-scaling` Boolean
+  * `overlay-scrollbars` Boolean
+  * `overlay-fullscreen-video` Boolean
+  * `shared-worker` Boolean
+  * `direct-write` Boolean - Whether the DirectWrite font rendering system on
+     Windows is enabled.
+  * `page-visibility` Boolean - Page would be forced to be always in visible
+     or hidden state once set, instead of reflecting current window's
+     visibility. Users can set it to `true` to prevent throttling of DOM
+     timers.
+
+## Events
+
+The `BrowserWindow` object emits the following events:
 
 ### Event: 'page-title-updated'
+
+Returns:
 
 * `event` Event
 
@@ -122,16 +127,18 @@ would prevent the native window's title to change.
 
 ### Event: 'close'
 
+Returns:
+
 * `event` Event
 
 Emitted when the window is going to be closed. It's emitted before the
-`beforeunload` and `unload` event of DOM, calling `event.preventDefault()`
-would cancel the close.
+`beforeunload` and `unload` event of the DOM. Calling `event.preventDefault()`
+will cancel the close.
 
 Usually you would want to use the `beforeunload` handler to decide whether the
 window should be closed, which will also be called when the window is
 reloaded. In Electron, returning an empty string or `false` would cancel the
-close. An example is:
+close. For example:
 
 ```javascript
 window.onbeforeunload = function(e) {
@@ -139,7 +146,7 @@ window.onbeforeunload = function(e) {
 
   // Unlike usual browsers, in which a string should be returned and the user is
   // prompted to confirm the page unload, Electron gives developers more options.
-  // Returning empty string or false would prevent the unloading now.
+  // Returning an empty string or false will prevent the unloading.
   // You can also use the dialog API to let the user confirm closing the application.
   e.returnValue = false;
 };
@@ -160,11 +167,11 @@ Emitted when the unresponsive web page becomes responsive again.
 
 ### Event: 'blur'
 
-Emitted when window loses focus.
+Emitted when the window loses focus.
 
 ### Event: 'focus'
 
-Emitted when window gains focus.
+Emitted when the window gains focus.
 
 ### Event: 'maximize'
 
@@ -172,19 +179,19 @@ Emitted when window is maximized.
 
 ### Event: 'unmaximize'
 
-Emitted when window exits from maximized state.
+Emitted when the window exits from maximized state.
 
 ### Event: 'minimize'
 
-Emitted when window is minimized.
+Emitted when the window is minimized.
 
 ### Event: 'restore'
 
-Emitted when window is restored from minimized state.
+Emitted when the window is restored from minimized state.
 
 ### Event: 'resize'
 
-Emitted when window is getting resized.
+Emitted when the window is getting resized.
 
 ### Event: 'move'
 
@@ -200,19 +207,19 @@ __Note__: This event is available only on OS X.
 
 ### Event: 'enter-full-screen'
 
-Emitted when window enters full screen state.
+Emitted when the window enters full screen state.
 
 ### Event: 'leave-full-screen'
 
-Emitted when window leaves full screen state.
+Emitted when the window leaves full screen state.
 
 ### Event: 'enter-html-full-screen'
 
-Emitted when window enters full screen state triggered by html api.
+Emitted when the window enters full screen state triggered by html api.
 
 ### Event: 'leave-html-full-screen'
 
-Emitted when window leaves full screen state triggered by html api.
+Emitted when the window leaves full screen state triggered by html api.
 
 ### Event: 'devtools-opened'
 
@@ -228,7 +235,7 @@ Emitted when devtools is focused / opened.
 
 ### Event: 'app-command':
 
-Emitted when an [App Command](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646275(v=vs.85).aspx) is invoked. These are typically related to keyboard media keys or browser commands, as well as the "Back" button built into some mice on Windows.
+Emitted when an [App Command](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646275(v=vs.85).aspx is invoked. These are typically related to keyboard media keys or browser commands, as well as the "Back" button built into some mice on Windows.
 
 ```js
 someWindow.on('app-command', function(e, cmd) {
@@ -241,27 +248,31 @@ someWindow.on('app-command', function(e, cmd) {
 
 __Note__: This event is only fired on Windows.
 
-### Class Method: BrowserWindow.getAllWindows()
+## Methods
+
+The `BrowserWindow` object has the following methods:
+
+### `BrowserWindow.getAllWindows()`
 
 Returns an array of all opened browser windows.
 
-### Class Method: BrowserWindow.getFocusedWindow()
+### `BrowserWindow.getFocusedWindow()`
 
 Returns the window that is focused in this application.
 
-### Class Method: BrowserWindow.fromWebContents(webContents)
+### `BrowserWindow.fromWebContents(webContents)`
 
-* `webContents` WebContents
+* `webContents` [WebContents](#webcontents)
 
-Find a window according to the `webContents` it owns
+Find a window according to the `webContents` it owns.
 
-### Class Method: BrowserWindow.fromId(id)
+### `BrowserWindow.fromId(id)`
 
 * `id` Integer
 
 Find a window according to its ID.
 
-### Class Method: BrowserWindow.addDevToolsExtension(path)
+### `BrowserWindow.addDevToolsExtension(path)`
 
 * `path` String
 
@@ -270,186 +281,201 @@ Adds devtools extension located at `path`, and returns extension's name.
 The extension will be remembered so you only need to call this API once, this
 API is not for programming use.
 
-### Class Method: BrowserWindow.removeDevToolsExtension(name)
+### `BrowserWindow.removeDevToolsExtension(name)`
 
 * `name` String
 
 Remove the devtools extension whose name is `name`.
 
-### BrowserWindow.webContents
+## Instance Methods
+
+Objects created with `new BrowserWindow` have the following instance methods:
+
+```javascript
+var BrowserWindow = require('browser-window');
+
+// In this example `win` is our instance
+var win = new BroswerWindow({width: 800, height: 1500});
+
+```
+
+### `win.webContents`
 
 The `WebContents` object this window owns, all web page related events and
-operations would be done via it.
+operations will be done via it.
+
+See the [`webContents` documentation](web-contents.md) for its methods and events.
 
 **Note:** Users should never store this object because it may become `null`
 when the renderer process (web page) has crashed.
 
-### BrowserWindow.devToolsWebContents
+### `win.devToolsWebContents`
 
-Get the `WebContents` of devtools of this window.
+Get the `WebContents` of devtools for this window.
 
 **Note:** Users should never store this object because it may become `null`
 when the devtools has been closed.
 
-### BrowserWindow.id
+### `win.id`
 
 Get the unique ID of this window.
 
-### BrowserWindow.destroy()
+### `win.destroy()`
 
 Force closing the window, the `unload` and `beforeunload` event won't be emitted
-for the web page, and `close` event would also not be emitted
-for this window, but it would guarantee the `closed` event to be emitted.
+for the web page, and `close` event will also not be emitted
+for this window, but it guarantees the `closed` event will be emitted.
 
 You should only use this method when the renderer process (web page) has crashed.
 
-### BrowserWindow.close()
+### `win.close()`
 
 Try to close the window, this has the same effect with user manually clicking
 the close button of the window. The web page may cancel the close though, see
 the [close event](#event-close).
 
-### BrowserWindow.focus()
+### `win.focus()`
 
 Focus on the window.
 
-### BrowserWindow.isFocused()
+### `win.isFocused()`
 
-Returns whether the window is focused.
+Returns a boolean, whether the window is focused.
 
-### BrowserWindow.show()
+### `win.show()`
 
 Shows and gives focus to the window.
 
-### BrowserWindow.showInactive()
+### `win.showInactive()`
 
 Shows the window but doesn't focus on it.
 
-### BrowserWindow.hide()
+### `win.hide()`
 
 Hides the window.
 
-### BrowserWindow.isVisible()
+### `win.isVisible()`
 
-Returns whether the window is visible to the user.
+Returns a boolean, whether the window is visible to the user.
 
-### BrowserWindow.maximize()
+### `win.maximize()`
 
 Maximizes the window.
 
-### BrowserWindow.unmaximize()
+### `win.unmaximize()`
 
 Unmaximizes the window.
 
-### BrowserWindow.isMaximized()
+### `win.isMaximized()`
 
-Returns whether the window is maximized.
+Returns a boolean, whether the window is maximized.
 
-### BrowserWindow.minimize()
+### `win.minimize()`
 
 Minimizes the window. On some platforms the minimized window will be shown in
 the Dock.
 
-### BrowserWindow.restore()
+### `win.restore()`
 
 Restores the window from minimized state to its previous state.
 
-### BrowserWindow.isMinimized()
+### `win.isMinimized()`
 
-Returns whether the window is minimized.
+Returns a boolean, whether the window is minimized.
 
-### BrowserWindow.setFullScreen(flag)
+### `win.setFullScreen(flag)`
 
 * `flag` Boolean
 
 Sets whether the window should be in fullscreen mode.
 
-### BrowserWindow.isFullScreen()
+### `win.isFullScreen()`
 
-Returns whether the window is in fullscreen mode.
+Returns a boolean, whether the window is in fullscreen mode.
 
-### BrowserWindow.setAspectRatio(aspectRatio[, extraSize])
+### `win.setAspectRatio(aspectRatio[, extraSize])`
 
 * `aspectRatio` The aspect ratio we want to maintain for some portion of the content view.
-* `rect` Object - The extra size to not be included in the aspect ratio to be maintained.
+* `rect` Object - The extra size to not be included in the aspect ratio to be maintained. Properties:
   * `width` Integer
   * `height` Integer
 
-This will have a window maintain an aspect ratio. The extra size allows a developer to be able to have space, specifified in pixels, not included within the aspect ratio calculations. This API already takes into account the difference between a window's size and it's content size.
+This will have a window maintain an aspect ratio. The extra size allows a developer to have space, specified in pixels, not included within the aspect ratio calculations. This API already takes into account the difference between a window's size and its content size.
 
-Consider a normal window with an HD video player and associated controls. Perhaps there are 15 pixels of controls on the left edge, 25 pixels of controls on the right edge and 50 pixels of controls below the player. In order to maintain a 16:9 aspect ratio (standard aspect ratio for HD @1920x1080) within the player itself we would call this function with arguments of 16/9 and [ 40, 50 ]. The second argument doesn't care where the extra width and height are within the content view — only that they exist. Just sum any extra width and height areas you have within the overall content view.
+Consider a normal window with an HD video player and associated controls. Perhaps there are 15 pixels of controls on the left edge, 25 pixels of controls on the right edge and 50 pixels of controls below the player. In order to maintain a 16:9 aspect ratio (standard aspect ratio for HD @1920x1080) within the player itself we would call this function with arguments of 16/9 and [ 40, 50 ]. The second argument doesn't care where the extra width and height are within the content view--only that they exist. Just sum any extra width and height areas you have within the overall content view.
 
 __Note__: This API is only implemented on OS X.
 
-### BrowserWindow.setBounds(options)
+### `win.setBounds(options)`
 
-* `options` Object
-  * `x` Integer
-  * `y` Integer
-  * `width` Integer
-  * `height` Integer
+`options` Object, properties:
+
+* `x` Integer
+* `y` Integer
+* `width` Integer
+* `height` Integer
 
 Resizes and moves the window to `width`, `height`, `x`, `y`.
 
-### BrowserWindow.getBounds()
+### `win.getBounds()`
 
 Returns an object that contains window's width, height, x and y values.
 
-### BrowserWindow.setSize(width, height)
+### `win.setSize(width, height)`
 
 * `width` Integer
 * `height` Integer
 
 Resizes the window to `width` and `height`.
 
-### BrowserWindow.getSize()
+### `win.getSize()`
 
 Returns an array that contains window's width and height.
 
-### BrowserWindow.setContentSize(width, height)
+### `win.setContentSize(width, height)`
 
 * `width` Integer
 * `height` Integer
 
 Resizes the window's client area (e.g. the web page) to `width` and `height`.
 
-### BrowserWindow.getContentSize()
+### `win.getContentSize()`
 
 Returns an array that contains window's client area's width and height.
 
-### BrowserWindow.setMinimumSize(width, height)
+### `win.setMinimumSize(width, height)`
 
 * `width` Integer
 * `height` Integer
 
 Sets the minimum size of window to `width` and `height`.
 
-### BrowserWindow.getMinimumSize()
+### `win.getMinimumSize()`
 
 Returns an array that contains window's minimum width and height.
 
-### BrowserWindow.setMaximumSize(width, height)
+### `win.setMaximumSize(width, height)`
 
 * `width` Integer
 * `height` Integer
 
 Sets the maximum size of window to `width` and `height`.
 
-### BrowserWindow.getMaximumSize()
+### `win.getMaximumSize()`
 
 Returns an array that contains window's maximum width and height.
 
-### BrowserWindow.setResizable(resizable)
+### `win.setResizable(resizable)`
 
 * `resizable` Boolean
 
 Sets whether the window can be manually resized by user.
 
-### BrowserWindow.isResizable()
+### `win.isResizable()`
 
 Returns whether the window can be manually resized by user.
 
-### BrowserWindow.setAlwaysOnTop(flag)
+### `win.setAlwaysOnTop(flag)`
 
 * `flag` Boolean
 
@@ -457,61 +483,61 @@ Sets whether the window should show always on top of other windows. After
 setting this, the window is still a normal window, not a toolbox window which
 can not be focused on.
 
-### BrowserWindow.isAlwaysOnTop()
+### `win.isAlwaysOnTop()`
 
 Returns whether the window is always on top of other windows.
 
-### BrowserWindow.center()
+### `win.center()`
 
 Moves window to the center of the screen.
 
-### BrowserWindow.setPosition(x, y)
+### `win.setPosition(x, y)`
 
 * `x` Integer
 * `y` Integer
 
 Moves window to `x` and `y`.
 
-### BrowserWindow.getPosition()
+### `win.getPosition()`
 
 Returns an array that contains window's current position.
 
-### BrowserWindow.setTitle(title)
+### `win.setTitle(title)`
 
 * `title` String
 
 Changes the title of native window to `title`.
 
-### BrowserWindow.getTitle()
+### `win.getTitle()`
 
 Returns the title of the native window.
 
 **Note:** The title of web page can be different from the title of the native
 window.
 
-### BrowserWindow.flashFrame(flag)
+### `win.flashFrame(flag)`
 
 * `flag` Boolean
 
 Starts or stops flashing the window to attract user's attention.
 
-### BrowserWindow.setSkipTaskbar(skip)
+### `win.setSkipTaskbar(skip)`
 
 * `skip` Boolean
 
 Makes the window not show in the taskbar.
 
-### BrowserWindow.setKiosk(flag)
+### `win.setKiosk(flag)`
 
 * `flag` Boolean
 
 Enters or leaves the kiosk mode.
 
-### BrowserWindow.isKiosk()
+### `win.isKiosk()`
 
 Returns whether the window is in kiosk mode.
 
-### BrowserWindow.setRepresentedFilename(filename)
+### `win.setRepresentedFilename(filename)`
 
 * `filename` String
 
@@ -520,13 +546,13 @@ will show in window's title bar.
 
 __Note__: This API is only available on OS X.
 
-### BrowserWindow.getRepresentedFilename()
+### `win.getRepresentedFilename()`
 
 Returns the pathname of the file the window represents.
 
 __Note__: This API is only available on OS X.
 
-### BrowserWindow.setDocumentEdited(edited)
+### `win.setDocumentEdited(edited)`
 
 * `edited` Boolean
 
@@ -535,77 +561,85 @@ bar will become grey when set to `true`.
 
 __Note__: This API is only available on OS X.
 
-### BrowserWindow.IsDocumentEdited()
+### `win.IsDocumentEdited()`
 
 Whether the window's document has been edited.
 
 __Note__: This API is only available on OS X.
 
-### BrowserWindow.openDevTools([options])
+### `win.openDevTools([options])`
 
-* `options` Object
+* `options` Object, optional. Properties:
   * `detach` Boolean - opens devtools in a new window
 
 Opens the developer tools.
 
-### BrowserWindow.closeDevTools()
+### `win.closeDevTools()`
 
 Closes the developer tools.
 
-### BrowserWindow.isDevToolsOpened()
+### `win.isDevToolsOpened()`
 
 Returns whether the developer tools are opened.
 
-### BrowserWindow.toggleDevTools()
+### `win.toggleDevTools()`
 
 Toggle the developer tools.
 
-### BrowserWindow.inspectElement(x, y)
+### `win.inspectElement(x, y)`
 
 * `x` Integer
 * `y` Integer
 
 Starts inspecting element at position (`x`, `y`).
 
-### BrowserWindow.inspectServiceWorker()
+### `win.inspectServiceWorker()`
 
 Opens the developer tools for the service worker context present in the web contents.
 
-### BrowserWindow.focusOnWebView()
+### `win.focusOnWebView()`
 
-### BrowserWindow.blurWebView()
+### `win.blurWebView()`
 
-### BrowserWindow.capturePage([rect, ]callback)
+### `win.capturePage([rect, ]callback)`
 
-* `rect` Object - The area of page to be captured
+* `rect` Object - The area of page to be captured, properties:
   * `x` Integer
   * `y` Integer
   * `width` Integer
   * `height` Integer
 * `callback` Function
 
-Captures the snapshot of page within `rect`, upon completion `callback` would be
-called with `callback(image)`, the `image` is an instance of
-[NativeImage](native-image.md) that stores data of the snapshot. Omitting the
-`rect` would capture the whole visible page.
+Captures a snapshot of the page within `rect`. Upon completion `callback` will be
+called with `callback(image)`. The `image` is an instance of
+[NativeImage](native-image.md) that stores data of the snapshot. Omitting
+`rect` will capture the whole visible page.
 
+<<<<<<< HEAD
 ### BrowserWindow.print([options])
+=======
+**Note:** Be sure to read documents on remote buffer in
+[remote](remote.md) if you are going to use this API in renderer
+process.
 
-Same with `webContents.print([options])`
+### `win.print([options])`
+>>>>>>> Break out methods, standardize
 
-### BrowserWindow.printToPDF(options, callback)
+Same as `webContents.print([options])`
 
-Same with `webContents.printToPDF(options, callback)`
+### `win.printToPDF(options, callback)`
 
-### BrowserWindow.loadUrl(url, [options])
+Same as `webContents.printToPDF(options, callback)`
 
-Same with `webContents.loadUrl(url, [options])`.
+### `win.loadUrl(url[, options])`
 
-### BrowserWindow.reload()
+Same as `webContents.loadUrl(url[, options])`.
 
-Same with `webContents.reload`.
+### `win.reload()`
 
-### BrowserWindow.setMenu(menu)
+Same as `webContents.reload`.
+
+### `win.setMenu(menu)`
 
 * `menu` Menu
 
@@ -614,7 +648,7 @@ menu bar.
 
 __Note:__ This API is not available on OS X.
 
-### BrowserWindow.setProgressBar(progress)
+### `win.setProgressBar(progress)`
 
 * `progress` Double
 
@@ -627,7 +661,7 @@ On Linux platform, only supports Unity desktop environment, you need to specify
 the `*.desktop` file name to `desktopName` field in `package.json`. By default,
 it will assume `app.getName().desktop`.
 
-### BrowserWindow.setOverlayIcon(overlay, description)
+### `win.setOverlayIcon(overlay, description)`
 
 * `overlay` [NativeImage](native-image.md) - the icon to display on the bottom
 right corner of the taskbar icon. If this parameter is `null`, the overlay is
@@ -640,27 +674,29 @@ Sets a 16px overlay onto the current taskbar icon, usually used to convey some s
 __Note:__ This API is only available on Windows (Windows 7 and above)
 
 
-### BrowserWindow.setThumbarButtons(buttons)
+### `win.setThumbarButtons(buttons)`
 
-* `buttons` Array
-  * `button` Object
-    * `icon` [NativeImage](native-image.md) - The icon showing in thumbnail
-      toolbar.
-    * `tooltip` String (optional) - The text of the button's tooltip.
-    * `flags` Array (optional) - Control specific states and behaviors
-      of the button. By default, it uses `enabled`. It can include following
-      Strings:
-      * `enabled` - The button is active and available to the user.
-      * `disabled` - The button is disabled. It is present, but has a visual
-        state that indicates that it will not respond to user action.
-      * `dismissonclick` - When the button is clicked, the taskbar button's
-        flyout closes immediately.
-      * `nobackground` - Do not draw a button border, use only the image.
-      * `hidden` - The button is not shown to the user.
-      * `noninteractive` - The button is enabled but not interactive; no
-        pressed button state is drawn. This value is intended for instances
-        where the button is used in a notification.
-    * `click` - Function
+`buttons` Array od `button` Objects:
+
+`button` Object, properties:
+
+* `icon` [NativeImage](native-image.md) - The icon showing in thumbnail
+  toolbar.
+* `tooltip` String (optional) - The text of the button's tooltip.
+* `flags` Array (optional) - Control specific states and behaviors
+  of the button. By default, it uses `enabled`. It can include following
+  Strings:
+  * `enabled` - The button is active and available to the user.
+  * `disabled` - The button is disabled. It is present, but has a visual
+    state that indicates that it will not respond to user action.
+  * `dismissonclick` - When the button is clicked, the taskbar button's
+    flyout closes immediately.
+  * `nobackground` - Do not draw a button border, use only the image.
+  * `hidden` - The button is not shown to the user.
+  * `noninteractive` - The button is enabled but not interactive; no
+    pressed button state is drawn. This value is intended for instances
+    where the button is used in a notification.
+* `click` - Function
 
 Add a thumbnail toolbar with a specified set of buttons to the thumbnail image
 of a window in a taskbar button layout. Returns a `Boolean` object indicates
@@ -672,13 +708,13 @@ the limited room. Once you setup the thumbnail toolbar, the toolbar cannot be
 removed due to the platform's limitation. But you can call the API with an empty
 array to clean the buttons.
 
-### BrowserWindow.showDefinitionForSelection()
+### `win.showDefinitionForSelection()`
 
 Shows pop-up dictionary that searches the selected word on the page.
 
 __Note__: This API is only available on OS X.
 
-### BrowserWindow.setAutoHideMenuBar(hide)
+### `win.setAutoHideMenuBar(hide)`
 
 * `hide` Boolean
 
@@ -688,22 +724,22 @@ menu bar will only show when users press the single `Alt` key.
 If the menu bar is already visible, calling `setAutoHideMenuBar(true)` won't
 hide it immediately.
 
-### BrowserWindow.isMenuBarAutoHide()
+### `win.isMenuBarAutoHide()`
 
 Returns whether menu bar automatically hides itself.
 
-### BrowserWindow.setMenuBarVisibility(visible)
+### `win.setMenuBarVisibility(visible)`
 
 * `visible` Boolean
 
 Sets whether the menu bar should be visible. If the menu bar is auto-hide, users
 can still bring up the menu bar by pressing the single `Alt` key.
 
-### BrowserWindow.isMenuBarVisible()
+### `win.isMenuBarVisible()`
 
 Returns whether the menu bar is visible.
 
-### BrowserWindow.setVisibleOnAllWorkspaces(visible)
+### `win.setVisibleOnAllWorkspaces(visible)`
 
 * `visible` Boolean
 
@@ -711,11 +747,12 @@ Sets whether the window should be visible on all workspaces.
 
 **Note:** This API does nothing on Windows.
 
-### BrowserWindow.isVisibleOnAllWorkspaces()
+### `win.isVisibleOnAllWorkspaces()`
 
 Returns whether the window is visible on all workspaces.
 
 **Note:** This API always returns false on Windows.
+<<<<<<< HEAD
 
 ## Class: WebContents
 
@@ -1287,3 +1324,5 @@ proxy-uri = [<proxy-scheme>"://"]<proxy-host>[":"<proxy-port>]
 
 Sets download saving directory. By default, the download directory will be the
 `Downloads` under the respective app folder.
+=======
+>>>>>>> Break out methods, standardize

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -660,7 +660,7 @@ Same as `webContents.loadUrl(url[, options])`.
 
 Same as `webContents.reload`.
 
-### `win.setMenu(menu)`
+### `win.setMenu(menu)` _OS X_
 
 * `menu` Menu
 
@@ -682,7 +682,7 @@ On Linux platform, only supports Unity desktop environment, you need to specify
 the `*.desktop` file name to `desktopName` field in `package.json`. By default,
 it will assume `app.getName().desktop`.
 
-### `win.setOverlayIcon(overlay, description)`
+### `win.setOverlayIcon(overlay, description)` _Windows_
 
 * `overlay` [NativeImage](native-image.md) - the icon to display on the bottom
 right corner of the taskbar icon. If this parameter is `null`, the overlay is
@@ -696,7 +696,7 @@ sort of application status or to passively notify the user.
 __Note:__ This API is only available on Windows (Windows 7 and above)
 
 
-### `win.setThumbarButtons(buttons)`
+### `win.setThumbarButtons(buttons)` _Windows_
 
 `buttons` Array of `button` Objects:
 
@@ -730,7 +730,7 @@ the limited room. Once you setup the thumbnail toolbar, the toolbar cannot be
 removed due to the platform's limitation. But you can call the API with an empty
 array to clean the buttons.
 
-### `win.showDefinitionForSelection()`
+### `win.showDefinitionForSelection()` _OS X_
 
 Shows pop-up dictionary that searches the selected word on the page.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1,6 +1,7 @@
 # BrowserWindow
 
-The `BrowserWindow` class gives you the ability to create a browser window, for example:
+The `BrowserWindow` class gives you the ability to create a browser window, for
+example:
 
 ```javascript
 var BrowserWindow = require('browser-window');
@@ -79,14 +80,14 @@ Properties `width` and `height` are required.
   textured window. Defaults to `true`.
 * `web-preferences` Object - Settings of web page's features, properties:
   * `javascript` Boolean
-  * `web-security` Boolean - When setting `false`, it will disable the same-origin
-    policy (Usually using testing websites by people), and set `allow_displaying_insecure_content`
+  * `web-security` Boolean - When setting `false`, it will disable the
+    same-origin policy (Usually using testing websites by people), and set `allow_displaying_insecure_content`
     and `allow_running_insecure_content` to `true` if these two options are not
     set by user.
   * `allow-displaying-insecure-content` Boolean - Allow an https page to display
     content like images from http URLs.
-  * `allow-running-insecure-content` Boolean - Allow a https page to run JavaScript,
-    CSS or plugins from http URLs.
+  * `allow-running-insecure-content` Boolean - Allow a https page to run
+    JavaScript, CSS or plugins from http URLs.
   * `images` Boolean
   * `java` Boolean
   * `text-areas-are-resizable` Boolean
@@ -147,8 +148,13 @@ window.onbeforeunload = function(e) {
   // Unlike usual browsers, in which a string should be returned and the user is
   // prompted to confirm the page unload, Electron gives developers more options.
   // Returning an empty string or `false` will prevent the unloading.
+<<<<<<< HEAD
   // You can also use the dialog API to let the user confirm closing the application.
   e.returnValue = false;
+=======
+  // You can also use the dialog API to let the user confirm closing the app.
+  return false;
+>>>>>>> Line wrap 80-col
 };
 ```
 
@@ -235,7 +241,9 @@ Emitted when devtools is focused / opened.
 
 ### Event: 'app-command':
 
-Emitted when an [App Command](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646275(v=vs.85).aspx is invoked. These are typically related to keyboard media keys or browser commands, as well as the "Back" button built into some mice on Windows.
+Emitted when an [App Command](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646275(v=vs.85).aspx
+is invoked. These are typically related to keyboard media keys or browser
+commands, as well as the "Back" button built into some mice on Windows.
 
 ```js
 someWindow.on('app-command', function(e, cmd) {
@@ -304,7 +312,8 @@ var win = new BrowserWindow({ width: 800, height: 600 });
 The `WebContents` object this window owns, all web page related events and
 operations will be done via it.
 
-See the [`webContents` documentation](web-contents.md) for its methods and events.
+See the [`webContents` documentation](web-contents.md) for its methods and
+events.
 
 **Note:** Users should never store this object because it may become `null`
 when the renderer process (web page) has crashed.
@@ -395,14 +404,25 @@ Returns a boolean, whether the window is in fullscreen mode.
 
 ### `win.setAspectRatio(aspectRatio[, extraSize])`
 
-* `aspectRatio` The aspect ratio we want to maintain for some portion of the content view.
-* `rect` Object - The extra size to not be included in the aspect ratio to be maintained. Properties:
+* `aspectRatio` The aspect ratio we want to maintain for some portion of the
+content view.
+* `rect` Object - The extra size to not be included in the aspect ratio to be
+maintained. Properties:
   * `width` Integer
   * `height` Integer
 
-This will have a window maintain an aspect ratio. The extra size allows a developer to have space, specified in pixels, not included within the aspect ratio calculations. This API already takes into account the difference between a window's size and its content size.
+This will have a window maintain an aspect ratio. The extra size allows a
+developer to have space, specified in pixels, not included within the aspect ratio calculations. This API already takes into account the difference between a
+window's size and its content size.
 
-Consider a normal window with an HD video player and associated controls. Perhaps there are 15 pixels of controls on the left edge, 25 pixels of controls on the right edge and 50 pixels of controls below the player. In order to maintain a 16:9 aspect ratio (standard aspect ratio for HD @1920x1080) within the player itself we would call this function with arguments of 16/9 and [ 40, 50 ]. The second argument doesn't care where the extra width and height are within the content view--only that they exist. Just sum any extra width and height areas you have within the overall content view.
+Consider a normal window with an HD video player and associated controls.
+Perhaps there are 15 pixels of controls on the left edge, 25 pixels of controls
+on the right edge and 50 pixels of controls below the player. In order to
+maintain a 16:9 aspect ratio (standard aspect ratio for HD @1920x1080) within
+the player itself we would call this function with arguments of 16/9 and
+[ 40, 50 ]. The second argument doesn't care where the extra width and height
+are within the content view--only that they exist. Just sum any extra width and
+height areas you have within the overall content view.
 
 __Note__: This API is only implemented on OS X.
 
@@ -595,7 +615,8 @@ Starts inspecting element at position (`x`, `y`).
 
 ### `win.inspectServiceWorker()`
 
-Opens the developer tools for the service worker context present in the web contents.
+Opens the developer tools for the service worker context present in the web
+contents.
 
 ### `win.focusOnWebView()`
 
@@ -669,7 +690,8 @@ cleared
 * `description` String - a description that will be provided to Accessibility
 screen readers
 
-Sets a 16px overlay onto the current taskbar icon, usually used to convey some sort of application status or to passively notify the user.
+Sets a 16px overlay onto the current taskbar icon, usually used to convey some
+sort of application status or to passively notify the user.
 
 __Note:__ This API is only available on Windows (Windows 7 and above)
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1,6 +1,6 @@
 # BrowserWindow
 
-The `BrowserWindow` class gives you the ability to create a browser window, for
+The `BrowserWindow` class gives you the ability to create a browser window. For
 example:
 
 ```javascript
@@ -147,14 +147,9 @@ window.onbeforeunload = function(e) {
 
   // Unlike usual browsers, in which a string should be returned and the user is
   // prompted to confirm the page unload, Electron gives developers more options.
-  // Returning an empty string or `false` will prevent the unloading.
-<<<<<<< HEAD
+  // Returning empty string or false would prevent the unloading now.
   // You can also use the dialog API to let the user confirm closing the application.
   e.returnValue = false;
-=======
-  // You can also use the dialog API to let the user confirm closing the app.
-  return false;
->>>>>>> Line wrap 80-col
 };
 ```
 
@@ -307,7 +302,7 @@ var win = new BrowserWindow({ width: 800, height: 600 });
 
 ```
 
-### `win.webContents`
+### `win.webContents()`
 
 The `WebContents` object this window owns, all web page related events and
 operations will be done via it.
@@ -318,14 +313,14 @@ events.
 **Note:** Users should never store this object because it may become `null`
 when the renderer process (web page) has crashed.
 
-### `win.devToolsWebContents`
+### `win.devToolsWebContents()`
 
 Get the `WebContents` of devtools for this window.
 
 **Note:** Users should never store this object because it may become `null`
 when the devtools has been closed.
 
-### `win.id`
+### `win.id()`
 
 Get the unique ID of this window.
 
@@ -335,7 +330,8 @@ Force closing the window, the `unload` and `beforeunload` event won't be emitted
 for the web page, and `close` event will also not be emitted
 for this window, but it guarantees the `closed` event will be emitted.
 
-You should only use this method when the renderer process (web page) has crashed.
+You should only use this method when the renderer process (web page) has
+crashed.
 
 ### `win.close()`
 
@@ -412,7 +408,8 @@ maintaining the aspect ratio. Properties:
   * `height` Integer
 
 This will have a window maintain an aspect ratio. The extra size allows a
-developer to have space, specified in pixels, not included within the aspect ratio calculations. This API already takes into account the difference between a
+developer to have space, specified in pixels, not included within the aspect
+ratio calculations. This API already takes into account the difference between a
 window's size and its content size.
 
 Consider a normal window with an HD video player and associated controls.
@@ -631,20 +628,12 @@ contents.
   * `height` Integer
 * `callback` Function
 
-Captures a snapshot of the page within `rect`. Upon completion `callback` will be
-called with `callback(image)`. The `image` is an instance of
+Captures a snapshot of the page within `rect`. Upon completion `callback` will
+be called with `callback(image)`. The `image` is an instance of
 [NativeImage](native-image.md) that stores data of the snapshot. Omitting
 `rect` will capture the whole visible page.
 
-<<<<<<< HEAD
-### BrowserWindow.print([options])
-=======
-**Note:** Be sure to read documents on remote buffer in
-[remote](remote.md) if you are going to use this API in renderer
-process.
-
 ### `win.print([options])`
->>>>>>> Break out methods, standardize
 
 Same as `webContents.print([options])`
 
@@ -774,577 +763,3 @@ Sets whether the window should be visible on all workspaces.
 Returns whether the window is visible on all workspaces.
 
 **Note:** This API always returns false on Windows.
-<<<<<<< HEAD
-
-## Class: WebContents
-
-A `WebContents` is responsible for rendering and controlling a web page.
-
-`WebContents` is an
-[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter).
-
-### Event: 'did-finish-load'
-
-Emitted when the navigation is done, i.e. the spinner of the tab will stop
-spinning, and the `onload` event was dispatched.
-
-### Event: 'did-fail-load'
-
-* `event` Event
-* `errorCode` Integer
-* `errorDescription` String
-
-This event is like `did-finish-load`, but emitted when the load failed or was
-cancelled, e.g. `window.stop()` is invoked.
-
-### Event: 'did-frame-finish-load'
-
-* `event` Event
-* `isMainFrame` Boolean
-
-Emitted when a frame has done navigation.
-
-### Event: 'did-start-loading'
-
-Corresponds to the points in time when the spinner of the tab starts spinning.
-
-### Event: 'did-stop-loading'
-
-Corresponds to the points in time when the spinner of the tab stops spinning.
-
-### Event: 'did-get-response-details'
-
-* `event` Event
-* `status` Boolean
-* `newUrl` String
-* `originalUrl` String
-* `httpResponseCode` Integer
-* `requestMethod` String
-* `referrer` String
-* `headers` Object
-
-Emitted when details regarding a requested resource is available.
-`status` indicates the socket connection to download the resource.
-
-### Event: 'did-get-redirect-request'
-
-* `event` Event
-* `oldUrl` String
-* `newUrl` String
-* `isMainFrame` Boolean
-
-Emitted when a redirect was received while requesting a resource.
-
-### Event: 'dom-ready'
-
-* `event` Event
-
-Emitted when document in the given frame is loaded.
-
-### Event: 'page-favicon-updated'
-
-* `event` Event
-* `favicons` Array - Array of Urls
-
-Emitted when page receives favicon urls.
-
-### Event: 'new-window'
-
-* `event` Event
-* `url` String
-* `frameName` String
-* `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
-  `new-window` and `other`
-
-Emitted when the page requested to open a new window for `url`. It could be
-requested by `window.open` or an external link like `<a target='_blank'>`.
-
-By default a new `BrowserWindow` will be created for the `url`.
-
-Calling `event.preventDefault()` can prevent creating new windows.
-
-### Event: 'will-navigate'
-
-* `event` Event
-* `url` String
-
-Emitted when user or the page wants to start a navigation, it can happen when
-`window.location` object is changed or user clicks a link in the page.
-
-This event will not emit when the navigation is started programmatically with APIs
-like `WebContents.loadUrl` and `WebContents.back`.
-
-Calling `event.preventDefault()` can prevent the navigation.
-
-### Event: 'crashed'
-
-Emitted when the renderer process is crashed.
-
-### Event: 'plugin-crashed'
-
-* `event` Event
-* `name` String
-* `version` String
-
-Emitted when a plugin process is crashed.
-
-### Event: 'destroyed'
-
-Emitted when the WebContents is destroyed.
-
-### WebContents.session
-
-Returns the `Session` object used by this WebContents.
-
-### WebContents.loadUrl(url, [options])
-
-* `url` URL
-* `options` URL
-  * `httpReferrer` String - A HTTP Referer url
-  * `userAgent` String - A user agent originating the request
-
-Loads the `url` in the window, the `url` must contains the protocol prefix,
-e.g. the `http://` or `file://`.
-
-### WebContents.getUrl()
-
-Returns URL of current web page.
-
-### WebContents.getTitle()
-
-Returns the title of web page.
-
-### WebContents.isLoading()
-
-Returns whether web page is still loading resources.
-
-### WebContents.isWaitingForResponse()
-
-Returns whether web page is waiting for a first-response for the main resource
-of the page.
-
-### WebContents.stop()
-
-Stops any pending navigation.
-
-### WebContents.reload()
-
-Reloads current page.
-
-### WebContents.reloadIgnoringCache()
-
-Reloads current page and ignores cache.
-
-### WebContents.canGoBack()
-
-Returns whether the web page can go back.
-
-### WebContents.canGoForward()
-
-Returns whether the web page can go forward.
-
-### WebContents.canGoToOffset(offset)
-
-* `offset` Integer
-
-Returns whether the web page can go to `offset`.
-
-### WebContents.clearHistory()
-
-Clears the navigation history.
-
-### WebContents.goBack()
-
-Makes the web page go back.
-
-### WebContents.goForward()
-
-Makes the web page go forward.
-
-### WebContents.goToIndex(index)
-
-* `index` Integer
-
-Navigates to the specified absolute index.
-
-### WebContents.goToOffset(offset)
-
-* `offset` Integer
-
-Navigates to the specified offset from the "current entry".
-
-### WebContents.isCrashed()
-
-Whether the renderer process has crashed.
-
-### WebContents.setUserAgent(userAgent)
-
-* `userAgent` String
-
-Overrides the user agent for this page.
-
-### WebContents.getUserAgent()
-
-Returns a `String` represents the user agent for this page.
-
-### WebContents.insertCSS(css)
-
-* `css` String
-
-Injects CSS into this page.
-
-### WebContents.executeJavaScript(code[, userGesture])
-
-* `code` String
-* `userGesture` Boolean
-
-Evaluates `code` in page.
-
-In browser some HTML APIs like `requestFullScreen` can only be invoked if it
-is started by user gesture, by specifying `userGesture` to `true` developers
-can ignore this limitation.
-
-### WebContents.setAudioMuted(muted)
-
-+ `muted` Boolean
-
-Set the page muted.
-
-### WebContents.isAudioMuted()
-
-Returns whether this page has been muted.
-
-### WebContents.undo()
-
-Executes editing command `undo` in page.
-
-### WebContents.redo()
-
-Executes editing command `redo` in page.
-
-### WebContents.cut()
-
-Executes editing command `cut` in page.
-
-### WebContents.copy()
-
-Executes editing command `copy` in page.
-
-### WebContents.paste()
-
-Executes editing command `paste` in page.
-
-### WebContents.pasteAndMatchStyle()
-
-Executes editing command `pasteAndMatchStyle` in page.
-
-### WebContents.delete()
-
-Executes editing command `delete` in page.
-
-### WebContents.selectAll()
-
-Executes editing command `selectAll` in page.
-
-### WebContents.unselect()
-
-Executes editing command `unselect` in page.
-
-### WebContents.replace(text)
-
-* `text` String
-
-Executes editing command `replace` in page.
-
-### WebContents.replaceMisspelling(text)
-
-* `text` String
-
-Executes editing command `replaceMisspelling` in page.
-
-### WebContents.hasServiceWorker(callback)
-
-* `callback` Function
-
-Checks if any serviceworker is registered and returns boolean as
-response to `callback`.
-
-### WebContents.unregisterServiceWorker(callback)
-
-* `callback` Function
-
-Unregisters any serviceworker if present and returns boolean as
-response to `callback` when the JS promise is fullfilled or false
-when the JS promise is rejected.  
-
-### WebContents.print([options])
-
-* `options` Object
-  * `silent` Boolean - Don't ask user for print settings, defaults to `false`
-  * `printBackground` Boolean - Also prints the background color and image of
-    the web page, defaults to `false`.
-
-Prints window's web page. When `silent` is set to `false`, Electron will pick
-up system's default printer and default settings for printing.
-
-Calling `window.print()` in web page is equivalent to call
-`WebContents.print({silent: false, printBackground: false})`.
-
-**Note:** On Windows, the print API relies on `pdf.dll`. If your application
-doesn't need print feature, you can safely remove `pdf.dll` in saving binary
-size.
-
-### WebContents.printToPDF(options, callback)
-
-* `options` Object
-  * `marginsType` Integer - Specify the type of margins to use
-    * 0 - default
-    * 1 - none
-    * 2 - minimum
-  * `pageSize` String - Specify page size of the generated PDF
-    * `A4`
-    * `A3`
-    * `Legal`
-    * `Letter`
-    * `Tabloid`
-  * `printBackground` Boolean - Whether to print CSS backgrounds.
-  * `printSelectionOnly` Boolean - Whether to print selection only.
-  * `landscape` Boolean - `true` for landscape, `false` for portrait.
-
-* `callback` Function - `function(error, data) {}`
-  * `error` Error
-  * `data` Buffer - PDF file content
-
-Prints windows' web page as PDF with Chromium's preview printing custom
-settings.
-
-By default, an empty `options` will be regarded as
-`{marginsType:0, printBackground:false, printSelectionOnly:false,
-  landscape:false}`.
-
-```javascript
-var BrowserWindow = require('browser-window');
-var fs = require('fs');
-
-var win = new BrowserWindow({width: 800, height: 600});
-win.loadUrl("http://github.com");
-
-win.webContents.on("did-finish-load", function() {
-  // Use default printing options
-  win.webContents.printToPDF({}, function(error, data) {
-    if (error) throw error;
-    fs.writeFile("/tmp/print.pdf", data, function(error) {
-      if (err)
-        throw error;
-      console.log("Write PDF successfully.");
-    })
-  })
-});
-```
-
-### WebContents.addWorkSpace(path)
-
-* `path` String
-
-Adds the specified path to devtools workspace.
-
-### WebContents.removeWorkSpace(path)
-
-* `path` String
-
-Removes the specified path from devtools workspace.
-
-### WebContents.send(channel[, args...])
-
-* `channel` String
-
-Send `args..` to the web page via `channel` in asynchronous message, the web
-page can handle it by listening to the `channel` event of `ipc` module.
-
-An example of sending messages from the main process to the renderer process:
-
-```javascript
-// On the main process.
-var window = null;
-app.on('ready', function() {
-  window = new BrowserWindow({width: 800, height: 600});
-  window.loadUrl('file://' + __dirname + '/index.html');
-  window.webContents.on('did-finish-load', function() {
-    window.webContents.send('ping', 'whoooooooh!');
-  });
-});
-```
-
-```html
-// index.html
-<html>
-<body>
-  <script>
-    require('ipc').on('ping', function(message) {
-      console.log(message);  // Prints "whoooooooh!"
-    });
-  </script>
-</body>
-</html>
-```
-
-**Note:**
-
-1. The IPC message handler in web pages do not have a `event` parameter, which
-   is different from the handlers on the main process.
-2. There is no way to send synchronous messages from the main process to a
-   renderer process, because it would be very easy to cause dead locks.
-
-## Class: Session
-
-### Session.cookies
-
-The `cookies` gives you ability to query and modify cookies, an example is:
-
-```javascript
-var BrowserWindow = require('browser-window');
-
-var win = new BrowserWindow({ width: 800, height: 600 });
-
-win.loadUrl('https://github.com');
-
-win.webContents.on('did-finish-load', function() {
-  // Query all cookies.
-  win.webContents.session.cookies.get({}, function(error, cookies) {
-    if (error) throw error;
-    console.log(cookies);
-  });
-
-  // Query all cookies that are associated with a specific url.
-  win.webContents.session.cookies.get({ url : "http://www.github.com" },
-      function(error, cookies) {
-        if (error) throw error;
-        console.log(cookies);
-  });
-
-  // Set a cookie with the given cookie data;
-  // may overwrite equivalent cookies if they exist.
-  win.webContents.session.cookies.set(
-    { url : "http://www.github.com", name : "dummy_name", value : "dummy"},
-    function(error, cookies) {
-      if (error) throw error;
-      console.log(cookies);
-  });
-});
-```
-
-### Session.cookies.get(details, callback)
-
-* `details` Object
-  * `url` String - Retrieves cookies which are associated with `url`.
-    Empty imples retrieving cookies of all urls.
-  * `name` String - Filters cookies by name
-  * `domain` String - Retrieves cookies whose domains match or are subdomains of `domains`
-  * `path` String - Retrieves cookies whose path matches `path`
-  * `secure` Boolean - Filters cookies by their Secure property
-  * `session` Boolean - Filters out session or persistent cookies.
-* `callback` Function - function(error, cookies)
-  * `error` Error
-  * `cookies` Array - array of `cookie` objects.
-    * `cookie` - Object
-      *  `name` String - The name of the cookie
-      *  `value` String - The value of the cookie
-      *  `domain` String - The domain of the cookie
-      *  `host_only` String - Whether the cookie is a host-only cookie
-      *  `path` String - The path of the cookie
-      *  `secure` Boolean - Whether the cookie is marked as Secure (typically HTTPS)
-      *  `http_only` Boolean - Whether the cookie is marked as HttpOnly
-      *  `session` Boolean - Whether the cookie is a session cookie or a persistent
-         cookie with an expiration date.
-      *  `expirationDate` Double - (Option) The expiration date of the cookie as
-         the number of seconds since the UNIX epoch. Not provided for session cookies.
-
-
-### Session.cookies.set(details, callback)
-
-* `details` Object
-  * `url` String - Retrieves cookies which are associated with `url`
-  * `name` String - The name of the cookie. Empty by default if omitted.
-  * `value` String - The value of the cookie. Empty by default if omitted.
-  * `domain` String - The domain of the cookie. Empty by default if omitted.
-  * `path` String - The path of the cookie. Empty by default if omitted.
-  * `secure` Boolean - Whether the cookie should be marked as Secure. Defaults to false.
-  * `session` Boolean - Whether the cookie should be marked as HttpOnly. Defaults to false.
-  * `expirationDate` Double -	The expiration date of the cookie as the number of
-    seconds since the UNIX epoch. If omitted, the cookie becomes a session cookie.
-
-* `callback` Function - function(error)
-  * `error` Error
-
-### Session.cookies.remove(details, callback)
-
-* `details` Object
-  * `url` String - The URL associated with the cookie
-  * `name` String - The name of cookie to remove
-* `callback` Function - function(error)
-  * `error` Error
-
-### Session.clearCache(callback)
-
-* `callback` Function - Called when operation is done
-
-Clears the session's HTTP cache.
-
-### Session.clearStorageData([options, ]callback)
-
-* `options` Object
-  * `origin` String - Should follow `window.location.origin`'s representation
-    `scheme://host:port`
-  * `storages` Array - The types of storages to clear, can contain:
-    `appcache`, `cookies`, `filesystem`, `indexdb`, `localstorage`,
-    `shadercache`, `websql`, `serviceworkers`
-  * `quotas` Array - The types of quotas to clear, can contain:
-    `temporary`, `persistent`, `syncable`
-* `callback` Function - Called when operation is done
-
-Clears the data of web storages.
-
-### Session.setProxy(config, callback)
-
-* `config` String
-* `callback` Function - Called when operation is done
-
-Parses the `config` indicating which proxies to use for the session.
-
-```
-config = scheme-proxies[";"<scheme-proxies>]
-scheme-proxies = [<url-scheme>"="]<proxy-uri-list>
-url-scheme = "http" | "https" | "ftp" | "socks"
-proxy-uri-list = <proxy-uri>[","<proxy-uri-list>]
-proxy-uri = [<proxy-scheme>"://"]<proxy-host>[":"<proxy-port>]
-
-  For example:
-       "http=foopy:80;ftp=foopy2"  -- use HTTP proxy "foopy:80" for http://
-                                      URLs, and HTTP proxy "foopy2:80" for
-                                      ftp:// URLs.
-       "foopy:80"                  -- use HTTP proxy "foopy:80" for all URLs.
-       "foopy:80,bar,direct://"    -- use HTTP proxy "foopy:80" for all URLs,
-                                      failing over to "bar" if "foopy:80" is
-                                      unavailable, and after that using no
-                                      proxy.
-       "socks4://foopy"            -- use SOCKS v4 proxy "foopy:1080" for all
-                                      URLs.
-       "http=foopy,socks5://bar.com -- use HTTP proxy "foopy" for http URLs,
-                                      and fail over to the SOCKS5 proxy
-                                      "bar.com" if "foopy" is unavailable.
-       "http=foopy,direct://       -- use HTTP proxy "foopy" for http URLs,
-                                      and use no proxy if "foopy" is
-                                      unavailable.
-       "http=foopy;socks=foopy2   --  use HTTP proxy "foopy" for http URLs,
-                                      and use socks4://foopy2 for all other
-                                      URLs.
-```
-
-### Session.setDownloadPath(path)
-
-* `path` String - The download location
-
-Sets download saving directory. By default, the download directory will be the
-`Downloads` under the respective app folder.
-=======
->>>>>>> Break out methods, standardize

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -14,7 +14,7 @@ win.loadUrl('https://github.com');
 win.show();
 ```
 
-You can also create a window without Chrome by using
+You can also create a window without chrome by using
 [Frameless Window](frameless-window.md) API.
 
 ## Class: BrowserWindow
@@ -146,7 +146,7 @@ window.onbeforeunload = function(e) {
 
   // Unlike usual browsers, in which a string should be returned and the user is
   // prompted to confirm the page unload, Electron gives developers more options.
-  // Returning an empty string or false will prevent the unloading.
+  // Returning an empty string or `false` will prevent the unloading.
   // You can also use the dialog API to let the user confirm closing the application.
   e.returnValue = false;
 };
@@ -295,7 +295,7 @@ Objects created with `new BrowserWindow` have the following instance methods:
 var BrowserWindow = require('browser-window');
 
 // In this example `win` is our instance
-var win = new BroswerWindow({width: 800, height: 1500});
+var win = new BrowserWindow({ width: 800, height: 600 });
 
 ```
 
@@ -676,7 +676,7 @@ __Note:__ This API is only available on Windows (Windows 7 and above)
 
 ### `win.setThumbarButtons(buttons)`
 
-`buttons` Array od `button` Objects:
+`buttons` Array of `button` Objects:
 
 `button` Object, properties:
 
@@ -688,7 +688,7 @@ __Note:__ This API is only available on Windows (Windows 7 and above)
   Strings:
   * `enabled` - The button is active and available to the user.
   * `disabled` - The button is disabled. It is present, but has a visual
-    state that indicates that it will not respond to user action.
+    state indicating it will not respond to user action.
   * `dismissonclick` - When the button is clicked, the taskbar button's
     flyout closes immediately.
   * `nobackground` - Do not draw a button border, use only the image.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -200,11 +200,9 @@ Emitted when the window is getting moved to a new position.
 
 __Note__: On OS X this event is just an alias of `moved`.
 
-### Event: 'moved'
+### Event: 'moved' _OS X_
 
 Emitted once when the window is moved to a new position.
-
-__Note__: This event is available only on OS X.
 
 ### Event: 'enter-full-screen'
 
@@ -234,7 +232,7 @@ Emitted when devtools is closed.
 
 Emitted when devtools is focused / opened.
 
-### Event: 'app-command':
+### Event: 'app-command' _Windows_
 
 Emitted when an [App Command](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646275(v=vs.85).aspx
 is invoked. These are typically related to keyboard media keys or browser
@@ -248,8 +246,6 @@ someWindow.on('app-command', function(e, cmd) {
   }
 });
 ```
-
-__Note__: This event is only fired on Windows.
 
 ## Methods
 
@@ -421,8 +417,6 @@ the player itself we would call this function with arguments of 16/9 and
 are within the content view--only that they exist. Just sum any extra width and
 height areas you have within the overall content view.
 
-__Note__: This API is only implemented on OS X.
-
 ### `win.setBounds(options)`
 
 `options` Object, properties:
@@ -554,35 +548,27 @@ Enters or leaves the kiosk mode.
 
 Returns whether the window is in kiosk mode.
 
-### `win.setRepresentedFilename(filename)`
+### `win.setRepresentedFilename(filename)` _OS X_
 
 * `filename` String
 
 Sets the pathname of the file the window represents, and the icon of the file
 will show in window's title bar.
 
-__Note__: This API is only available on OS X.
-
-### `win.getRepresentedFilename()`
+### `win.getRepresentedFilename()` _OS X_
 
 Returns the pathname of the file the window represents.
 
-__Note__: This API is only available on OS X.
-
-### `win.setDocumentEdited(edited)`
+### `win.setDocumentEdited(edited)` _OS X_
 
 * `edited` Boolean
 
 Specifies whether the window’s document has been edited, and the icon in title
 bar will become grey when set to `true`.
 
-__Note__: This API is only available on OS X.
-
-### `win.IsDocumentEdited()`
+### `win.IsDocumentEdited()` _OS X_
 
 Whether the window's document has been edited.
-
-__Note__: This API is only available on OS X.
 
 ### `win.openDevTools([options])`
 
@@ -656,8 +642,6 @@ Same as `webContents.reload`.
 Sets the `menu` as the window's menu bar, setting it to `null` will remove the
 menu bar.
 
-__Note:__ This API is not available on OS X.
-
 ### `win.setProgressBar(progress)`
 
 * `progress` Double
@@ -671,7 +655,7 @@ On Linux platform, only supports Unity desktop environment, you need to specify
 the `*.desktop` file name to `desktopName` field in `package.json`. By default,
 it will assume `app.getName().desktop`.
 
-### `win.setOverlayIcon(overlay, description)` _Windows_
+### `win.setOverlayIcon(overlay, description)` _Windows 7+_
 
 * `overlay` [NativeImage](native-image.md) - the icon to display on the bottom
 right corner of the taskbar icon. If this parameter is `null`, the overlay is
@@ -682,10 +666,8 @@ screen readers
 Sets a 16px overlay onto the current taskbar icon, usually used to convey some
 sort of application status or to passively notify the user.
 
-__Note:__ This API is only available on Windows (Windows 7 and above)
 
-
-### `win.setThumbarButtons(buttons)` _Windows_
+### `win.setThumbarButtons(buttons)` _Windows 7+_
 
 `buttons` Array of `button` Objects:
 
@@ -713,7 +695,6 @@ Add a thumbnail toolbar with a specified set of buttons to the thumbnail image
 of a window in a taskbar button layout. Returns a `Boolean` object indicates
 whether the thumbnail has been added successfully.
 
-__Note:__ This API is only available on Windows (Windows 7 and above).
 The number of buttons in thumbnail toolbar should be no greater than 7 due to
 the limited room. Once you setup the thumbnail toolbar, the toolbar cannot be
 removed due to the platform's limitation. But you can call the API with an empty
@@ -722,8 +703,6 @@ array to clean the buttons.
 ### `win.showDefinitionForSelection()` _OS X_
 
 Shows pop-up dictionary that searches the selected word on the page.
-
-__Note__: This API is only available on OS X.
 
 ### `win.setAutoHideMenuBar(hide)`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -30,8 +30,8 @@ Properties `width` and `height` are required.
 
 `options` Object, properties:
 
-* `width` Integer **required** - Window's width.
-* `height` Integer **required** - Window's height.
+* `width` Integer (**required**) - Window's width.
+* `height` Integer (**required**) - Window's height.
 * `x` Integer - Window's left offset from screen.
 * `y` Integer - Window's top offset from screen.
 * `use-content-size` Boolean - The `width` and `height` would be used as web
@@ -402,12 +402,12 @@ Sets whether the window should be in fullscreen mode.
 
 Returns a boolean, whether the window is in fullscreen mode.
 
-### `win.setAspectRatio(aspectRatio[, extraSize])`
+### `win.setAspectRatio(aspectRatio[, extraSize])` _OS X_
 
 * `aspectRatio` The aspect ratio we want to maintain for some portion of the
 content view.
-* `rect` Object - The extra size to not be included in the aspect ratio to be
-maintained. Properties:
+* `extraSize` Object (optional) - The extra size not to be included while
+maintaining the aspect ratio. Properties:
   * `width` Integer
   * `height` Integer
 
@@ -589,7 +589,7 @@ __Note__: This API is only available on OS X.
 
 ### `win.openDevTools([options])`
 
-* `options` Object, optional. Properties:
+* `options` Object (optional). Properties:
   * `detach` Boolean - opens devtools in a new window
 
 Opens the developer tools.
@@ -624,7 +624,7 @@ contents.
 
 ### `win.capturePage([rect, ]callback)`
 
-* `rect` Object - The area of page to be captured, properties:
+* `rect` Object (optional)- The area of page to be captured, properties:
   * `x` Integer
   * `y` Integer
   * `width` Integer

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -5,7 +5,7 @@ The `session` object is a property of [`webContents`](web-contents.md) which is 
 ```javascript
 var BrowserWindow = require('browser-window');
 
-var win = new BroswerWindow({ width: 800, height: 600 });
+var win = new BrowserWindow({ width: 800, height: 600 });
 win.loadUrl("http://github.com");
 
 var session = win.webContents.session
@@ -17,7 +17,7 @@ The `session` object has the following methods:
 
 ### session.cookies
 
-The `cookies` gives you ability to query and modify cookies, an example is:
+The `cookies` gives you ability to query and modify cookies. For example:
 
 ```javascript
 var BrowserWindow = require('browser-window');
@@ -33,7 +33,7 @@ win.webContents.on('did-finish-load', function() {
     console.log(cookies);
   });
 
-  // Query all cookies that are associated with a specific url.
+  // Query all cookies associated with a specific url.
   win.webContents.session.cookies.get({ url : "http://www.github.com" },
       function(error, cookies) {
         if (error) throw error;

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1,6 +1,8 @@
 # session
 
-The `session` object is a property of [`webContents`](web-contents.md) which is a property of [`BrowserWindow`](browser-window.md). You can access it through an instance of `BrowserWindow`. For example:
+The `session` object is a property of [`webContents`](web-contents.md) which is
+a property of [`BrowserWindow`](browser-window.md). You can access it through an
+instance of `BrowserWindow`. For example:
 
 ```javascript
 var BrowserWindow = require('browser-window');
@@ -58,7 +60,8 @@ win.webContents.on('did-finish-load', function() {
 * `url` String - Retrieves cookies which are associated with `url`.
   Empty implies retrieving cookies of all urls.
 * `name` String - Filters cookies by name
-* `domain` String - Retrieves cookies whose domains match or are subdomains of `domains`
+* `domain` String - Retrieves cookies whose domains match or are subdomains of
+  `domains`
 * `path` String - Retrieves cookies whose path matches `path`
 * `secure` Boolean - Filters cookies by their Secure property
 * `session` Boolean - Filters out session or persistent cookies.
@@ -75,7 +78,8 @@ win.webContents.on('did-finish-load', function() {
   *  `session` Boolean - Whether the cookie is a session cookie or a persistent
      cookie with an expiration date.
   *  `expirationDate` Double - (Option) The expiration date of the cookie as
-     the number of seconds since the UNIX epoch. Not provided for session cookies.
+     the number of seconds since the UNIX epoch. Not provided for session
+     cookies.
 
 ### `session.cookies.set(details, callback)`
 
@@ -86,8 +90,10 @@ win.webContents.on('did-finish-load', function() {
 * `value` String - The value of the cookie. Empty by default if omitted.
 * `domain` String - The domain of the cookie. Empty by default if omitted.
 * `path` String - The path of the cookie. Empty by default if omitted.
-* `secure` Boolean - Whether the cookie should be marked as Secure. Defaults to false.
-* `session` Boolean - Whether the cookie should be marked as HttpOnly. Defaults to false.
+* `secure` Boolean - Whether the cookie should be marked as Secure. Defaults to
+  false.
+* `session` Boolean - Whether the cookie should be marked as HttpOnly. Defaults
+  to false.
 * `expirationDate` Double -	The expiration date of the cookie as the number of
   seconds since the UNIX epoch. If omitted, the cookie becomes a session cookie.
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1,0 +1,166 @@
+# session
+
+The `session` object is a property of [`webContents`](web-contents.md) which is a property of [`BrowserWindow`](browser-window.md). You can access it through an instance of `BrowserWindow`. For example:
+
+```javascript
+var BrowserWindow = require('browser-window');
+
+var win = new BroswerWindow({ width: 800, height: 600 });
+win.loadUrl("http://github.com");
+
+var session = win.webContents.session
+```
+
+## Methods
+
+The `session` object has the following methods:
+
+### session.cookies
+
+The `cookies` gives you ability to query and modify cookies, an example is:
+
+```javascript
+var BrowserWindow = require('browser-window');
+
+var win = new BrowserWindow({ width: 800, height: 600 });
+
+win.loadUrl('https://github.com');
+
+win.webContents.on('did-finish-load', function() {
+  // Query all cookies.
+  win.webContents.session.cookies.get({}, function(error, cookies) {
+    if (error) throw error;
+    console.log(cookies);
+  });
+
+  // Query all cookies that are associated with a specific url.
+  win.webContents.session.cookies.get({ url : "http://www.github.com" },
+      function(error, cookies) {
+        if (error) throw error;
+        console.log(cookies);
+  });
+
+  // Set a cookie with the given cookie data;
+  // may overwrite equivalent cookies if they exist.
+  win.webContents.session.cookies.set(
+    { url : "http://www.github.com", name : "dummy_name", value : "dummy"},
+    function(error, cookies) {
+      if (error) throw error;
+      console.log(cookies);
+  });
+});
+```
+
+### `session.cookies.get(details, callback)`
+
+`details` Object
+
+* `url` String - Retrieves cookies which are associated with `url`.
+  Empty implies retrieving cookies of all urls.
+* `name` String - Filters cookies by name
+* `domain` String - Retrieves cookies whose domains match or are subdomains of `domains`
+* `path` String - Retrieves cookies whose path matches `path`
+* `secure` Boolean - Filters cookies by their Secure property
+* `session` Boolean - Filters out session or persistent cookies.
+* `callback` Function - function(error, cookies)
+* `error` Error
+* `cookies` Array - array of `cookie` objects, properties:
+  *  `name` String - The name of the cookie.
+  *  `value` String - The value of the cookie.
+  *  `domain` String - The domain of the cookie.
+  *  `host_only` String - Whether the cookie is a host-only cookie.
+  *  `path` String - The path of the cookie.
+  *  `secure` Boolean - Whether the cookie is marked as Secure (typically HTTPS).
+  *  `http_only` Boolean - Whether the cookie is marked as HttpOnly.
+  *  `session` Boolean - Whether the cookie is a session cookie or a persistent
+     cookie with an expiration date.
+  *  `expirationDate` Double - (Option) The expiration date of the cookie as
+     the number of seconds since the UNIX epoch. Not provided for session cookies.
+
+### `session.cookies.set(details, callback)`
+
+`details` Object
+
+* `url` String - Retrieves cookies which are associated with `url`
+* `name` String - The name of the cookie. Empty by default if omitted.
+* `value` String - The value of the cookie. Empty by default if omitted.
+* `domain` String - The domain of the cookie. Empty by default if omitted.
+* `path` String - The path of the cookie. Empty by default if omitted.
+* `secure` Boolean - Whether the cookie should be marked as Secure. Defaults to false.
+* `session` Boolean - Whether the cookie should be marked as HttpOnly. Defaults to false.
+* `expirationDate` Double -	The expiration date of the cookie as the number of
+  seconds since the UNIX epoch. If omitted, the cookie becomes a session cookie.
+
+* `callback` Function - function(error)
+  * `error` Error
+
+### `session.cookies.remove(details, callback)`
+
+* `details` Object
+  * `url` String - The URL associated with the cookie
+  * `name` String - The name of cookie to remove
+* `callback` Function - function(error)
+  * `error` Error
+
+### `session.clearCache(callback)`
+
+* `callback` Function - Called when operation is done
+
+Clears the session’s HTTP cache.
+
+### `session.clearStorageData([options, ]callback)`
+
+* `options` Object
+  * `origin` String - Should follow `window.location.origin`’s representation
+    `scheme://host:port`
+  * `storages` Array - The types of storages to clear, can contain:
+    `appcache`, `cookies`, `filesystem`, `indexdb`, `local storage`,
+    `shadercache`, `websql`, `serviceworkers`
+  * `quotas` Array - The types of quotas to clear, can contain:
+    `temporary`, `persistent`, `syncable`
+* `callback` Function - Called when operation is done
+
+Clears the data of web storages.
+
+### `session.setProxy(config, callback)`
+
+* `config` String
+* `callback` Function - Called when operation is done
+
+Parses the `config` indicating which proxies to use for the session.
+
+```
+config = scheme-proxies[";"<scheme-proxies>]
+scheme-proxies = [<url-scheme>"="]<proxy-uri-list>
+url-scheme = "http" | "https" | "ftp" | "socks"
+proxy-uri-list = <proxy-uri>[","<proxy-uri-list>]
+proxy-uri = [<proxy-scheme>"://"]<proxy-host>[":"<proxy-port>]
+
+  For example:
+       "http=foopy:80;ftp=foopy2"  -- use HTTP proxy "foopy:80" for http://
+                                      URLs, and HTTP proxy "foopy2:80" for
+                                      ftp:// URLs.
+       "foopy:80"                  -- use HTTP proxy "foopy:80" for all URLs.
+       "foopy:80,bar,direct://"    -- use HTTP proxy "foopy:80" for all URLs,
+                                      failing over to "bar" if "foopy:80" is
+                                      unavailable, and after that using no
+                                      proxy.
+       "socks4://foopy"            -- use SOCKS v4 proxy "foopy:1080" for all
+                                      URLs.
+       "http=foopy,socks5://bar.com -- use HTTP proxy "foopy" for http URLs,
+                                      and fail over to the SOCKS5 proxy
+                                      "bar.com" if "foopy" is unavailable.
+       "http=foopy,direct://       -- use HTTP proxy "foopy" for http URLs,
+                                      and use no proxy if "foopy" is
+                                      unavailable.
+       "http=foopy;socks=foopy2   --  use HTTP proxy "foopy" for http URLs,
+                                      and use socks4://foopy2 for all other
+                                      URLs.
+```
+
+### `session.setDownloadPath(path)`
+
+* `path` String - The download location
+
+Sets download saving directory. By default, the download directory will be the
+`Downloads` under the respective app folder.

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -116,7 +116,7 @@ Clears the session’s HTTP cache.
 
 ### `session.clearStorageData([options, ]callback)`
 
-* `options` Object
+* `options` Object (optional)
   * `origin` String - Should follow `window.location.origin`’s representation
     `scheme://host:port`
   * `storages` Array - The types of storages to clear, can contain:

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -17,7 +17,7 @@ var session = win.webContents.session
 
 The `session` object has the following methods:
 
-### session.cookies
+### `session.cookies`
 
 The `cookies` gives you ability to query and modify cookies. For example:
 
@@ -55,7 +55,7 @@ win.webContents.on('did-finish-load', function() {
 
 ### `session.cookies.get(details, callback)`
 
-`details` Object
+`details` Object, properties:
 
 * `url` String - Retrieves cookies which are associated with `url`.
   Empty implies retrieving cookies of all urls.
@@ -83,7 +83,7 @@ win.webContents.on('did-finish-load', function() {
 
 ### `session.cookies.set(details, callback)`
 
-`details` Object
+`details` Object, properties:
 
 * `url` String - Retrieves cookies which are associated with `url`
 * `name` String - The name of the cookie. Empty by default if omitted.
@@ -102,7 +102,7 @@ win.webContents.on('did-finish-load', function() {
 
 ### `session.cookies.remove(details, callback)`
 
-* `details` Object
+* `details` Object, proprties:
   * `url` String - The URL associated with the cookie
   * `name` String - The name of cookie to remove
 * `callback` Function - function(error)
@@ -116,22 +116,22 @@ Clears the session’s HTTP cache.
 
 ### `session.clearStorageData([options, ]callback)`
 
-* `options` Object (optional)
+* `options` Object (optional), proprties:
   * `origin` String - Should follow `window.location.origin`’s representation
-    `scheme://host:port`
+    `scheme://host:port`.
   * `storages` Array - The types of storages to clear, can contain:
     `appcache`, `cookies`, `filesystem`, `indexdb`, `local storage`,
     `shadercache`, `websql`, `serviceworkers`
   * `quotas` Array - The types of quotas to clear, can contain:
-    `temporary`, `persistent`, `syncable`
-* `callback` Function - Called when operation is done
+    `temporary`, `persistent`, `syncable`.
+* `callback` Function - Called when operation is done.
 
 Clears the data of web storages.
 
 ### `session.setProxy(config, callback)`
 
 * `config` String
-* `callback` Function - Called when operation is done
+* `callback` Function - Called when operation is done.
 
 Parses the `config` indicating which proxies to use for the session.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -8,7 +8,7 @@ It is responsible for rendering and controlling a web page and is a property of 
 ```javascript
 var BrowserWindow = require('browser-window');
 
-var win = new BroswerWindow({width: 800, height: 1500});
+var win = new BrowserWindow({width: 800, height: 1500});
 win.loadUrl("http://github.com");
 
 var webContents = win.webContents
@@ -163,7 +163,7 @@ See [session documentation](session.md) for this object's methods.
   * `httpReferrer` String - A HTTP Referrer url
   * `userAgent` String - A user agent originating the request
 
-Loads the `url` in the window, the `url` must contains the protocol prefix,
+Loads the `url` in the window, the `url` must contain the protocol prefix,
 e.g. the `http://` or `file://`.
 
 ### `webContents.getUrl()`
@@ -177,11 +177,11 @@ win.loadUrl("http://github.com");
 var currentUrl = win.webContents.getUrl();
 ```
 
-Returns URL of current web page.
+Returns URL of the current web page.
 
 ### `webContents.getTitle()`
 
-Returns the title of web page.
+Returns the title of the current web page.
 
 ### `webContents.isLoading()`
 
@@ -189,7 +189,7 @@ Returns whether web page is still loading resources.
 
 ### `webContents.isWaitingForResponse()`
 
-Returns whether web page is waiting for a first-response for the main resource
+Returns whether the web page is waiting for a first-response for the main resource
 of the page.
 
 ### `webContents.stop()`
@@ -198,7 +198,7 @@ Stops any pending navigation.
 
 ### `webContents.reload()`
 
-Reloads current page.
+Reloads the current web page.
 
 ### `webContents.reloadIgnoringCache()`
 
@@ -206,11 +206,11 @@ Reloads current page and ignores cache.
 
 ### `webContents.canGoBack()`
 
-Returns whether the web page can go back.
+Returns whether the browser can go back to previous web page.
 
 ### `webContents.canGoForward()`
 
-Returns whether the web page can go forward.
+Returns whether the browser can go forward to next web page.
 
 ### `webContents.canGoToOffset(offset)`
 
@@ -224,17 +224,17 @@ Clears the navigation history.
 
 ### `webContents.goBack()`
 
-Makes the web page go back.
+Makes the browser go back a web page.
 
 ### `webContents.goForward()`
 
-Makes the web page go forward.
+Makes the browser go forward a web page.
 
 ### `webContents.goToIndex(index)`
 
 * `index` Integer
 
-Navigates to the specified absolute index.
+Navigates browser to the specified absolute web page index.
 
 ### `webContents.goToOffset(offset)`
 
@@ -254,13 +254,13 @@ Overrides the user agent for this page.
 
 ### `webContents.getUserAgent()`
 
-Returns a `String` represents the user agent for this page.
+Returns a `String` representing the user agent for this page.
 
 ### `webContents.insertCSS(css)`
 
 * `css` String
 
-Injects CSS into this page.
+Injects CSS into the current web page.
 
 ### `webContents.executeJavaScript(code[, userGesture])`
 
@@ -269,15 +269,13 @@ Injects CSS into this page.
 
 Evaluates `code` in page.
 
-In browser some HTML APIs like `requestFullScreen` can only be invoked if it
-is started by user gesture, by specifying `userGesture` to `true` developers
-can ignore this limitation.
+In the browser window some HTML APIs like `requestFullScreen` can only be invoked by a gesture from the user. Setting `userGesture` to `true` will remove this limitation.
 
 ### `webContents.setAudioMuted(muted)`
 
 + `muted` Boolean
 
-Set the page muted.
+Mute the audio on the current web page.
 
 ### `webContents.isAudioMuted()`
 
@@ -335,15 +333,15 @@ Executes editing command `replaceMisspelling` in page.
 
 * `callback` Function
 
-Checks if any serviceworker is registered and returns boolean as
+Checks if any ServiceWorker is registered and returns a boolean as
 response to `callback`.
 
 ### `webContents.unregisterServiceWorker(callback)`
 
 * `callback` Function
 
-Unregisters any serviceworker if present and returns boolean as
-response to `callback` when the JS promise is fullfilled or false
+Unregisters any ServiceWorker if present and returns a boolean as
+response to `callback` when the JS promise is fulfilled or false
 when the JS promise is rejected.
 
 ### `webContents.print([options])`
@@ -361,7 +359,7 @@ Calling `window.print()` in web page is equivalent to call
 `webContents.print({silent: false, printBackground: false})`.
 
 **Note:** On Windows, the print API relies on `pdf.dll`. If your application
-doesn't need print feature, you can safely remove `pdf.dll` in saving binary
+doesn't need the print feature, you can safely remove `pdf.dll` to reduce binary
 size.
 
 ### `webContents.printToPDF(options, callback)`
@@ -390,9 +388,16 @@ size.
 Prints window's web page as PDF with Chromium's preview printing custom
 settings.
 
-By default, an empty `options` will be regarded as
-`{marginsType:0, printBackgrounds:false, printSelectionOnly:false,
-  landscape:false}`.
+By default, an empty `options` will be regarded as:
+
+```javascript
+{
+  marginsType:0,
+  printBackgrounds:false,
+  printSelectionOnly:false,
+  landscape:false
+}
+```
 
 ```javascript
 var BrowserWindow = require('browser-window');

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -3,7 +3,9 @@
 `webContents` is an
 [EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter).
 
-It is responsible for rendering and controlling a web page and is a property of the [`BrowserWindow`](browser-window.md) object. An example of accessing the `webContents` object:
+It is responsible for rendering and controlling a web page and is a property of
+the [`BrowserWindow`](browser-window.md) object. An example of accessing the
+`webContents` object:
 
 ```javascript
 var BrowserWindow = require('browser-window');
@@ -123,8 +125,8 @@ Returns:
 Emitted when user or the page wants to start a navigation, it can happen when
 `window.location` object is changed or user clicks a link in the page.
 
-This event will not emit when the navigation is started programmatically with APIs
-like `webContents.loadUrl` and `webContents.back`.
+This event will not emit when the navigation is started programmatically with
+APIs like `webContents.loadUrl` and `webContents.back`.
 
 Calling `event.preventDefault()` can prevent the navigation.
 
@@ -189,8 +191,8 @@ Returns whether web page is still loading resources.
 
 ### `webContents.isWaitingForResponse()`
 
-Returns whether the web page is waiting for a first-response for the main resource
-of the page.
+Returns whether the web page is waiting for a first-response for the main
+resource of the page.
 
 ### `webContents.stop()`
 
@@ -269,7 +271,9 @@ Injects CSS into the current web page.
 
 Evaluates `code` in page.
 
-In the browser window some HTML APIs like `requestFullScreen` can only be invoked by a gesture from the user. Setting `userGesture` to `true` will remove this limitation.
+In the browser window some HTML APIs like `requestFullScreen` can only be
+invoked by a gesture from the user. Setting `userGesture` to `true` will remove
+this limitation.
 
 ### `webContents.setAudioMuted(muted)`
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1,0 +1,468 @@
+# webContents
+
+`webContents` is an
+[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter).
+
+It is responsible for rendering and controlling a web page and is a property of the [`BrowserWindow`](browser-window.md) object. An example of accessing the `webContents` object:
+
+```javascript
+var BrowserWindow = require('browser-window');
+
+var win = new BroswerWindow({width: 800, height: 1500});
+win.loadUrl("http://github.com");
+
+var webContents = win.webContents
+
+```
+
+## Events
+
+The `webContents` object emits the following events:
+
+### Event: 'did-finish-load'
+
+Emitted when the navigation is done, i.e. the spinner of the tab has stopped
+spinning, and the `onload` event was dispatched.
+
+### Event: 'did-fail-load'
+
+Returns:
+
+* `event` Event
+* `errorCode` Integer
+* `errorDescription` String
+
+This event is like `did-finish-load` but emitted when the load failed or was
+cancelled, e.g. `window.stop()` is invoked.
+
+### Event: 'did-frame-finish-load'
+
+Returns:
+
+* `event` Event
+* `isMainFrame` Boolean
+
+Emitted when a frame has done navigation.
+
+### Event: 'did-start-loading'
+
+Corresponds to the points in time when the spinner of the tab started spinning.
+
+### Event: 'did-stop-loading'
+
+Corresponds to the points in time when the spinner of the tab stopped spinning.
+
+### Event: 'did-get-response-details'
+
+Returns:
+
+* `event` Event
+* `status` Boolean
+* `newUrl` String
+* `originalUrl` String
+* `httpResponseCode` Integer
+* `requestMethod` String
+* `referrer` String
+* `headers` Object
+
+Emitted when details regarding a requested resource is available.
+`status` indicates the socket connection to download the resource.
+
+### Event: 'did-get-redirect-request'
+
+Returns:
+
+* `event` Event
+* `oldUrl` String
+* `newUrl` String
+* `isMainFrame` Boolean
+
+Emitted when a redirect was received while requesting a resource.
+
+### Event: 'dom-ready'
+
+Returns:
+
+* `event` Event
+
+Emitted when the document in the given frame is loaded.
+
+### Event: 'page-favicon-updated'
+
+Returns:
+
+* `event` Event
+* `favicons` Array - Array of Urls
+
+Emitted when page receives favicon urls.
+
+### Event: 'new-window'
+
+Returns:
+
+* `event` Event
+* `url` String
+* `frameName` String
+* `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
+  `new-window` and `other`
+
+Emitted when the page requests to open a new window for a `url`. It could be
+requested by `window.open` or an external link like `<a target='_blank'>`.
+
+By default a new `BrowserWindow` will be created for the `url`.
+
+Calling `event.preventDefault()` can prevent creating new windows.
+
+### Event: 'will-navigate'
+
+Returns:
+
+* `event` Event
+* `url` String
+
+Emitted when user or the page wants to start a navigation, it can happen when
+`window.location` object is changed or user clicks a link in the page.
+
+This event will not emit when the navigation is started programmatically with APIs
+like `webContents.loadUrl` and `webContents.back`.
+
+Calling `event.preventDefault()` can prevent the navigation.
+
+### Event: 'crashed'
+
+Emitted when the renderer process has crashed.
+
+### Event: 'plugin-crashed'
+
+Returns:
+
+* `event` Event
+* `name` String
+* `version` String
+
+Emitted when a plugin process has crashed.
+
+### Event: 'destroyed'
+
+Emitted when `webContents` is destroyed.
+
+## Instance Methods
+
+The `webContents` object has the following instance methods:
+
+### `webContents.session`
+
+Returns the `Session` object used by this webContents.
+
+See [session documentation](session.md) for this object's methods.
+
+### `webContents.loadUrl(url[, options])`
+
+* `url` URL
+* `options` Object, properties:
+  * `httpReferrer` String - A HTTP Referrer url
+  * `userAgent` String - A user agent originating the request
+
+Loads the `url` in the window, the `url` must contains the protocol prefix,
+e.g. the `http://` or `file://`.
+
+### `webContents.getUrl()`
+
+```javascript
+var BrowserWindow = require('browser-window');
+
+var win = new BrowserWindow({width: 800, height: 600});
+win.loadUrl("http://github.com");
+
+var currentUrl = win.webContents.getUrl();
+```
+
+Returns URL of current web page.
+
+### `webContents.getTitle()`
+
+Returns the title of web page.
+
+### `webContents.isLoading()`
+
+Returns whether web page is still loading resources.
+
+### `webContents.isWaitingForResponse()`
+
+Returns whether web page is waiting for a first-response for the main resource
+of the page.
+
+### `webContents.stop()`
+
+Stops any pending navigation.
+
+### `webContents.reload()`
+
+Reloads current page.
+
+### `webContents.reloadIgnoringCache()`
+
+Reloads current page and ignores cache.
+
+### `webContents.canGoBack()`
+
+Returns whether the web page can go back.
+
+### `webContents.canGoForward()`
+
+Returns whether the web page can go forward.
+
+### `webContents.canGoToOffset(offset)`
+
+* `offset` Integer
+
+Returns whether the web page can go to `offset`.
+
+### `webContents.clearHistory()`
+
+Clears the navigation history.
+
+### `webContents.goBack()`
+
+Makes the web page go back.
+
+### `webContents.goForward()`
+
+Makes the web page go forward.
+
+### `webContents.goToIndex(index)`
+
+* `index` Integer
+
+Navigates to the specified absolute index.
+
+### `webContents.goToOffset(offset)`
+
+* `offset` Integer
+
+Navigates to the specified offset from the "current entry".
+
+### `webContents.isCrashed()`
+
+Whether the renderer process has crashed.
+
+### `webContents.setUserAgent(userAgent)`
+
+* `userAgent` String
+
+Overrides the user agent for this page.
+
+### `webContents.getUserAgent()`
+
+Returns a `String` represents the user agent for this page.
+
+### `webContents.insertCSS(css)`
+
+* `css` String
+
+Injects CSS into this page.
+
+### `webContents.executeJavaScript(code[, userGesture])`
+
+* `code` String
+* `userGesture` Boolean
+
+Evaluates `code` in page.
+
+In browser some HTML APIs like `requestFullScreen` can only be invoked if it
+is started by user gesture, by specifying `userGesture` to `true` developers
+can ignore this limitation.
+
+### `webContents.setAudioMuted(muted)`
+
++ `muted` Boolean
+
+Set the page muted.
+
+### `webContents.isAudioMuted()`
+
+Returns whether this page has been muted.
+
+### `webContents.undo()`
+
+Executes editing command `undo` in page.
+
+### `webContents.redo()`
+
+Executes editing command `redo` in page.
+
+### `webContents.cut()`
+
+Executes editing command `cut` in page.
+
+### `webContents.copy()`
+
+Executes editing command `copy` in page.
+
+### `webContents.paste()`
+
+Executes editing command `paste` in page.
+
+### `webContents.pasteAndMatchStyle()`
+
+Executes editing command `pasteAndMatchStyle` in page.
+
+### `webContents.delete()`
+
+Executes editing command `delete` in page.
+
+### `webContents.selectAll()`
+
+Executes editing command `selectAll` in page.
+
+### `webContents.unselect()`
+
+Executes editing command `unselect` in page.
+
+### `webContents.replace(text)`
+
+* `text` String
+
+Executes editing command `replace` in page.
+
+### `webContents.replaceMisspelling(text)`
+
+* `text` String
+
+Executes editing command `replaceMisspelling` in page.
+
+### `webContents.hasServiceWorker(callback)`
+
+* `callback` Function
+
+Checks if any serviceworker is registered and returns boolean as
+response to `callback`.
+
+### `webContents.unregisterServiceWorker(callback)`
+
+* `callback` Function
+
+Unregisters any serviceworker if present and returns boolean as
+response to `callback` when the JS promise is fullfilled or false
+when the JS promise is rejected.
+
+### `webContents.print([options])`
+
+`options` Object, properties:
+
+* `silent` Boolean - Don't ask user for print settings, defaults to `false`
+* `printBackground` Boolean - Also prints the background color and image of
+  the web page, defaults to `false`.
+
+Prints window's web page. When `silent` is set to `false`, Electron will pick
+up system's default printer and default settings for printing.
+
+Calling `window.print()` in web page is equivalent to call
+`webContents.print({silent: false, printBackground: false})`.
+
+**Note:** On Windows, the print API relies on `pdf.dll`. If your application
+doesn't need print feature, you can safely remove `pdf.dll` in saving binary
+size.
+
+### `webContents.printToPDF(options, callback)`
+
+`options` Object, properties:
+
+* `marginsType` Integer - Specify the type of margins to use
+  * 0 - default
+  * 1 - none
+  * 2 - minimum
+* `pageSize` String - Specify page size of the generated PDF
+  * `A4`
+  * `A3`
+  * `Legal`
+  * `Letter`
+  * `Tabloid`
+* `printBackground` Boolean - Whether to print CSS backgrounds.
+* `printSelectionOnly` Boolean - Whether to print selection only.
+* `landscape` Boolean - `true` for landscape, `false` for portrait.
+
+`callback` Function - `function(error, data) {}`
+
+* `error` Error
+* `data` Buffer - PDF file content
+
+Prints window's web page as PDF with Chromium's preview printing custom
+settings.
+
+By default, an empty `options` will be regarded as
+`{marginsType:0, printBackgrounds:false, printSelectionOnly:false,
+  landscape:false}`.
+
+```javascript
+var BrowserWindow = require('browser-window');
+var fs = require('fs');
+
+var win = new BrowserWindow({width: 800, height: 600});
+win.loadUrl("http://github.com");
+
+win.webContents.on("did-finish-load", function() {
+  // Use default printing options
+  win.webContents.printToPDF({}, function(error, data) {
+    if (error) throw error;
+    fs.writeFile("/tmp/print.pdf", data, function(error) {
+      if (err)
+        throw error;
+      console.log("Write PDF successfully.");
+    })
+  })
+});
+```
+
+### `webContents.addWorkSpace(path)`
+
+* `path` String
+
+Adds the specified path to devtools workspace.
+
+### `webContents.removeWorkSpace(path)`
+
+* `path` String
+
+Removes the specified path from devtools workspace.
+
+### `webContents.send(channel[, args...])`
+
+* `channel` String
+
+Send `args..` to the web page via `channel` in an asynchronous message, the web
+page can handle it by listening to the `channel` event of the `ipc` module.
+
+An example of sending messages from the main process to the renderer process:
+
+```javascript
+// On the main process.
+var window = null;
+app.on('ready', function() {
+  window = new BrowserWindow({width: 800, height: 600});
+  window.loadUrl('file://' + __dirname + '/index.html');
+  window.webContents.on('did-finish-load', function() {
+    window.webContents.send('ping', 'whoooooooh!');
+  });
+});
+```
+
+```html
+<!-- index.html -->
+<html>
+<body>
+  <script>
+    require('ipc').on('ping', function(message) {
+      console.log(message);  // Prints "whoooooooh!"
+    });
+  </script>
+</body>
+</html>
+```
+
+**Note:**
+
+1. The IPC message handler in web pages does not have an `event` parameter, which
+   is different from the handlers on the main process.
+2. There is no way to send synchronous messages from the main process to a
+   renderer process, because it would be very easy to cause dead locks.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -161,7 +161,7 @@ See [session documentation](session.md) for this object's methods.
 ### `webContents.loadUrl(url[, options])`
 
 * `url` URL
-* `options` Object, properties:
+* `options` Object (optional). Properties:
   * `httpReferrer` String - A HTTP Referrer url
   * `userAgent` String - A user agent originating the request
 
@@ -267,7 +267,7 @@ Injects CSS into the current web page.
 ### `webContents.executeJavaScript(code[, userGesture])`
 
 * `code` String
-* `userGesture` Boolean
+* `userGesture` Boolean (optional)
 
 Evaluates `code` in page.
 
@@ -350,7 +350,7 @@ when the JS promise is rejected.
 
 ### `webContents.print([options])`
 
-`options` Object, properties:
+`options` Object (optional). Properties:
 
 * `silent` Boolean - Don't ask user for print settings, defaults to `false`
 * `printBackground` Boolean - Also prints the background color and image of
@@ -438,8 +438,9 @@ Removes the specified path from devtools workspace.
 ### `webContents.send(channel[, args...])`
 
 * `channel` String
+* `args...` (optional)
 
-Send `args..` to the web page via `channel` in an asynchronous message, the web
+Send `args...` to the web page via `channel` in an asynchronous message, the web
 page can handle it by listening to the `channel` event of the `ipc` module.
 
 An example of sending messages from the main process to the renderer process:

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -13,8 +13,7 @@ var BrowserWindow = require('browser-window');
 var win = new BrowserWindow({width: 800, height: 1500});
 win.loadUrl("http://github.com");
 
-var webContents = win.webContents
-
+var webContents = win.webContents;
 ```
 
 ## Events
@@ -67,7 +66,7 @@ Returns:
 * `referrer` String
 * `headers` Object
 
-Emitted when details regarding a requested resource is available.
+Emitted when details regarding a requested resource are available.
 `status` indicates the socket connection to download the resource.
 
 ### Event: 'did-get-redirect-request'
@@ -79,7 +78,7 @@ Returns:
 * `newUrl` String
 * `isMainFrame` Boolean
 
-Emitted when a redirect was received while requesting a resource.
+Emitted when a redirect is received while requesting a resource.
 
 ### Event: 'dom-ready'
 
@@ -106,14 +105,14 @@ Returns:
 * `url` String
 * `frameName` String
 * `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
-  `new-window` and `other`
+  `new-window` and `other`.
 
 Emitted when the page requests to open a new window for a `url`. It could be
 requested by `window.open` or an external link like `<a target='_blank'>`.
 
 By default a new `BrowserWindow` will be created for the `url`.
 
-Calling `event.preventDefault()` can prevent creating new windows.
+Calling `event.preventDefault()` will prevent creating new windows.
 
 ### Event: 'will-navigate'
 
@@ -122,13 +121,13 @@ Returns:
 * `event` Event
 * `url` String
 
-Emitted when user or the page wants to start a navigation, it can happen when
-`window.location` object is changed or user clicks a link in the page.
+Emitted when a user or the page wants to start navigation. It can happen when the
+`window.location` object is changed or a user clicks a link in the page.
 
 This event will not emit when the navigation is started programmatically with
 APIs like `webContents.loadUrl` and `webContents.back`.
 
-Calling `event.preventDefault()` can prevent the navigation.
+Calling `event.preventDefault()` will prevent the navigation.
 
 ### Event: 'crashed'
 
@@ -154,16 +153,16 @@ The `webContents` object has the following instance methods:
 
 ### `webContents.session`
 
-Returns the `Session` object used by this webContents.
+Returns the `session` object used by this webContents.
 
 See [session documentation](session.md) for this object's methods.
 
 ### `webContents.loadUrl(url[, options])`
 
 * `url` URL
-* `options` Object (optional). Properties:
-  * `httpReferrer` String - A HTTP Referrer url
-  * `userAgent` String - A user agent originating the request
+* `options` Object (optional), properties:
+  * `httpReferrer` String - A HTTP Referrer url.
+  * `userAgent` String - A user agent originating the request.
 
 Loads the `url` in the window, the `url` must contain the protocol prefix,
 e.g. the `http://` or `file://`.
@@ -191,7 +190,7 @@ Returns whether web page is still loading resources.
 
 ### `webContents.isWaitingForResponse()`
 
-Returns whether the web page is waiting for a first-response for the main
+Returns whether the web page is waiting for a first-response from the main
 resource of the page.
 
 ### `webContents.stop()`
@@ -252,11 +251,11 @@ Whether the renderer process has crashed.
 
 * `userAgent` String
 
-Overrides the user agent for this page.
+Overrides the user agent for this web page.
 
 ### `webContents.getUserAgent()`
 
-Returns a `String` representing the user agent for this page.
+Returns a `String` representing the user agent for this web page.
 
 ### `webContents.insertCSS(css)`
 
@@ -287,51 +286,51 @@ Returns whether this page has been muted.
 
 ### `webContents.undo()`
 
-Executes editing command `undo` in page.
+Executes the editing command `undo` in web page.
 
 ### `webContents.redo()`
 
-Executes editing command `redo` in page.
+Executes the editing command `redo` in web page.
 
 ### `webContents.cut()`
 
-Executes editing command `cut` in page.
+Executes the editing command `cut` in web page.
 
 ### `webContents.copy()`
 
-Executes editing command `copy` in page.
+Executes the editing command `copy` in web page.
 
 ### `webContents.paste()`
 
-Executes editing command `paste` in page.
+Executes the editing command `paste` in web page.
 
 ### `webContents.pasteAndMatchStyle()`
 
-Executes editing command `pasteAndMatchStyle` in page.
+Executes the editing command `pasteAndMatchStyle` in web page.
 
 ### `webContents.delete()`
 
-Executes editing command `delete` in page.
+Executes the editing command `delete` in web page.
 
 ### `webContents.selectAll()`
 
-Executes editing command `selectAll` in page.
+Executes the editing command `selectAll` in web page.
 
 ### `webContents.unselect()`
 
-Executes editing command `unselect` in page.
+Executes the editing command `unselect` in web page.
 
 ### `webContents.replace(text)`
 
 * `text` String
 
-Executes editing command `replace` in page.
+Executes the editing command `replace` in web page.
 
 ### `webContents.replaceMisspelling(text)`
 
 * `text` String
 
-Executes editing command `replaceMisspelling` in page.
+Executes the editing command `replaceMisspelling` in web page.
 
 ### `webContents.hasServiceWorker(callback)`
 
@@ -350,7 +349,7 @@ when the JS promise is rejected.
 
 ### `webContents.print([options])`
 
-`options` Object (optional). Properties:
+`options` Object (optional), properties:
 
 * `silent` Boolean - Don't ask user for print settings, defaults to `false`
 * `printBackground` Boolean - Also prints the background color and image of
@@ -359,7 +358,7 @@ when the JS promise is rejected.
 Prints window's web page. When `silent` is set to `false`, Electron will pick
 up system's default printer and default settings for printing.
 
-Calling `window.print()` in web page is equivalent to call
+Calling `window.print()` in web page is equivalent to calling
 `webContents.print({silent: false, printBackground: false})`.
 
 **Note:** On Windows, the print API relies on `pdf.dll`. If your application
@@ -374,7 +373,7 @@ size.
   * 0 - default
   * 1 - none
   * 2 - minimum
-* `pageSize` String - Specify page size of the generated PDF
+* `pageSize` String - Specify page size of the generated PDF.
   * `A4`
   * `A3`
   * `Legal`
@@ -387,7 +386,7 @@ size.
 `callback` Function - `function(error, data) {}`
 
 * `error` Error
-* `data` Buffer - PDF file content
+* `data` Buffer - PDF file content.
 
 Prints window's web page as PDF with Chromium's preview printing custom
 settings.
@@ -396,10 +395,10 @@ By default, an empty `options` will be regarded as:
 
 ```javascript
 {
-  marginsType:0,
-  printBackgrounds:false,
-  printSelectionOnly:false,
-  landscape:false
+  marginsType: 0,
+  printBackground: false,
+  printSelectionOnly: false,
+  landscape: false
 }
 ```
 
@@ -472,7 +471,7 @@ app.on('ready', function() {
 
 **Note:**
 
-1. The IPC message handler in web pages does not have an `event` parameter, which
-   is different from the handlers on the main process.
+1. The IPC message handler in web pages does not have an `event` parameter,
+   which is different from the handlers on the main process.
 2. There is no way to send synchronous messages from the main process to a
    renderer process, because it would be very easy to cause dead locks.


### PR DESCRIPTION
I've pulled `BrowserWindow` documentation work into its own PR since it's such a large and important part of the docs. I've done some things and I've got some questions!

- To reduce length, have pulled `webContents` and `session` into their own document :ok: :grey_question: 
- I link to the new `webContents` and `session` from their places in `BrowserWindow` doc.
- In most places I've gotten rid of a level of list nesting so that we don't hit the short limit from our markdown parser.
- In `BrowserWindow` the instance methods were noted as `BrowserWindow.devToolsWebContents` which I feel is a bit misleading since you can't call `devToolsWebContents` _on_ `BroswerWindow` but instead need an instance of it. Also confusing since the prototype methods are written in this same way. So I've given an example of `var win = new BrowserWindow()` and then made the method headings include `win.` How do people feel about this? Screenshot below. :ok: :grey_question: 

<img width="814" alt="screen shot 2015-08-20 at 3 27 31 pm" src="https://cloud.githubusercontent.com/assets/1305617/9384318/07810bb6-4750-11e5-9e9d-2b79902cca3f.png">

- Consistently kept `session` and `webContents` with lowercase first letter.
- Applied other standardization mentioned [here](https://github.com/atom/electron/pull/2533#issue-102116862).
- Am trying to figure out the best way to document `session` and `webContents` methods which are properties on properties... I add examples showing how to access each object but keep the method headers `session.foo`. Example of the how to access code snippet:

```javascript
var BrowserWindow = require('browser-window');

var win = new BroswerWindow({ width: 800, height: 600 });
win.loadUrl("http://github.com");

var session = win.webContents.session
```