### PR TITLE
Fix for issue 1968: use uv_backend_timeout to determine timeout to match other platforms

### DIFF
--- a/atom/common/node_bindings_win.cc
+++ b/atom/common/node_bindings_win.cc
@@ -22,37 +22,26 @@ NodeBindingsWin::~NodeBindingsWin() {
 }
 
 void NodeBindingsWin::PollEvents() {
-  // Unlike Unix, in which we can just rely on one backend fd to determine
-  // whether we should iterate libuv loop, on Window, IOCP is just one part
-  // of the libuv loop, we should also check whether we have other types of
-  // events.
-  bool block = uv_loop_->idle_handles == NULL &&
-               uv_loop_->pending_reqs_tail == NULL &&
-               uv_loop_->endgame_handles == NULL &&
-               !uv_loop_->stop_flag &&
-               (uv_loop_->active_handles > 0 ||
-                !QUEUE_EMPTY(&uv_loop_->active_reqs));
+  // If there are other kinds of events pending, uv_backend_timeout will
+  // instruct us not to wait.
+  DWORD bytes, timeout;
+  ULONG_PTR key;
+  OVERLAPPED* overlapped;
 
-  // When there is no other types of events, we block on the IOCP.
-  if (block) {
-    DWORD bytes, timeout;
-    ULONG_PTR key;
-    OVERLAPPED* overlapped;
+  timeout = uv_backend_timeout(uv_loop_);
 
-    timeout = uv_backend_timeout(uv_loop_);
-    GetQueuedCompletionStatus(uv_loop_->iocp,
-                              &bytes,
-                              &key,
-                              &overlapped,
-                              timeout);
+  GetQueuedCompletionStatus(uv_loop_->iocp,
+                            &bytes,
+                            &key,
+                            &overlapped,
+                            timeout);
 
-    // Give the event back so libuv can deal with it.
-    if (overlapped != NULL)
-      PostQueuedCompletionStatus(uv_loop_->iocp,
-                                 bytes,
-                                 key,
-                                 overlapped);
-  }
+  // Give the event back so libuv can deal with it.
+  if (overlapped != NULL)
+    PostQueuedCompletionStatus(uv_loop_->iocp,
+                               bytes,
+                               key,
+                               overlapped);
 }
 
 // static


### PR DESCRIPTION
As discussed in #1968 1968 -- fixes the problem where sockets appear to be starved in Windows.