### PR TITLE
Fix message box missing a close button on Windows

### DIFF
--- a/atom/browser/ui/message_box_win.cc
+++ b/atom/browser/ui/message_box_win.cc
@@ -79,8 +79,8 @@ int ShowMessageBoxUTF16(HWND parent,
                         const base::string16& detail,
                         const gfx::ImageSkia& icon) {
   TASKDIALOG_FLAGS flags =
-      TDF_SIZE_TO_CONTENT | // Show all content.
-      TDF_ALLOW_DIALOG_CANCELLATION; // Allow canceling the dialog.
+      TDF_SIZE_TO_CONTENT |  // Show all content.
+      TDF_ALLOW_DIALOG_CANCELLATION;  // Allow canceling the dialog.
 
   TASKDIALOGCONFIG config = { 0 };
   config.cbSize     = sizeof(config);

--- a/atom/browser/ui/message_box_win.cc
+++ b/atom/browser/ui/message_box_win.cc
@@ -78,9 +78,9 @@ int ShowMessageBoxUTF16(HWND parent,
                         const base::string16& message,
                         const base::string16& detail,
                         const gfx::ImageSkia& icon) {
-  TASKDIALOG_FLAGS flags = TDF_SIZE_TO_CONTENT;  // show all content.
-  if (cancel_id != 0)
-    flags |= TDF_ALLOW_DIALOG_CANCELLATION;  // allow dialog to be cancelled.
+  TASKDIALOG_FLAGS flags =
+      TDF_SIZE_TO_CONTENT | // Show all content.
+      TDF_ALLOW_DIALOG_CANCELLATION; // Allow canceling the dialog.
 
   TASKDIALOGCONFIG config = { 0 };
   config.cbSize     = sizeof(config);

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -80,12 +80,15 @@ window.alert = (message, title='') ->
   buttons = ['OK']
   message = message.toString()
   dialog.showMessageBox remote.getCurrentWindow(), {message, title, buttons}
+  # Alert should always return undefined.
+  return
 
 # And the confirm().
 window.confirm = (message, title='') ->
   dialog = remote.require 'dialog'
   buttons = ['OK', 'Cancel']
-  not dialog.showMessageBox remote.getCurrentWindow(), {message, title, buttons}
+  cancelId = 1
+  not dialog.showMessageBox remote.getCurrentWindow(), {message, title, buttons, cancelId}
 
 # But we do not support prompt().
 window.prompt = ->


### PR DESCRIPTION
This resolves #2293.

The issue was that on Windows the close button (the `X` in the dialog's border) was visible only if `cancelId` wasn't 0. This is weird, because it means that no dialog that contains a single button will ever have a close button (e.g. the `alert` dialog). The OS X and Linux implementation doesn't do that. So I changed the Windows code, to always show the close button.

I added two additional small changes:
- Changed `alert` to always return `undefined` instead of 0 (the index of the `OK` button), so it will comply with the spec (or at least how most browsers choose to implement it).
- Explicitly set the `cancelId` for `confirm` to 1. The button on index 1 is `Cancel` and according to the documentation `cancelId` will automatically be set to it in the Windows and OS X implementation. This change makes sure that Linux will use the same `cancelId`.