### PR TITLE
Fix path comparison in api-ipc-spec

### DIFF
--- a/spec/api-ipc-spec.coffee
+++ b/spec/api-ipc-spec.coffee
@@ -5,6 +5,13 @@ remote = require 'remote'
 
 BrowserWindow = remote.require 'browser-window'
 
+comparePaths = (path1, path2) ->
+  if process.platform is 'win32'
+    # Paths in Windows are case insensitive.
+    path1 = path1.toLowerCase()
+    path2 = path2.toLowerCase()
+  assert.equal path1, path2
+
 describe 'ipc module', ->
   fixtures = path.join __dirname, 'fixtures'
 
@@ -19,8 +26,8 @@ describe 'ipc module', ->
       assert.equal a.id, 1127
 
     it 'should search module from the user app', ->
-      assert.equal path.normalize(remote.process.mainModule.filename), path.resolve(__dirname, 'static', 'main.js')
-      assert.equal path.normalize(remote.process.mainModule.paths[0]), path.resolve(__dirname, 'static', 'node_modules')
+      comparePaths path.normalize(remote.process.mainModule.filename), path.resolve(__dirname, 'static', 'main.js')
+      comparePaths path.normalize(remote.process.mainModule.paths[0]), path.resolve(__dirname, 'static', 'node_modules')
 
   describe 'remote.createFunctionWithReturnValue', ->
     it 'should be called in browser synchronously', ->


### PR DESCRIPTION
This resolves the first test that failed in #2558.
The test failed because in one of the paths the drive letter was upper case `C` and in the other it was lower case `c`.
Paths in Windows are case insensitive, so this shouldn't fail. The fix was to lower case the paths before comparison (only on Windows).