### PR TITLE
Remove little remains in translations, remove outdated comments

### DIFF
--- a/docs-translations/ko/api/content-tracing-ko.md
+++ b/docs-translations/ko/api/content-tracing-ko.md
@@ -135,5 +135,3 @@ process.
 ## tracing.cancelWatchEvent()
 
 Watch 이벤트를 중단합니다. 만약 추적이 활성화되어 있다면 이 함수는 watch 이벤트 콜백과 race가 일어날 것입니다.
-
-Cancel the watch event. If tracing is enabled, this may race with the watch event callback.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -589,10 +589,6 @@ called with `callback(image)`, the `image` is an instance of
 [NativeImage](native-image.md) that stores data of the snapshot. Omitting the
 `rect` would capture the whole visible page.
 
-**Note:** Be sure to read documents on remote buffer in
-[remote](remote.md) if you are going to use this API in renderer
-process.
-
 ### BrowserWindow.print([options])
 
 Same with `webContents.print([options])`


### PR DESCRIPTION
Remove little remains(typo) in content-tracing-ko.md and outdated comments about remote buffer in browser-window.md