### PR TITLE
Update build-instructions-windows

### DIFF
--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -54,7 +54,8 @@ You can also only build the Debug target:
 python script\build.py -c D
 ```
 
-After building is done, you can find `atom.exe` under `out\D`.
+After building is done, you can find `electron.exe` under `out\D` (debug 
+target) or under `out\R` (release target).
 
 ## 64bit build
 


### PR DESCRIPTION
The build instructions mistakenly said that you can find `atom.exe` under `out\D` instead of `electron.exe`. I fixed that and mentioned that the release build will be to `out\R`.