### PR TITLE
nativemate: increase recursion depth

### DIFF
--- a/atom/common/native_mate_converters/v8_value_converter.cc
+++ b/atom/common/native_mate_converters/v8_value_converter.cc
@@ -17,7 +17,7 @@ namespace atom {
 
 namespace {
 
-const int kMaxRecursionDepth = 20;
+const int kMaxRecursionDepth = 100;
 
 }  // namespace
 


### PR DESCRIPTION
Fixes #1403 

This is the maximum depth supported by `ipc_message_utils` .