### PR TITLE
win: Delay quitting until next tick of message loop

### DIFF
--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -45,7 +45,8 @@ void Browser::Shutdown() {
   FOR_EACH_OBSERVER(BrowserObserver, observers_, OnQuit());
 
   is_quiting_ = true;
-  base::MessageLoop::current()->Quit();
+  base::MessageLoop::current()->PostTask(
+      FROM_HERE, base::MessageLoop::QuitWhenIdleClosure());
 }
 
 std::string Browser::GetVersion() const {


### PR DESCRIPTION
This fixes app.quit() not working when it is called before the message loop starts to run.

Closes #2312.