### PR TITLE
Add webFrame.setZoomLevelLimits API

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -50,6 +50,10 @@ double WebFrame::GetZoomFactor() const {
   return blink::WebView::zoomLevelToZoomFactor(GetZoomLevel());
 }
 
+void WebFrame::SetZoomLevelLimits(double min_level, double max_level) {
+  web_frame_->view()->setDefaultPageScaleLimits(min_level, max_level);
+}
+
 v8::Local<v8::Value> WebFrame::RegisterEmbedderCustomElement(
     const base::string16& name, v8::Local<v8::Object> options) {
   blink::WebExceptionCode c = 0;
@@ -102,6 +106,7 @@ mate::ObjectTemplateBuilder WebFrame::GetObjectTemplateBuilder(
       .SetMethod("getZoomLevel", &WebFrame::GetZoomLevel)
       .SetMethod("setZoomFactor", &WebFrame::SetZoomFactor)
       .SetMethod("getZoomFactor", &WebFrame::GetZoomFactor)
+      .SetMethod("setZoomLevelLimits", &WebFrame::SetZoomLevelLimits)
       .SetMethod("registerEmbedderCustomElement",
                  &WebFrame::RegisterEmbedderCustomElement)
       .SetMethod("registerElementResizeCallback",

--- a/atom/renderer/api/atom_api_web_frame.h
+++ b/atom/renderer/api/atom_api_web_frame.h
@@ -41,6 +41,8 @@ class WebFrame : public mate::Wrappable {
   double SetZoomFactor(double factor);
   double GetZoomFactor() const;
 
+  void SetZoomLevelLimits(double min_level, double max_level);
+
   v8::Local<v8::Value> RegisterEmbedderCustomElement(
       const base::string16& name, v8::Local<v8::Object> options);
   void RegisterElementResizeCallback(

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -32,6 +32,13 @@ limits of 300% and 50% of original size, respectively.
 
 Returns the current zoom level.
 
+## webFrame.setZoomLevelLimits(minimumLevel, maximumLevel)
+
+* `minimumLevel` Number
+* `maximumLevel` Number
+
+Sets the maximum and minimum zoom level.
+
 ## webFrame.setSpellCheckProvider(language, autoCorrectWord, provider)
 
 * `language` String


### PR DESCRIPTION
By calling `require('web-frame').setZoomLevelLimits(1, 1);`, the pinch-to-zoom feature can be turned off. There is no global switch to do that though, Chromium just hard coded this feature.

Fixes #2500.