### PR TITLE
Opt into location services

### DIFF
--- a/atom/browser/atom_access_token_store.cc
+++ b/atom/browser/atom_access_token_store.cc
@@ -9,6 +9,7 @@
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/atom_browser_main_parts.h"
 #include "atom/common/google_api_key.h"
+#include "content/public/browser/geolocation_provider.h"
 
 namespace atom {
 
@@ -24,6 +25,7 @@ const char* kGeolocationProviderUrl =
 }  // namespace
 
 AtomAccessTokenStore::AtomAccessTokenStore() {
+  content::GeolocationProvider::GetInstance()->UserDidOptIntoLocationServices();
 }
 
 AtomAccessTokenStore::~AtomAccessTokenStore() {


### PR DESCRIPTION
Chromium requires this operation before using the geolocation API.

Fixes #1376.