### PR TITLE
Notes about server-side implementation of auto-updater

### DIFF
--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -98,6 +98,10 @@ appropriate format.
 
 `pub_date` (if present) must be formatted according to ISO 8601.
 
+## Update server implementations
+
+[Nuts](https://github.com/GitbookIO/nuts) is an open source implementation of the update server described above, it integrates beautifully with GitHub releases. Nuts manages downloads and updates, it’s compatible with `Squirrel.Mac` and `Squirrel.Windows` so you get cross-platform support out of the box.
+
 ## Events
 
 The `autoUpdater` object emits the following events:


### PR DESCRIPTION
This PR adds a section in the documentation about the auto-updater to list open source implementations.

At GitBook, we built [Nuts](https://github.com/GitbookIO/nuts) to manage downloads and auto-updates of our desktop application. This is a pure server-implementations that works perfectly with Squirrel.Mac and Squirrel.Windows.

I think [Nuts](https://github.com/GitbookIO/nuts) can be useful to other `electron` users, not only as something they can use out of the box, but a reference implementation of the update server.