### PR TITLE
Fix a few navigation related problems

### DIFF
--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -52,10 +52,6 @@ bool IsSwitchEnabled(base::CommandLine* command_line,
   return true;
 }
 
-bool IsGuestFrame(blink::WebFrame* frame) {
-  return frame->uniqueName().utf8() == "ATOM_SHELL_GUEST_WEB_VIEW";
-}
-
 // global.Uint8Array;
 v8::Local<v8::Function> GetUint8ArrayConstructor(
     v8::Isolate* isolate, v8::Local<v8::Context> context) {
@@ -189,14 +185,11 @@ bool AtomRendererClient::OverrideCreatePlugin(
 void AtomRendererClient::DidCreateScriptContext(
     blink::WebFrame* frame,
     v8::Handle<v8::Context> context) {
-  // Only attach node bindings in main frame or guest frame.
-  if (!IsGuestFrame(frame)) {
-    if (main_frame_)
-      return;
+  if (main_frame_)
+    return;
 
-    // The first web frame is the main frame.
-    main_frame_ = frame;
-  }
+  // The first web frame is the main frame.
+  main_frame_ = frame;
 
   // Give the node loop a run to make sure everything is ready.
   node_bindings_->RunMessageLoop();
@@ -221,10 +214,6 @@ bool AtomRendererClient::ShouldFork(blink::WebFrame* frame,
                                     bool is_initial_navigation,
                                     bool is_server_redirect,
                                     bool* send_referrer) {
-  // Never fork renderer process for guests.
-  if (IsGuestFrame(frame))
-    return false;
-
   // Handle all the navigations and reloads in browser.
   // FIXME We only support GET here because http method will be ignored when
   // the OpenURLFromTab is triggered, which means form posting would not work,

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -109,8 +109,7 @@ class AtomRenderFrameObserver : public content::RenderFrameObserver {
 
 AtomRendererClient::AtomRendererClient()
     : node_bindings_(NodeBindings::Create(false)),
-      atom_bindings_(new AtomBindings),
-      main_frame_(nullptr) {
+      atom_bindings_(new AtomBindings) {
 }
 
 AtomRendererClient::~AtomRendererClient() {
@@ -185,11 +184,9 @@ bool AtomRendererClient::OverrideCreatePlugin(
 void AtomRendererClient::DidCreateScriptContext(
     blink::WebFrame* frame,
     v8::Handle<v8::Context> context) {
-  if (main_frame_)
+  // Only insert node integration for the main frame.
+  if (frame->parent())
     return;
-
-  // The first web frame is the main frame.
-  main_frame_ = frame;
 
   // Give the node loop a run to make sure everything is ready.
   node_bindings_->RunMessageLoop();

--- a/atom/renderer/atom_renderer_client.h
+++ b/atom/renderer/atom_renderer_client.h
@@ -64,9 +64,6 @@ class AtomRendererClient : public content::ContentRendererClient,
   scoped_ptr<NodeBindings> node_bindings_;
   scoped_ptr<AtomBindings> atom_bindings_;
 
-  // The main frame.
-  blink::WebFrame* main_frame_;
-
   DISALLOW_COPY_AND_ASSIGN(AtomRendererClient);
 };
 

--- a/atom/renderer/lib/init.coffee
+++ b/atom/renderer/lib/init.coffee
@@ -29,8 +29,6 @@ for arg in process.argv
   if arg.indexOf('--guest-instance-id=') == 0
     # This is a guest web view.
     process.guestInstanceId = parseInt arg.substr(arg.indexOf('=') + 1)
-    # Set the frame name to make AtomRendererClient recognize this guest.
-    require('web-frame').setName 'ATOM_SHELL_GUEST_WEB_VIEW'
   else if arg.indexOf('--node-integration=') == 0
     nodeIntegration = arg.substr arg.indexOf('=') + 1
   else if arg.indexOf('--preload=') == 0

--- a/spec/chromium-spec.coffee
+++ b/spec/chromium-spec.coffee
@@ -63,6 +63,15 @@ describe 'chromium feature', ->
         b.close()
         done(if opener isnt null then undefined else opener)
 
+  describe 'window.opener.postMessage', ->
+    it 'sets source and origin correctly', (done) ->
+      b = window.open "file://#{fixtures}/pages/window-opener-postMessage.html", 'test', 'show=no'
+      window.addEventListener 'message', (event) ->
+        b.close()
+        assert.equal event.source.guestId, b.guestId
+        assert.equal event.origin, 'file://'
+        done()
+
   describe 'creating a Uint8Array under browser side', ->
     it 'does not crash', ->
       RUint8Array = remote.getGlobal 'Uint8Array'

--- a/spec/fixtures/pages/post.html
+++ b/spec/fixtures/pages/post.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+  <form id="form" action="d.html" method="post" accept-charset="utf-8">
+  <p><input type="submit" value="submit"></p>
+  </form>
+  <script type="text/javascript" charset="utf-8">
+    document.getElementById("form").submit();
+  </script>
+</body>
+</html>

--- a/spec/fixtures/pages/window-opener-postMessage.html
+++ b/spec/fixtures/pages/window-opener-postMessage.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  window.opener.postMessage('message', '*');
+</script>
+</body>
+</html>

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -48,6 +48,14 @@ describe '<webview> tag', ->
       webview.src = "file://#{fixtures}/pages/d.html"
       document.body.appendChild webview
 
+    it 'loads node symbols after POST navigation when set', (done) ->
+      webview.addEventListener 'console-message', (e) ->
+        assert.equal e.message, 'function object object'
+        done()
+      webview.setAttribute 'nodeintegration', 'on'
+      webview.src = "file://#{fixtures}/pages/post.html"
+      document.body.appendChild webview
+
     # If the test is executed with the debug build on Windows, we will skip it
     # because native modules don't work with the debug build (see issue #2558).
     if process.platform isnt 'win32' or


### PR DESCRIPTION
* Navigation in webview now restarts renderer process.
* Fix node integration not working after POST request (closes #1959).
* Set correct `source` and `origin` for `window.opener.postMessage`.