### PR TITLE
Session: Introduce a download-updated event

### DIFF
--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -29,7 +29,8 @@ class AtomBrowserContext;
 namespace api {
 
 class Session: public mate::TrackableObject<Session>,
-               public content::DownloadManager::Observer {
+               public content::DownloadManager::Observer,
+               public content::DownloadItem::Observer {
  public:
   using ResolveProxyCallback = base::Callback<void(std::string)>;
 
@@ -46,6 +47,9 @@ class Session: public mate::TrackableObject<Session>,
   // content::DownloadManager::Observer:
   void OnDownloadCreated(content::DownloadManager* manager,
                          content::DownloadItem* item) override;
+
+  // content::DownloadItem::Observer:
+  void OnDownloadUpdated(content::DownloadItem* item) override;
 
   // mate::Wrappable implementations:
   mate::ObjectTemplateBuilder GetObjectTemplateBuilder(


### PR DESCRIPTION
The session already has a 'will-download' event which informs us about a
download. This adds an aditional signal called 'download-updated' which
is called each time the download-state changes.

Additionally, the DownloadItem object now has some additional
parameters-

* DisplayName
* percentComplete
* currentSpeed
* state (InProgress, Complete, Cancelled or Interruped)

--

I'm not sure if this is the correct approach. Perhaps a better API would be for the DownloadItem to be an EventEmitter, and for it to emit 'updated', and other signals. Specially since we will also need to expose functions such as 'open' and 'openDirectory'. Could you provide some pointers on how I would implement this?

We will also need many other DownloadItem properties to be exposed.

