### PR TITLE
add ValidatedUrl to did-fail-load event

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -388,7 +388,7 @@ void WebContents::DidFailProvisionalLoad(
     int error_code,
     const base::string16& error_description,
     bool was_ignored_by_handler) {
-  Emit("did-fail-load", error_code, error_description);
+  Emit("did-fail-load", error_code, error_description, validated_url);
 }
 
 void WebContents::DidFailLoad(content::RenderFrameHost* render_frame_host,
@@ -396,7 +396,7 @@ void WebContents::DidFailLoad(content::RenderFrameHost* render_frame_host,
                               int error_code,
                               const base::string16& error_description,
                               bool was_ignored_by_handler) {
-  Emit("did-fail-load", error_code, error_description);
+  Emit("did-fail-load", error_code, error_description, validated_url);
 }
 
 void WebContents::DidStartLoading() {

--- a/atom/renderer/lib/web-view/guest-view-internal.coffee
+++ b/atom/renderer/lib/web-view/guest-view-internal.coffee
@@ -6,7 +6,7 @@ requestId = 0
 WEB_VIEW_EVENTS =
   'load-commit': ['url', 'isMainFrame']
   'did-finish-load': []
-  'did-fail-load': ['errorCode', 'errorDescription']
+  'did-fail-load': ['errorCode', 'errorDescription', 'validatedUrl']
   'did-frame-finish-load': ['isMainFrame']
   'did-start-loading': []
   'did-stop-loading': []

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -32,6 +32,7 @@ Returns:
 * `event` Event
 * `errorCode` Integer
 * `errorDescription` String
+* `validatedUrl` String
 
 This event is like `did-finish-load` but emitted when the load failed or was
 cancelled, e.g. `window.stop()` is invoked.

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -384,6 +384,7 @@ Returns:
 
 * `errorCode` Integer
 * `errorDescription` String
+* `validatedUrl` String
 
 This event is like `did-finish-load`, but fired when the load failed or was
 cancelled, e.g. `window.stop()` is invoked.


### PR DESCRIPTION
This PR add `validatedUrl` to the `did-fail-load` event.
`validatedUrl` is added as third parameter to the event to avoid breaking backward compatibility.
Without `validatedUrl` it's not possible to determine if the main url failed to load or an asset.

In our usage of electron, it's important for us to know if the requested url failed to load or one of its resources.