### PR TITLE
Adding support for offscreen render and keyboard/mouse event sending to browser-window.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/atom/chromium-breakpad.git
 [submodule "vendor/native_mate"]
 	path = vendor/native_mate
-	url = https://github.com/brenca/native-mate.git
+	url = https://github.com/zcbenz/native-mate.git
 [submodule "vendor/crashpad"]
 	path = vendor/crashpad
 	url = https://github.com/atom/crashpad.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/atom/chromium-breakpad.git
 [submodule "vendor/native_mate"]
 	path = vendor/native_mate
-	url = https://github.com/zcbenz/native-mate.git
+	url = https://github.com/brenca/native-mate.git
 [submodule "vendor/crashpad"]
 	path = vendor/crashpad
 	url = https://github.com/atom/crashpad.git

--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -93,6 +93,7 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
     FILE* dontcare;
     freopen_s(&dontcare, "CON", "w", stdout);
     freopen_s(&dontcare, "CON", "w", stderr);
+    freopen_s(&dontcare, "CON", "r", stdin);
   }
 
   // Convert argv to to UTF8

--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -90,12 +90,9 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
   if (env->GetVar("OS", &os) && os != "cygwin") {
     AttachConsole(ATTACH_PARENT_PROCESS);
 
-    FILE* dontcare, *out, *err;
-    out = fopen("out.txt", "w");
-    err = fopen("err.txt", "w");
-    freopen_s(&out, "CON", "w", stdout);
-    freopen_s(&err, "CON", "w", stderr);
-    freopen_s(&dontcare, "CON", "r", stdin);
+    FILE* dontcare;
+    freopen_s(&dontcare, "CON", "w", stdout);
+    freopen_s(&dontcare, "CON", "w", stderr);
   }
 
   // Convert argv to to UTF8

--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -90,9 +90,11 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
   if (env->GetVar("OS", &os) && os != "cygwin") {
     AttachConsole(ATTACH_PARENT_PROCESS);
 
-    FILE* dontcare;
-    freopen_s(&dontcare, "CON", "w", stdout);
-    freopen_s(&dontcare, "CON", "w", stderr);
+    FILE* dontcare, *out, *err;
+    out = fopen("out.txt", "w");
+    err = fopen("err.txt", "w");
+    freopen_s(&out, "CON", "w", stdout);
+    freopen_s(&err, "CON", "w", stderr);
     freopen_s(&dontcare, "CON", "r", stdin);
   }
 

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -528,10 +528,10 @@ void Window::SendKeyboardEvent(v8::Isolate* isolate, const mate::Dictionary& dat
   int keycode = 0;
   int native = 0;
   std::string type_str = "";
-  std::vector<std::string> modifier_array;
+  mate::Dictionary modifier_list = mate::Dictionary::CreateEmpty(isolate);
 
   data.Get(switches::kEventType, &type_str);
-  data.Get(switches::kModifiers, &modifier_array);
+  data.Get(switches::kModifiers, &modifier_list);
   data.Get(switches::kKeyCode, &keycode);
   data.Get(switches::kNativeKeyCode, &native);
 
@@ -543,28 +543,22 @@ void Window::SendKeyboardEvent(v8::Isolate* isolate, const mate::Dictionary& dat
     type = blink::WebInputEvent::Type::Char;
   }
 
-  for(std::vector<std::string>::iterator mod = modifier_array.begin(); mod != modifier_array.end(); ++mod) {
-    if(mod->compare(event_types::kModifierIsKeyPad) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::IsKeyPad;
-    }else if(mod->compare(event_types::kModifierIsAutoRepeat) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::IsAutoRepeat;
-    }else if(mod->compare(event_types::kModifierIsLeft) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::IsLeft;
-    }else if(mod->compare(event_types::kModifierIsRight) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::IsRight;
-    }else if(mod->compare(event_types::kModifierShiftKey) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::ShiftKey;
-    }else if(mod->compare(event_types::kModifierControlKey) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::ControlKey;
-    }else if(mod->compare(event_types::kModifierAltKey) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::AltKey;
-    }else if(mod->compare(event_types::kModifierMetaKey) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::MetaKey;
-    }else if(mod->compare(event_types::kModifierCapsLockOn) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::CapsLockOn;
-    }else if(mod->compare(event_types::kModifierNumLockOn) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::NumLockOn;
-    }
+  std::map<std::string, bool> modifier_types;
+  modifier_types[event_types::kModifierIsKeyPad] = false;
+  modifier_types[event_types::kModifierIsAutoRepeat] = false;
+  modifier_types[event_types::kModifierIsLeft] = false;
+  modifier_types[event_types::kModifierIsRight] = false;
+  modifier_types[event_types::kModifierShiftKey] = false;
+  modifier_types[event_types::kModifierControlKey] = false;
+  modifier_types[event_types::kModifierAltKey] = false;
+  modifier_types[event_types::kModifierMetaKey] = false;
+  modifier_types[event_types::kModifierCapsLockOn] = false;
+  modifier_types[event_types::kModifierNumLockOn] = false;
+
+  for(std::map<std::string, bool>::iterator it = modifier_types.begin(); it != modifier_types.end(); ++it){
+    modifier_list.Get(it->first,&(it->second));
+
+    if(it->second) modifiers = modifiers & event_types::modifierStrToWebModifier(it->first);
   }
 
   window_->SendKeyboardEvent(type, modifiers, keycode, native);
@@ -574,7 +568,7 @@ void Window::SendMouseEvent(v8::Isolate* isolate, const mate::Dictionary& data){
   int x, y, movementX, movementY, clickCount;
   std::string type_str = "";
   std::string button_str = "";
-  std::vector<std::string> modifier_array;
+  mate::Dictionary modifier_list = mate::Dictionary::CreateEmpty(isolate);
 
   blink::WebInputEvent::Type type = blink::WebInputEvent::Type::MouseMove;
   blink::WebMouseEvent::Button button = blink::WebMouseEvent::Button::ButtonNone;
@@ -582,7 +576,7 @@ void Window::SendMouseEvent(v8::Isolate* isolate, const mate::Dictionary& data){
 
   data.Get(switches::kEventType, &type_str);
   data.Get(switches::kMouseEventButton, &button_str);
-  data.Get(switches::kModifiers, &modifier_array);
+  data.Get(switches::kModifiers, &modifier_list);
 
   if(type_str.compare(event_types::kMouseDown) == 0){
     type = blink::WebInputEvent::Type::MouseDown;
@@ -600,37 +594,24 @@ void Window::SendMouseEvent(v8::Isolate* isolate, const mate::Dictionary& data){
     type = blink::WebInputEvent::Type::MouseWheel;
   }
 
-  if(button_str.compare(event_types::kMouseLeftButton) == 0){
-    modifiers = modifiers & blink::WebInputEvent::Modifiers::LeftButtonDown;
-    button = blink::WebMouseEvent::Button::ButtonLeft;
-  }else if(button_str.compare(event_types::kMouseRightButton) == 0){
-    modifiers = modifiers & blink::WebInputEvent::Modifiers::RightButtonDown;
-    button = blink::WebMouseEvent::Button::ButtonRight;
-  }else if(button_str.compare(event_types::kMouseMiddleButton) == 0){
-    modifiers = modifiers & blink::WebInputEvent::Modifiers::MiddleButtonDown;
-    button = blink::WebMouseEvent::Button::ButtonMiddle;
-  }
+  std::map<std::string, bool> modifier_types;
+  modifier_types[event_types::kMouseLeftButton] = false;
+  modifier_types[event_types::kMouseRightButton] = false;
+  modifier_types[event_types::kMouseMiddleButton] = false;
+  modifier_types[event_types::kModifierLeftButtonDown] = false;
+  modifier_types[event_types::kModifierMiddleButtonDown] = false;
+  modifier_types[event_types::kModifierRightButtonDown] = false;
+  modifier_types[event_types::kModifierShiftKey] = false;
+  modifier_types[event_types::kModifierControlKey] = false;
+  modifier_types[event_types::kModifierAltKey] = false;
+  modifier_types[event_types::kModifierMetaKey] = false;
+  modifier_types[event_types::kModifierCapsLockOn] = false;
+  modifier_types[event_types::kModifierNumLockOn] = false;
 
-  for(std::vector<std::string>::iterator mod = modifier_array.begin(); mod != modifier_array.end(); ++mod) {
-    if(mod->compare(event_types::kModifierLeftButtonDown) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::LeftButtonDown;
-    }else if(mod->compare(event_types::kModifierMiddleButtonDown) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::MiddleButtonDown;
-    }else if(mod->compare(event_types::kModifierRightButtonDown) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::RightButtonDown;
-    }else if(mod->compare(event_types::kModifierShiftKey) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::ShiftKey;
-    }else if(mod->compare(event_types::kModifierControlKey) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::ControlKey;
-    }else if(mod->compare(event_types::kModifierAltKey) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::AltKey;
-    }else if(mod->compare(event_types::kModifierMetaKey) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::MetaKey;
-    }else if(mod->compare(event_types::kModifierCapsLockOn) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::CapsLockOn;
-    }else if(mod->compare(event_types::kModifierNumLockOn) == 0){
-      modifiers = modifiers & blink::WebInputEvent::Modifiers::NumLockOn;
-    }
+  for(std::map<std::string, bool>::iterator it = modifier_types.begin(); it != modifier_types.end(); ++it){
+    modifier_list.Get(it->first,&(it->second));
+
+    if(it->second) modifiers = modifiers & event_types::modifierStrToWebModifier(it->first);
   }
 
   if(type == blink::WebInputEvent::Type::MouseWheel){

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -526,12 +526,14 @@ void Window::SendKeyboardEvent(v8::Isolate* isolate, const mate::Dictionary& dat
   auto type = blink::WebInputEvent::Type::Char;
   int modifiers = 0;
   int keycode = 0;
+  int native = 0;
   std::string type_str = "";
   std::vector<std::string> modifier_array;
 
-  data.Get(switches::kMouseEventType, &type_str);
+  data.Get(switches::kEventType, &type_str);
   data.Get(switches::kModifiers, &modifier_array);
   data.Get(switches::kKeyCode, &keycode);
+  data.Get(switches::kNativeKeyCode, &native);
 
   if(type_str.compare(event_types::kKeyDown) == 0){
     type = blink::WebInputEvent::Type::KeyDown;
@@ -565,7 +567,7 @@ void Window::SendKeyboardEvent(v8::Isolate* isolate, const mate::Dictionary& dat
     }
   }
 
-  window_->SendKeyboardEvent(type, modifiers, keycode);
+  window_->SendKeyboardEvent(type, modifiers, keycode, native);
 }
 
 void Window::SendMouseEvent(v8::Isolate* isolate, const mate::Dictionary& data){
@@ -578,7 +580,7 @@ void Window::SendMouseEvent(v8::Isolate* isolate, const mate::Dictionary& data){
   blink::WebMouseEvent::Button button = blink::WebMouseEvent::Button::ButtonNone;
   int modifiers = 0;
 
-  data.Get(switches::kMouseEventType, &type_str);
+  data.Get(switches::kEventType, &type_str);
   data.Get(switches::kMouseEventButton, &button_str);
   data.Get(switches::kModifiers, &modifier_array);
 

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -8,6 +8,8 @@
 #include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/browser.h"
 #include "atom/browser/native_window.h"
+#include "atom/common/options_switches.h"
+#include "atom/common/event_types.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/gfx_converter.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
@@ -516,6 +518,144 @@ bool Window::IsVisibleOnAllWorkspaces() {
   return window_->IsVisibleOnAllWorkspaces();
 }
 
+void Window::SendKeyboardEvent(v8::Isolate* isolate, const mate::Dictionary& data){
+  auto type = blink::WebInputEvent::Type::Char;
+  int modifiers = 0;
+  int keycode = 0;
+  std::string type_str = "";
+  std::vector<std::string> modifier_array;
+
+  data.Get(switches::kMouseEventType, &type_str);
+  data.Get(switches::kModifiers, &modifier_array);
+  data.Get(switches::kKeyCode, &keycode);
+
+  if(type_str.compare(event_types::kKeyDown) == 0){
+    type = blink::WebInputEvent::Type::KeyDown;
+  }else if(type_str.compare(event_types::kKeyUp) == 0){
+    type = blink::WebInputEvent::Type::KeyUp;
+  }else if(type_str.compare(event_types::kChar) == 0){
+    type = blink::WebInputEvent::Type::Char;
+  }
+
+  for(std::vector<std::string>::iterator mod = modifier_array.begin(); mod != modifier_array.end(); ++mod) {
+    if(mod->compare(event_types::kModifierIsKeyPad) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::IsKeyPad;
+    }else if(mod->compare(event_types::kModifierIsAutoRepeat) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::IsAutoRepeat;
+    }else if(mod->compare(event_types::kModifierIsLeft) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::IsLeft;
+    }else if(mod->compare(event_types::kModifierIsRight) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::IsRight;
+    }else if(mod->compare(event_types::kModifierShiftKey) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::ShiftKey;
+    }else if(mod->compare(event_types::kModifierControlKey) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::ControlKey;
+    }else if(mod->compare(event_types::kModifierAltKey) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::AltKey;
+    }else if(mod->compare(event_types::kModifierMetaKey) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::MetaKey;
+    }else if(mod->compare(event_types::kModifierCapsLockOn) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::CapsLockOn;
+    }else if(mod->compare(event_types::kModifierNumLockOn) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::NumLockOn;
+    }
+  }
+
+  window_->SendKeyboardEvent(type, modifiers, keycode);
+}
+
+void Window::SendMouseEvent(v8::Isolate* isolate, const mate::Dictionary& data){
+  int x, y, movementX, movementY, clickCount;
+  std::string type_str = "";
+  std::string button_str = "";
+  std::vector<std::string> modifier_array;
+
+  blink::WebInputEvent::Type type = blink::WebInputEvent::Type::MouseMove;
+  blink::WebMouseEvent::Button button = blink::WebMouseEvent::Button::ButtonNone;
+  int modifiers = 0;
+
+  data.Get(switches::kMouseEventType, &type_str);
+  data.Get(switches::kMouseEventButton, &button_str);
+  data.Get(switches::kModifiers, &modifier_array);
+
+  if(type_str.compare(event_types::kMouseDown) == 0){
+    type = blink::WebInputEvent::Type::MouseDown;
+  }else if(type_str.compare(event_types::kMouseUp) == 0){
+    type = blink::WebInputEvent::Type::MouseUp;
+  }else if(type_str.compare(event_types::kMouseMove) == 0){
+    type = blink::WebInputEvent::Type::MouseMove;
+  }else if(type_str.compare(event_types::kMouseEnter) == 0){
+    type = blink::WebInputEvent::Type::MouseEnter;
+  }else if(type_str.compare(event_types::kMouseLeave) == 0){
+    type = blink::WebInputEvent::Type::MouseLeave;
+  }else if(type_str.compare(event_types::kContextMenu) == 0){
+    type = blink::WebInputEvent::Type::ContextMenu;
+  }else if(type_str.compare(event_types::kMouseWheel) == 0){
+    type = blink::WebInputEvent::Type::MouseWheel;
+  }
+
+  if(button_str.compare(event_types::kMouseLeftButton) == 0){
+    modifiers = modifiers & blink::WebInputEvent::Modifiers::LeftButtonDown;
+    button = blink::WebMouseEvent::Button::ButtonLeft;
+  }else if(button_str.compare(event_types::kMouseRightButton) == 0){
+    modifiers = modifiers & blink::WebInputEvent::Modifiers::RightButtonDown;
+    button = blink::WebMouseEvent::Button::ButtonRight;
+  }else if(button_str.compare(event_types::kMouseMiddleButton) == 0){
+    modifiers = modifiers & blink::WebInputEvent::Modifiers::MiddleButtonDown;
+    button = blink::WebMouseEvent::Button::ButtonMiddle;
+  }
+
+  for(std::vector<std::string>::iterator mod = modifier_array.begin(); mod != modifier_array.end(); ++mod) {
+    if(mod->compare(event_types::kModifierLeftButtonDown) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::LeftButtonDown;
+    }else if(mod->compare(event_types::kModifierMiddleButtonDown) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::MiddleButtonDown;
+    }else if(mod->compare(event_types::kModifierRightButtonDown) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::RightButtonDown;
+    }else if(mod->compare(event_types::kModifierShiftKey) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::ShiftKey;
+    }else if(mod->compare(event_types::kModifierControlKey) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::ControlKey;
+    }else if(mod->compare(event_types::kModifierAltKey) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::AltKey;
+    }else if(mod->compare(event_types::kModifierMetaKey) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::MetaKey;
+    }else if(mod->compare(event_types::kModifierCapsLockOn) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::CapsLockOn;
+    }else if(mod->compare(event_types::kModifierNumLockOn) == 0){
+      modifiers = modifiers & blink::WebInputEvent::Modifiers::NumLockOn;
+    }
+  }
+
+  if(type == blink::WebInputEvent::Type::MouseWheel){
+    bool precise = true;
+
+    x = 0;
+    y = 0;
+    data.Get(switches::kX, &x);
+    data.Get(switches::kY, &y);
+    data.Get(switches::kMouseWheelPrecise, &precise);
+
+    window_->SendMouseWheelEvent(modifiers, x, y, precise);
+  }else{
+    if (data.Get(switches::kX, &x) && data.Get(switches::kY, &y)) {
+      if(!data.Get(switches::kMovementX, &movementX)){
+        movementX = 0;
+      }
+
+      if(!data.Get(switches::kMovementY, &movementY)){
+        movementY = 0;
+      }
+
+      if(!data.Get(switches::kClickCount, &clickCount)){
+        clickCount = 0;
+      }
+
+      window_->SendMouseEvent(type, modifiers, button, x, y, movementX, movementY, clickCount);
+    }
+  }
+}
+
 int32_t Window::ID() const {
   return weak_map_id();
 }
@@ -599,6 +739,8 @@ void Window::BuildPrototype(v8::Isolate* isolate,
                  &Window::SetVisibleOnAllWorkspaces)
       .SetMethod("isVisibleOnAllWorkspaces",
                  &Window::IsVisibleOnAllWorkspaces)
+      .SetMethod("sendMouseEvent", &Window::SendMouseEvent)
+      .SetMethod("sendKeyboardEvent", &Window::SendKeyboardEvent)
 #if defined(OS_MACOSX)
       .SetMethod("showDefinitionForSelection",
                  &Window::ShowDefinitionForSelection)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -17,6 +17,7 @@
 #include "native_mate/constructor.h"
 #include "native_mate/dictionary.h"
 #include "ui/gfx/geometry/rect.h"
+#include "v8/include/v8.h"
 
 #if defined(OS_WIN)
 #include "atom/browser/native_window_views.h"
@@ -90,6 +91,16 @@ void Window::OnPageTitleUpdated(bool* prevent_default,
 
 void Window::WillCloseWindow(bool* prevent_default) {
   *prevent_default = Emit("close");
+}
+
+void Window::OnFrameRendered(scoped_ptr<uint8[]> rgb, const int size) {
+  v8::Locker locker(isolate());
+  v8::HandleScope handle_scope(isolate());
+
+  v8::Local<v8::ArrayBuffer> data = v8::ArrayBuffer::New(isolate(), rgb.get(), size);
+  v8::Local<v8::Uint8ClampedArray> uint_data = v8::Uint8ClampedArray::New(data, 0, size);
+
+  Emit("frame-rendered", uint_data, size);
 }
 
 void Window::OnWindowClosed() {

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -141,7 +141,8 @@ class Window : public mate::TrackableObject<Window>,
 
   void SendKeyboardEvent(v8::Isolate* isolate, const mate::Dictionary& data);
   void SendMouseEvent(v8::Isolate* isolate, const mate::Dictionary& data);
-  void SetOffscreenRender(bool isOffscreen);
+  void BeginFrameSubscription();
+  void EndFrameSubscription();
 
 #if defined(OS_MACOSX)
   void ShowDefinitionForSelection();

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -53,6 +53,7 @@ class Window : public mate::TrackableObject<Window>,
   void OnPageTitleUpdated(bool* prevent_default,
                           const std::string& title) override;
   void WillCloseWindow(bool* prevent_default) override;
+  void OnFrameRendered(scoped_ptr<uint8[]> rgb, const int size) override;
   void OnWindowClosed() override;
   void OnWindowBlur() override;
   void OnWindowFocus() override;

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -138,6 +138,8 @@ class Window : public mate::TrackableObject<Window>,
   void SetMenuBarVisibility(bool visible);
   bool IsMenuBarVisible();
   void SetAspectRatio(double aspect_ratio, mate::Arguments* args);
+  void SendKeyboardEvent(v8::Isolate* isolate, const mate::Dictionary& data);
+  void SendMouseEvent(v8::Isolate* isolate, const mate::Dictionary& data);
 
 #if defined(OS_MACOSX)
   void ShowDefinitionForSelection();

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -592,12 +592,8 @@ void NativeWindow::SendKeyboardEvent(blink::WebInputEvent::Type type, int modifi
 
   const auto view = web_contents()->GetRenderWidgetHostView();
   const auto host = view ? view->GetRenderWidgetHost() : nullptr;
-  host->ForwardKeyboardEvent(*keyb_event);
 
-  if(keyb_event->type == blink::WebInputEvent::Type::KeyDown){
-    keyb_event->type = blink::WebInputEvent::RawKeyDown;
-    host->ForwardKeyboardEvent(*keyb_event);
-  }
+  host->ForwardKeyboardEvent(*keyb_event);
 }
 
 void NativeWindow::SendMouseEvent(blink::WebInputEvent::Type type, int modifiers, blink::WebMouseEvent::Button button, int x, int y, int movementX, int movementY, int clickCount){

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -333,7 +333,7 @@ void NativeWindow::CapturePage(const gfx::Rect& rect,
       kBGRA_8888_SkColorType);
 }
 
-void NativeWindow::SetOffscreenRender(bool isOffscreen) {
+void NativeWindow::SetFrameSubscription(bool isOffscreen) {
   if (!isOffscreen && !offscreen_) return;
 
   const auto view = web_contents()->GetRenderWidgetHostView();
@@ -637,7 +637,7 @@ void NativeWindow::SendMouseWheelEvent(int modifiers, int x, int y, bool precise
 }
 
 void NativeWindow::DidFinishLoad(content::RenderFrameHost* render_frame_host, const GURL& validated_url) {
-  SetOffscreenRender(offscreen_);
+  SetFrameSubscription(offscreen_);
 }
 
 void NativeWindow::RenderViewCreated(

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -8,6 +8,9 @@
 #include <utility>
 #include <vector>
 
+#include "content/public/browser/render_widget_host_view_frame_subscriber.h"
+#include "media/base/video_frame.h"
+#include "media/base/yuv_convert.h"
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/atom_browser_main_parts.h"
 #include "atom/browser/window_list.h"
@@ -147,8 +150,9 @@ NativeWindow* NativeWindow::FromWebContents(
     content::WebContents* web_contents) {
   WindowList& window_list = *WindowList::GetInstance();
   for (NativeWindow* window : window_list) {
-    if (window->web_contents() == web_contents)
+    if (window->web_contents() == web_contents){
       return window;
+    }
   }
   return nullptr;
 }
@@ -200,6 +204,9 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   std::string title("Electron");
   options.Get(switches::kTitle, &title);
   SetTitle(title);
+
+  offscreen_ = false;
+  options.Get(switches::kOffScreenRender, &offscreen_);
 
   // Then show it.
   bool show = true;
@@ -540,6 +547,18 @@ void NativeWindow::DevToolsClosed() {
   FOR_EACH_OBSERVER(NativeWindowObserver, observers_, OnDevToolsClosed());
 }
 
+void NativeWindow::RenderViewReady(){
+  if(offscreen_){
+    const auto view = web_contents()->GetRenderWidgetHostView();
+
+    scoped_ptr<content::RenderWidgetHostViewFrameSubscriber> subscriber(new RenderSubscriber(
+      view->GetVisibleViewportSize(), base::Bind(&NativeWindow::OnFrameReceived, base::Unretained(this))
+    ));
+
+    view->BeginFrameSubscription(subscriber.Pass());
+  }
+}
+
 void NativeWindow::RenderViewCreated(
     content::RenderViewHost* render_view_host) {
   if (!transparent_)
@@ -615,6 +634,43 @@ void NativeWindow::OnCapturePageDone(const CapturePageCallback& callback,
                                      const SkBitmap& bitmap,
                                      content::ReadbackResponse response) {
   callback.Run(bitmap);
+}
+
+void NativeWindow::OnFrameReceived(bool result, scoped_refptr<media::VideoFrame> frame) {
+  if(result){
+    gfx::Rect rect = frame->visible_rect();
+
+    const int rgb_arr_size = rect.width()*rect.height()*4;
+    scoped_ptr<uint8[]> rgb_bytes(new uint8[rgb_arr_size]);
+
+    // Convert a frame of YUV to 32 bit ARGB.
+    media::ConvertYUVToRGB32(frame->data(media::VideoFrame::kYPlane),
+                             frame->data(media::VideoFrame::kUPlane),
+                             frame->data(media::VideoFrame::kVPlane),
+                             rgb_bytes.get(),
+                             rect.width(), rect.height(),
+                             frame->stride(media::VideoFrame::kYPlane),
+                             frame->stride(media::VideoFrame::kUVPlane),
+                             rect.width()*4,
+                             media::YV12);
+
+    FOR_EACH_OBSERVER(NativeWindowObserver,
+                      observers_,
+                      OnFrameRendered(rgb_bytes.Pass(), rgb_arr_size));
+  }
+}
+
+bool RenderSubscriber::ShouldCaptureFrame(const gfx::Rect& damage_rect,
+                        base::TimeTicks present_time,
+                        scoped_refptr<media::VideoFrame>* storage,
+                        DeliverFrameCallback* callback) {
+  last_present_time_ = present_time;
+  *storage = media::VideoFrame::CreateFrame(media::VideoFrame::YV12, size_,
+                                            gfx::Rect(size_), size_,
+                                            base::TimeDelta());
+
+  *callback = base::Bind(&RenderSubscriber::CallbackMethod, callback_, *storage);
+  return true;
 }
 
 }  // namespace atom

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -9,6 +9,8 @@
 #include <vector>
 
 #include "content/public/browser/render_widget_host_view_frame_subscriber.h"
+#include "content/public/browser/native_web_keyboard_event.h"
+#include "third_party/WebKit/public/web/WebInputEvent.h"
 #include "media/base/video_frame.h"
 #include "media/base/yuv_convert.h"
 #include "atom/browser/atom_browser_context.h"
@@ -547,10 +549,69 @@ void NativeWindow::DevToolsClosed() {
   FOR_EACH_OBSERVER(NativeWindowObserver, observers_, OnDevToolsClosed());
 }
 
-void NativeWindow::RenderViewReady(){
-  if(offscreen_){
-    const auto view = web_contents()->GetRenderWidgetHostView();
+void NativeWindow::SendKeyboardEvent(blink::WebInputEvent::Type type, int modifiers, int keycode){
+  auto keyb_event = new content::NativeWebKeyboardEvent;
 
+  keyb_event->nativeKeyCode = keycode;
+  keyb_event->windowsKeyCode = keycode;
+  keyb_event->setKeyIdentifierFromWindowsKeyCode();
+  keyb_event->type = type;
+  keyb_event->modifiers = modifiers;
+  keyb_event->isSystemKey = false;
+  keyb_event->timeStampSeconds = base::Time::Now().ToDoubleT();
+  keyb_event->skip_in_browser = false;
+
+  if (type == blink::WebInputEvent::Char || type == blink::WebInputEvent::KeyDown) {
+    keyb_event->text[0] = keycode;
+    keyb_event->unmodifiedText[0] = keycode;
+  }
+
+  const auto view = web_contents()->GetRenderWidgetHostView();
+  const auto host = view ? view->GetRenderWidgetHost() : nullptr;
+  host->ForwardKeyboardEvent(*keyb_event);
+}
+
+void NativeWindow::SendMouseEvent(blink::WebInputEvent::Type type, int modifiers, blink::WebMouseEvent::Button button, int x, int y, int movementX, int movementY, int clickCount){
+  auto mouse_event = new blink::WebMouseEvent();
+
+  mouse_event->x = x;
+  mouse_event->y = y;
+  mouse_event->windowX = x;
+  mouse_event->windowY = y;
+  mouse_event->clickCount = clickCount;
+  mouse_event->type = type;
+  mouse_event->modifiers = modifiers;
+  mouse_event->button = button;
+
+  mouse_event->timeStampSeconds = base::Time::Now().ToDoubleT();
+
+  const auto view = web_contents()->GetRenderWidgetHostView();
+  const auto host = view ? view->GetRenderWidgetHost() : nullptr;
+  host->ForwardMouseEvent(*mouse_event);
+}
+
+void NativeWindow::SendMouseWheelEvent(int modifiers, int x, int y, bool precise){
+  auto wheel_event = new blink::WebMouseWheelEvent();
+
+  wheel_event->type = blink::WebInputEvent::MouseWheel;
+  wheel_event->deltaX = x;
+  wheel_event->deltaY = y;
+  if(x) wheel_event->wheelTicksX = x > 0.0f ? 1.0f : -1.0f;
+  if(y) wheel_event->wheelTicksY = y > 0.0f ? 1.0f : -1.0f;
+  wheel_event->modifiers = modifiers;
+  wheel_event->hasPreciseScrollingDeltas = precise;
+  wheel_event->canScroll = true;
+
+  const auto view = web_contents()->GetRenderWidgetHostView();
+  const auto host = view ? view->GetRenderWidgetHost() : nullptr;
+  host->ForwardWheelEvent(*wheel_event);
+}
+
+void NativeWindow::DidFinishLoad(content::RenderFrameHost* render_frame_host, const GURL& validated_url) {
+  const auto view = web_contents()->GetRenderWidgetHostView();
+  const auto host = view ? view->GetRenderWidgetHost() : nullptr;
+
+  if(offscreen_){
     scoped_ptr<content::RenderWidgetHostViewFrameSubscriber> subscriber(new RenderSubscriber(
       view->GetVisibleViewportSize(), base::Bind(&NativeWindow::OnFrameReceived, base::Unretained(this))
     ));

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -242,7 +242,7 @@ class NativeWindow : public content::WebContentsObserver,
   void SendMouseEvent(blink::WebInputEvent::Type type, int modifiers, blink::WebMouseEvent::Button button, int x, int y, int movementX, int movementY, int clickCount);
   void SendMouseWheelEvent(int modifiers, int x, int y, bool clickCount);
 
-  void SetOffscreenRender(bool isOffscreen);
+  void SetFrameSubscription(bool isOffscreen);
 
  protected:
   NativeWindow(brightray::InspectableWebContents* inspectable_web_contents,

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -238,7 +238,7 @@ class NativeWindow : public content::WebContentsObserver,
 
   void OnFrameReceived(bool result, scoped_refptr<media::VideoFrame> frame);
 
-  void SendKeyboardEvent(blink::WebInputEvent::Type type, int modifiers, int keycode);
+  void SendKeyboardEvent(blink::WebInputEvent::Type type, int modifiers, int keycode, int nativeKeycode);
   void SendMouseEvent(blink::WebInputEvent::Type type, int modifiers, blink::WebMouseEvent::Button button, int x, int y, int movementX, int movementY, int clickCount);
   void SendMouseWheelEvent(int modifiers, int x, int y, bool clickCount);
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -332,6 +332,7 @@ class NativeWindow : public content::WebContentsObserver,
   DISALLOW_COPY_AND_ASSIGN(NativeWindow);
 };
 
+//This class provides a way to listen to frame renders and to use the rendered frames for offscreen rendering
 class RenderSubscriber : public content::RenderWidgetHostViewFrameSubscriber {
  public:
   RenderSubscriber(gfx::Size size, base::Callback<void(bool, scoped_refptr<media::VideoFrame>)> callback) : size_(size), callback_(callback) {}

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -11,6 +11,8 @@
 
 #include "media/base/video_frame.h"
 #include "content/public/browser/render_widget_host_view_frame_subscriber.h"
+#include "content/public/browser/native_web_keyboard_event.h"
+#include "third_party/WebKit/public/web/WebInputEvent.h"
 #include "atom/browser/native_window_observer.h"
 #include "atom/browser/ui/accelerator_util.h"
 #include "base/cancelable_callback.h"
@@ -236,6 +238,10 @@ class NativeWindow : public content::WebContentsObserver,
 
   void OnFrameReceived(bool result, scoped_refptr<media::VideoFrame> frame);
 
+  void SendKeyboardEvent(blink::WebInputEvent::Type type, int modifiers, int keycode);
+  void SendMouseEvent(blink::WebInputEvent::Type type, int modifiers, blink::WebMouseEvent::Button button, int x, int y, int movementX, int movementY, int clickCount);
+  void SendMouseWheelEvent(int modifiers, int x, int y, bool clickCount);
+
  protected:
   NativeWindow(brightray::InspectableWebContents* inspectable_web_contents,
                const mate::Dictionary& options);
@@ -248,6 +254,7 @@ class NativeWindow : public content::WebContentsObserver,
   // content::WebContentsObserver:
   void RenderViewCreated(content::RenderViewHost* render_view_host) override;
   void RenderViewReady() override;
+  void DidFinishLoad(content::RenderFrameHost* render_frame_host, const GURL& validated_url) override;
   void BeforeUnloadDialogCancelled() override;
   void TitleWasSet(content::NavigationEntry* entry, bool explicit_set) override;
   bool OnMessageReceived(const IPC::Message& message) override;

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -27,6 +27,8 @@ class NativeWindowObserver {
                                      const std::string& partition_id,
                                      WindowOpenDisposition disposition) {}
 
+  virtual void OnFrameRendered(scoped_ptr<uint8[]> rgb, const int size) {}
+
   // Called when user is starting an navigation in web page.
   virtual void WillNavigate(bool* prevent_default, const GURL& url) {}
 

--- a/atom/common/event_types.cc
+++ b/atom/common/event_types.cc
@@ -1,0 +1,45 @@
+// Copyright (c) 2013 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/common/event_types.h"
+
+namespace atom {
+
+namespace event_types {
+
+const char kMouseDown[] = "down";
+const char kMouseUp[] = "up";
+const char kMouseMove[] = "move";
+const char kMouseEnter[] = "enter";
+const char kMouseLeave[] = "leave";
+const char kContextMenu[] = "context-menu";
+const char kMouseWheel[] = "wheel";
+
+const char kKeyDown[] = "key-down";
+const char kKeyUp[] = "key-up";
+const char kChar[] = "char";
+
+const char kMouseLeftButton[] = "left";
+const char kMouseRightButton[] = "right";
+const char kMouseMiddleButton[] = "middle";
+
+const char kModifierLeftButtonDown[] = "left-button-down";
+const char kModifierMiddleButtonDown[] = "middle-button-down";
+const char kModifierRightButtonDown[] = "right-button-down";
+
+const char kModifierShiftKey[] = "shift";
+const char kModifierControlKey[] = "control";
+const char kModifierAltKey[] = "alt";
+const char kModifierMetaKey[] = "meta";
+const char kModifierCapsLockOn[] = "caps-lock";
+const char kModifierNumLockOn[] = "num-lock";
+
+const char kModifierIsKeyPad[] = "keypad";
+const char kModifierIsAutoRepeat[] = "auto-repeat";
+const char kModifierIsLeft[] = "left";
+const char kModifierIsRight[] = "right";
+
+}  // namespace switches
+
+}  // namespace atom

--- a/atom/common/event_types.cc
+++ b/atom/common/event_types.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "atom/common/event_types.h"
+#include "third_party/WebKit/public/web/WebInputEvent.h"
 
 namespace atom {
 
@@ -40,6 +41,78 @@ const char kModifierIsAutoRepeat[] = "auto-repeat";
 const char kModifierIsLeft[] = "left";
 const char kModifierIsRight[] = "right";
 
-}  // namespace switches
+int modifierStrToWebModifier(std::string modifier){
+  if(modifier.compare(event_types::kModifierLeftButtonDown) == 0){
+
+    return blink::WebInputEvent::Modifiers::LeftButtonDown;
+
+  }else if(modifier.compare(event_types::kModifierMiddleButtonDown) == 0){
+
+    return blink::WebInputEvent::Modifiers::MiddleButtonDown;
+
+  }else if(modifier.compare(event_types::kModifierRightButtonDown) == 0){
+
+    return blink::WebInputEvent::Modifiers::RightButtonDown;
+
+  }else if(modifier.compare(event_types::kMouseLeftButton) == 0){
+
+    return blink::WebInputEvent::Modifiers::LeftButtonDown;
+
+  }else if(modifier.compare(event_types::kMouseRightButton) == 0){
+
+    return blink::WebInputEvent::Modifiers::RightButtonDown;
+
+  }else if(modifier.compare(event_types::kMouseMiddleButton) == 0){
+
+    return blink::WebInputEvent::Modifiers::MiddleButtonDown;
+
+  }else if(modifier.compare(event_types::kModifierIsKeyPad) == 0){
+
+    return blink::WebInputEvent::Modifiers::IsKeyPad;
+
+  }else if(modifier.compare(event_types::kModifierIsAutoRepeat) == 0){
+
+    return blink::WebInputEvent::Modifiers::IsAutoRepeat;
+
+  }else if(modifier.compare(event_types::kModifierIsLeft) == 0){
+
+    return blink::WebInputEvent::Modifiers::IsLeft;
+
+  }else if(modifier.compare(event_types::kModifierIsRight) == 0){
+
+    return blink::WebInputEvent::Modifiers::IsRight;
+
+  }else if(modifier.compare(event_types::kModifierShiftKey) == 0){
+
+    return blink::WebInputEvent::Modifiers::ShiftKey;
+
+  }else if(modifier.compare(event_types::kModifierControlKey) == 0){
+
+    return blink::WebInputEvent::Modifiers::ControlKey;
+
+  }else if(modifier.compare(event_types::kModifierAltKey) == 0){
+
+    return blink::WebInputEvent::Modifiers::AltKey;
+
+  }else if(modifier.compare(event_types::kModifierMetaKey) == 0){
+
+    return blink::WebInputEvent::Modifiers::MetaKey;
+
+  }else if(modifier.compare(event_types::kModifierCapsLockOn) == 0){
+
+    return blink::WebInputEvent::Modifiers::CapsLockOn;
+
+  }else if(modifier.compare(event_types::kModifierNumLockOn) == 0){
+
+    return blink::WebInputEvent::Modifiers::NumLockOn;
+
+  }else{
+
+    return 0;
+
+  }
+}
+
+}  // namespace event_types
 
 }  // namespace atom

--- a/atom/common/event_types.cc
+++ b/atom/common/event_types.cc
@@ -16,8 +16,8 @@ const char kMouseLeave[] = "leave";
 const char kContextMenu[] = "context-menu";
 const char kMouseWheel[] = "wheel";
 
-const char kKeyDown[] = "key-down";
-const char kKeyUp[] = "key-up";
+const char kKeyDown[] = "down";
+const char kKeyUp[] = "up";
 const char kChar[] = "char";
 
 const char kMouseLeftButton[] = "left";

--- a/atom/common/event_types.h
+++ b/atom/common/event_types.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2013 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_COMMON_EVENT_TYPES_H_
+#define ATOM_COMMON_EVENT_TYPES_H_
+
+namespace atom {
+
+namespace event_types {
+
+extern const char kMouseDown[];
+extern const char kMouseUp[];
+extern const char kMouseMove[];
+extern const char kMouseEnter[];
+extern const char kMouseLeave[];
+extern const char kContextMenu[];
+extern const char kMouseWheel[];
+
+extern const char kKeyDown[];
+extern const char kKeyUp[];
+extern const char kChar[];
+
+extern const char kMouseLeftButton[];
+extern const char kMouseRightButton[];
+extern const char kMouseMiddleButton[];
+
+extern const char kModifierLeftButtonDown[];
+extern const char kModifierMiddleButtonDown[];
+extern const char kModifierRightButtonDown[];
+
+extern const char kModifierShiftKey[];
+extern const char kModifierControlKey[];
+extern const char kModifierAltKey[];
+extern const char kModifierMetaKey[];
+extern const char kModifierCapsLockOn[];
+extern const char kModifierNumLockOn[];
+
+extern const char kModifierIsKeyPad[];
+extern const char kModifierIsAutoRepeat[];
+extern const char kModifierIsLeft[];
+extern const char kModifierIsRight[];
+
+}  // namespace switches
+
+}  // namespace atom
+
+#endif  // ATOM_COMMON_EVENT_TYPES_H_

--- a/atom/common/event_types.h
+++ b/atom/common/event_types.h
@@ -5,6 +5,8 @@
 #ifndef ATOM_COMMON_EVENT_TYPES_H_
 #define ATOM_COMMON_EVENT_TYPES_H_
 
+#include "third_party/WebKit/public/web/WebInputEvent.h"
+
 namespace atom {
 
 namespace event_types {
@@ -41,7 +43,9 @@ extern const char kModifierIsAutoRepeat[];
 extern const char kModifierIsLeft[];
 extern const char kModifierIsRight[];
 
-}  // namespace switches
+int modifierStrToWebModifier(std::string modifier);
+
+}  // namespace event_types
 
 }  // namespace atom
 

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -112,6 +112,16 @@ const char kAppUserModelId[] = "app-user-model-id";
 
 const char kOffScreenRender[] = "offscreen-render";
 
+const char kModifiers[] = "modifiers";
+const char kKeyCode[] = "keycode";
+
+const char kMovementX[] = "movement-x";
+const char kMovementY[] = "movement-y";
+const char kClickCount[] = "click-count";
+const char kMouseEventType[] = "type";
+const char kMouseEventButton[] = "button";
+const char kMouseWheelPrecise[] = "precise";
+
 }  // namespace switches
 
 }  // namespace atom

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -113,12 +113,13 @@ const char kAppUserModelId[] = "app-user-model-id";
 const char kOffScreenRender[] = "offscreen-render";
 
 const char kModifiers[] = "modifiers";
-const char kKeyCode[] = "keycode";
+const char kKeyCode[] = "code";
+const char kNativeKeyCode[] = "native";
 
 const char kMovementX[] = "movement-x";
 const char kMovementY[] = "movement-y";
 const char kClickCount[] = "click-count";
-const char kMouseEventType[] = "type";
+const char kEventType[] = "type";
 const char kMouseEventButton[] = "button";
 const char kMouseWheelPrecise[] = "precise";
 

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -110,6 +110,8 @@ const char kRegisterStandardSchemes[] = "register-standard-schemes";
 // The browser process app model ID
 const char kAppUserModelId[] = "app-user-model-id";
 
+const char kOffScreenRender[] = "offscreen-render";
+
 }  // namespace switches
 
 }  // namespace atom

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -62,6 +62,16 @@ extern const char kAppUserModelId[];
 
 extern const char kOffScreenRender[];
 
+extern const char kModifiers[];
+extern const char kKeyCode[];
+
+extern const char kMovementX[];
+extern const char kMovementY[];
+extern const char kClickCount[];
+extern const char kMouseEventType[];
+extern const char kMouseEventButton[];
+extern const char kMouseWheelPrecise[];
+
 }  // namespace switches
 
 }  // namespace atom

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -64,11 +64,12 @@ extern const char kOffScreenRender[];
 
 extern const char kModifiers[];
 extern const char kKeyCode[];
+extern const char kNativeKeyCode[];
 
 extern const char kMovementX[];
 extern const char kMovementY[];
 extern const char kClickCount[];
-extern const char kMouseEventType[];
+extern const char kEventType[];
 extern const char kMouseEventButton[];
 extern const char kMouseWheelPrecise[];
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -60,6 +60,8 @@ extern const char kRegisterStandardSchemes[];
 
 extern const char kAppUserModelId[];
 
+extern const char kOffScreenRender[];
+
 }  // namespace switches
 
 }  // namespace atom

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -759,16 +759,16 @@ Sends a mouse event to the BrowserWindow.
     * `middle` String - The middle button was pressed.
   * `click-count` Integer - The number of clicks associated with the mouse event.
   * `precise` Boolean - For the `wheel` event type, this option sets the `hasPreciseScrollingDeltas` option of the event.
-  * `modifiers` Array of Strings - The modifier values associated with the event.
-    * `left-button-down` String - The left mouse button was pressed.
-    * `middle-button-down` String - The right mouse button was pressed.
-    * `right-button-down` String - The middle mouse button was pressed.
-    * `shift` String - The shift key was pressed.
-    * `control` String - The control key was pressed.
-    * `alt` String - The alt key was pressed.
-    * `meta` String - The meta key was pressed.
-    * `caps-lock` String - The caps-lock key was pressed.
-    * `num-lock` String - The num-lock key was pressed.
+  * `modifiers` Object - The modifier values associated with the event.
+    * `left-button-down` Boolean - The left mouse button was pressed.
+    * `middle-button-down` Boolean - The right mouse button was pressed.
+    * `right-button-down` Boolean - The middle mouse button was pressed.
+    * `shift` Boolean - The shift key was pressed.
+    * `control` Boolean - The control key was pressed.
+    * `alt` Boolean - The alt key was pressed.
+    * `meta` Boolean - The meta key was pressed.
+    * `caps-lock` Boolean - The caps-lock key was on.
+    * `num-lock` Boolean - The num-lock key was on.
 
 ### BrowserWindow.sendKeyboardEvent(options)
 
@@ -780,17 +780,17 @@ Sends a keyboard event to the BrowserWindow.
     * `char` String - Character event.
   * `code` Integer - The key code of the key that generated the event.
   * `native` Integer - The native key code of the key that generated the event.
-  * `modifiers` Array of Strings - The modifier values associated with the event.
-    * `keypad` String - Sets the `IsKeyPad` option of the event.
-    * `auto-repeat` String - Sets the `IsAutoRepeat` option of the event.
-    * `left` String - Sets the `IsLeft` option of the event.
-    * `right` String - Sets the `IsRight` option of the event.
-    * `shift` String - The shift key was pressed.
-    * `control` String - The control key was pressed.
-    * `alt` String - The alt key was pressed.
-    * `meta` String - The meta key was pressed.
-    * `caps-lock` String - The caps-lock key was pressed.
-    * `num-lock` String - The num-lock key was pressed.
+  * `modifiers` Object - The modifier values associated with the event.
+    * `keypad` Boolean - Sets the `IsKeyPad` option of the event.
+    * `auto-repeat` Boolean - Sets the `IsAutoRepeat` option of the event.
+    * `left` Boolean - Sets the `IsLeft` option of the event.
+    * `right` Boolean - Sets the `IsRight` option of the event.
+    * `shift` Boolean - The shift key was pressed.
+    * `control` Boolean - The control key was pressed.
+    * `alt` Boolean - The alt key was pressed.
+    * `meta` Boolean - The meta key was pressed.
+    * `caps-lock` Boolean - The caps-lock key was on.
+    * `num-lock` Boolean - The num-lock key was on.
 
 ## Class: WebContents
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -75,7 +75,8 @@ You can also create a window without chrome by using
   * `standard-window` Boolean - Uses the OS X's standard window instead of the
     textured window. Defaults to `true`.
   * `offscreen-render` Boolean - The frame of the window will be accessible
-    through the `frame-rendered` event in a buffer. Defaults to `false`.
+    through the `frame-rendered` event in a buffer (Uint8, BGRA). Defaults to
+    `false`.
   * `web-preferences` Object - Settings of web page's features
     * `javascript` Boolean
     * `web-security` Boolean - When setting `false`, it will disable the same-origin
@@ -732,10 +733,15 @@ Returns whether the window is visible on all workspaces.
 
 **Note:** This API always returns false on Windows.
 
-### BrowserWindow.setOffscreenRender(isOffscreen)
+### BrowserWindow.beginFrameSubscription()
 
-Sets the offscreen rendering, if `true` the `frame-rendered` event will fire,
-when the frame changes.
+Enables offscreen rendering, after this call `frame-rendered` events will be
+fired when the window receives a new frame from the renderer.
+
+### BrowserWindow.endFrameSubscription()
+
+Enables offscreen rendering, after this call `frame-rendered` events will
+no longer be fired if offscreen rendering was enabled before.
 
 ### BrowserWindow.sendMouseEvent(options)
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -737,6 +737,61 @@ Returns whether the window is visible on all workspaces.
 Sets the offscreen rendering, if `true` the `frame-rendered` event will fire,
 when the frame changes.
 
+### BrowserWindow.sendMouseEvent(options)
+
+Sends a mouse event to the BrowserWindow.
+* `options` Object
+  * `type` String - The type of the mouse event.
+    * `down` String - Mouse down event.
+    * `up` String -  Mouse up event.
+    * `move` String - Mouse move event.
+    * `enter` String - Mouse enter event.
+    * `leave` String - Mouse leave event.
+    * `context-menu` String - Context menu event.
+    * `wheel` String - Mouse wheel event.
+  * `x` Integer - The x component of the location of the mouse event.
+  * `y` Integer - The y component of the location of the mouse event.
+  * `movement-x` Integer - The x component of the mouse movement since the last event.
+  * `movement-y` Integer - The y component of the mouse movement since the last event.
+  * `button` String - The mouse button associated with the mouse event. Also sets the associated modifier values on the event.
+    * `left` String - The left button was pressed.
+    * `right` String - The right button was pressed.
+    * `middle` String - The middle button was pressed.
+  * `click-count` Integer - The number of clicks associated with the mouse event.
+  * `precise` Boolean - For the `wheel` event type, this option sets the `hasPreciseScrollingDeltas` option of the event.
+  * `modifiers` Array of Strings - The modifier values associated with the event.
+    * `left-button-down` String - The left mouse button was pressed.
+    * `middle-button-down` String - The right mouse button was pressed.
+    * `right-button-down` String - The middle mouse button was pressed.
+    * `shift` String - The shift key was pressed.
+    * `control` String - The control key was pressed.
+    * `alt` String - The alt key was pressed.
+    * `meta` String - The meta key was pressed.
+    * `caps-lock` String - The caps-lock key was pressed.
+    * `num-lock` String - The num-lock key was pressed.
+
+### BrowserWindow.sendKeyboardEvent(options)
+
+Sends a keyboard event to the BrowserWindow.
+* `options` Object
+  * `type` String - The type of the keyboard event.
+    * `down` String - Key down event.
+    * `up` String -  Key up event.
+    * `char` String - Character event.
+  * `code` Integer - The key code of the key that generated the event.
+  * `native` Integer - The native key code of the key that generated the event.
+  * `modifiers` Array of Strings - The modifier values associated with the event.
+    * `keypad` String - Sets the `IsKeyPad` option of the event.
+    * `auto-repeat` String - Sets the `IsAutoRepeat` option of the event.
+    * `left` String - Sets the `IsLeft` option of the event.
+    * `right` String - Sets the `IsRight` option of the event.
+    * `shift` String - The shift key was pressed.
+    * `control` String - The control key was pressed.
+    * `alt` String - The alt key was pressed.
+    * `meta` String - The meta key was pressed.
+    * `caps-lock` String - The caps-lock key was pressed.
+    * `num-lock` String - The num-lock key was pressed.
+
 ## Class: WebContents
 
 A `WebContents` is responsible for rendering and controlling a web page.

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -301,6 +301,8 @@
       'atom/common/node_includes.h',
       'atom/common/options_switches.cc',
       'atom/common/options_switches.h',
+      'atom/common/event_types.cc',
+      'atom/common/event_types.h',
       'atom/common/platform_util.h',
       'atom/common/platform_util_linux.cc',
       'atom/common/platform_util_mac.mm',


### PR DESCRIPTION
Offscreen render, mouse and keyboard event sending functionality using the content api. This relies on my other pull-request successfully being merged into native-mate, because the offscreen-render callback sends the image data in a Uint8ClampedArray, and I couldn't return that without the things I added to native-mate.