### PR TITLE
Update Documentation Links to web-contents

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -263,7 +263,7 @@ Returns the window that is focused in this application.
 
 ### `BrowserWindow.fromWebContents(webContents)`
 
-* `webContents` [WebContents](#webcontents)
+* `webContents` [WebContents](web-contents.md)
 
 Find a window according to the `webContents` it owns.
 

--- a/docs/api/ipc-main-process.md
+++ b/docs/api/ipc-main-process.md
@@ -7,7 +7,7 @@ a renderer will be emitted to this module.
 ## Sending Messages
 
 It is also possible to send messages from the main process to the renderer
-process, see [WebContents.send](browser-window.md#webcontents-send-channel-args)
+process, see [WebContents.send](web-contents.md#webcontentssendchannel-args)
 for more information.
 
 - When sending a message, the event name is the `channel`.

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -21,7 +21,7 @@ win.loadUrl('https://github.com');
 ```
 
 **Note:** for the reverse (access the renderer process from the main process),
-you can use [webContents.executeJavascript](browser-window.md#webcontents-executejavascript-code).
+you can use [webContents.executeJavascript](web-contents.md#webcontentsexecutejavascriptcode-usergesture).
 
 ## Remote Objects
 

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -355,7 +355,7 @@ Prints webview's web page as PDF, Same with `webContents.printToPDF(options, cal
 Send `args..` to guest page via `channel` in asynchronous message, the guest
 page can handle it by listening to the `channel` event of `ipc` module.
 
-See [WebContents.send](browser-window.md#webcontentssendchannel-args) for
+See [WebContents.send](web-contents.md#webcontentssendchannel-args) for
 examples.
 
 ## DOM events


### PR DESCRIPTION
This PR supersedes https://github.com/atom/electron/pull/2745, starting from there and updating all the links to `web-contents` that were incorrect because it is now its own file, `web-contents.md`.