### PR TITLE
Make sure global symbols of Node.js is always available in preload script

### DIFF
--- a/atom/common/lib/init.coffee
+++ b/atom/common/lib/init.coffee
@@ -38,10 +38,15 @@ wrapWithActivateUvLoop = (func) ->
     func.apply this, arguments
 process.nextTick = wrapWithActivateUvLoop process.nextTick
 
-# setTimeout needs to update the polling timeout of the event loop, when called
-# under Chromium's event loop the node's event loop won't get a chance to update
-# the timeout, so we have to force the node's event loop to recalculate the
-# timeout in browser process.
 if process.type is 'browser'
+  # setTimeout needs to update the polling timeout of the event loop, when
+  # called under Chromium's event loop the node's event loop won't get a chance
+  # to update the timeout, so we have to force the node's event loop to
+  # recalculate the timeout in browser process.
   global.setTimeout = wrapWithActivateUvLoop timers.setTimeout
   global.setInterval = wrapWithActivateUvLoop timers.setInterval
+else
+  # There are no setImmediate under renderer process by default, so we need to
+  # manually setup them here.
+  global.setImmediate = setImmediate
+  global.clearImmediate = clearImmediate

--- a/atom/common/lib/init.coffee
+++ b/atom/common/lib/init.coffee
@@ -45,6 +45,8 @@ if process.type is 'browser'
   # recalculate the timeout in browser process.
   global.setTimeout = wrapWithActivateUvLoop timers.setTimeout
   global.setInterval = wrapWithActivateUvLoop timers.setInterval
+  global.setImmediate = wrapWithActivateUvLoop timers.setImmediate
+  global.clearImmediate = wrapWithActivateUvLoop timers.clearImmediate
 else
   # There are no setImmediate under renderer process by default, so we need to
   # manually setup them here.

--- a/atom/common/lib/init.coffee
+++ b/atom/common/lib/init.coffee
@@ -37,8 +37,6 @@ wrapWithActivateUvLoop = (func) ->
     process.activateUvLoop()
     func.apply this, arguments
 process.nextTick = wrapWithActivateUvLoop process.nextTick
-global.setImmediate = wrapWithActivateUvLoop timers.setImmediate
-global.clearImmediate = timers.clearImmediate
 
 # setTimeout needs to update the polling timeout of the event loop, when called
 # under Chromium's event loop the node's event loop won't get a chance to update

--- a/spec/fixtures/module/preload-node-off.js
+++ b/spec/fixtures/module/preload-node-off.js
@@ -1,0 +1,7 @@
+setImmediate(function() {
+  try {
+    console.log([typeof process, typeof setImmediate, typeof global].join(' '));
+  } catch (e) {
+    console.log(e.message);
+  }
+});

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -84,6 +84,14 @@ describe '<webview> tag', ->
       webview.src = "file://#{fixtures}/pages/e.html"
       document.body.appendChild webview
 
+    it 'preload script can still use "process" in required modules when nodeintegration is off', (done) ->
+      webview.addEventListener 'console-message', (e) ->
+        assert.equal e.message, 'object function object'
+        done()
+      webview.setAttribute 'preload', "#{fixtures}/module/preload-node-off.js"
+      webview.src = "file://#{fixtures}/api/blank.html"
+      document.body.appendChild webview
+
     it 'receives ipc message in preload script', (done) ->
       message = 'boom!'
       listener = (e) ->


### PR DESCRIPTION
This PR relies the https://github.com/atom/node/commit/fdb584a0b42e89885f74ed68f279318b0fbff37f, fixes #2502.

Previously when node integration is turned off in the webview or BrowserWindow, the `process` and `global` symbols will not be available in the preload script after the first tick of message loop. This PR takes a work-around by turning those symbols into local variables, so scripts ran by `require` will still have access to them, and the web page won't be able to access them when node integration is off.

The downside is users won't be able to override global symbols in this way any more, since those symbols are local variables now:

```js
global.setImmediate = function() {
  // ...
}
```