### PR TITLE
Fix `BrowserWindow.addDevToolsExtension` not working

### DIFF
--- a/atom/app/atom_content_client.cc
+++ b/atom/app/atom_content_client.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "atom/common/atom_version.h"
 #include "atom/common/chrome_version.h"
 #include "atom/common/options_switches.h"
 #include "base/command_line.h"
@@ -14,6 +15,7 @@
 #include "base/strings/string_util.h"
 #include "content/public/common/content_constants.h"
 #include "content/public/common/pepper_plugin_info.h"
+#include "content/public/common/user_agent.h"
 #include "ppapi/shared_impl/ppapi_permissions.h"
 
 namespace atom {
@@ -70,6 +72,12 @@ AtomContentClient::~AtomContentClient() {
 
 std::string AtomContentClient::GetProduct() const {
   return "Chrome/" CHROME_VERSION_STRING;
+}
+
+std::string AtomContentClient::GetUserAgent() const {
+  return content::BuildUserAgentFromProduct(
+      "Chrome/" CHROME_VERSION_STRING " "
+      ATOM_PRODUCT_NAME "/" ATOM_VERSION_STRING);
 }
 
 void AtomContentClient::AddAdditionalSchemes(

--- a/atom/app/atom_content_client.h
+++ b/atom/app/atom_content_client.h
@@ -20,6 +20,7 @@ class AtomContentClient : public brightray::ContentClient {
  protected:
   // content::ContentClient:
   std::string GetProduct() const override;
+  std::string GetUserAgent() const override;
   void AddAdditionalSchemes(
       std::vector<std::string>* standard_schemes,
       std::vector<std::string>* savable_schemes) override;

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -547,6 +547,10 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
   web_contents()->GetController().LoadURLWithParams(params);
 }
 
+GURL WebContents::GetURL() const {
+  return web_contents()->GetURL();
+}
+
 base::string16 WebContents::GetTitle() const {
   return web_contents()->GetTitle();
 }
@@ -815,6 +819,7 @@ mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
         .SetMethod("getId", &WebContents::GetID)
         .SetMethod("equal", &WebContents::Equal)
         .SetMethod("_loadUrl", &WebContents::LoadURL)
+        .SetMethod("_getUrl", &WebContents::GetURL)
         .SetMethod("getTitle", &WebContents::GetTitle)
         .SetMethod("isLoading", &WebContents::IsLoading)
         .SetMethod("isWaitingForResponse", &WebContents::IsWaitingForResponse)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -55,6 +55,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   int GetID() const;
   bool Equal(const WebContents* web_contents) const;
   void LoadURL(const GURL& url, const mate::Dictionary& options);
+  GURL GetURL() const;
   base::string16 GetTitle() const;
   bool IsLoading() const;
   bool IsWaitingForResponse() const;

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -183,21 +183,21 @@ void Window::OnDevToolsFocus() {
 }
 
 void Window::OnDevToolsOpened() {
-  Emit("devtools-opened");
-
   v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
   auto handle = WebContents::CreateFrom(
       isolate(), api_web_contents_->GetDevToolsWebContents());
   devtools_web_contents_.Reset(isolate(), handle.ToV8());
+
+  Emit("devtools-opened");
 }
 
 void Window::OnDevToolsClosed() {
-  Emit("devtools-closed");
-
   v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
   devtools_web_contents_.Reset();
+
+  Emit("devtools-closed");
 }
 
 void Window::OnExecuteWindowsCommand(const std::string& command_name) {

--- a/atom/browser/api/lib/navigation-controller.coffee
+++ b/atom/browser/api/lib/navigation-controller.coffee
@@ -16,6 +16,11 @@ class NavigationController
   constructor: (@webContents) ->
     @clearHistory()
 
+    # webContents may have already navigated to a page.
+    if @webContents._getUrl()
+      @currentIndex++
+      @history.push @webContents._getUrl()
+
     @webContents.on 'navigation-entry-commited', (event, url, inPage, replaceEntry) =>
       if @inPageIndex > -1 and not inPage
         # Navigated to a new page, clear in-page mark.

--- a/atom/browser/api/lib/web-contents.coffee
+++ b/atom/browser/api/lib/web-contents.coffee
@@ -44,10 +44,8 @@ wrapWebContents = (webContents) ->
 
   # Make sure webContents.executeJavaScript would run the code only when the
   # web contents has been loaded.
-  webContents.loaded = false
-  webContents.once 'did-finish-load', -> @loaded = true
   webContents.executeJavaScript = (code, hasUserGesture=false) ->
-    if @loaded
+    if @getUrl() and not @isLoading()
       @_executeJavaScript code, hasUserGesture
     else
       webContents.once 'did-finish-load', @_executeJavaScript.bind(this, code, hasUserGesture)

--- a/atom/browser/lib/chrome-extension.coffee
+++ b/atom/browser/lib/chrome-extension.coffee
@@ -32,6 +32,7 @@ getExtensionInfoFromPath = (srcDirectory) ->
       startPage: page
       name: manifest.name
       srcDirectory: srcDirectory
+      exposeExperimentalAPIs: true
     extensionInfoMap[manifest.name]
 
 # The loaded extensions cache and its persistent path.


### PR DESCRIPTION
It was caused by 2 reasons: 1) user agent not correctly set in devtools; 2) executeJavaScript not working for devToolsWebContents.

Close #2404.