### PR TITLE
App app.getLocale() API to get application locale

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -30,6 +30,7 @@
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
 #include "net/ssl/ssl_cert_request_info.h"
+#include "ui/base/l10n/l10n_util.h"
 
 #if defined(OS_WIN)
 #include "base/strings/utf_string_conversions.h"
@@ -248,6 +249,10 @@ void App::SetAppUserModelId(const std::string& app_id) {
 #endif
 }
 
+std::string App::GetLocale() {
+  return l10n_util::GetApplicationLocale("");
+}
+
 v8::Local<v8::Value> App::DefaultSession(v8::Isolate* isolate) {
   if (default_session_.IsEmpty())
     return v8::Null(isolate);
@@ -278,6 +283,7 @@ mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(
       .SetMethod("getPath", &App::GetPath)
       .SetMethod("setDesktopName", &App::SetDesktopName)
       .SetMethod("setAppUserModelId", &App::SetAppUserModelId)
+      .SetMethod("getLocale", &App::GetLocale)
       .SetProperty("defaultSession", &App::DefaultSession);
 }
 

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -65,6 +65,7 @@ class App : public mate::EventEmitter,
 
   void SetDesktopName(const std::string& desktop_name);
   void SetAppUserModelId(const std::string& app_id);
+  std::string GetLocale();
   v8::Local<v8::Value> DefaultSession(v8::Isolate* isolate);
 
   v8::Global<v8::Value> default_session_;

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -239,6 +239,10 @@ to the npm modules spec. You should usually also specify a `productName`
 field, which is your application's full capitalized name, and which will be
 preferred over `name` by Electron.
 
+### `app.getLocale()`
+
+Returns the current application locale.
+
 ### `app.resolveProxy(url, callback)`
 
 * `url` URL

--- a/spec/api-app-spec.coffee
+++ b/spec/api-app-spec.coffee
@@ -26,6 +26,10 @@ describe 'app module', ->
       assert.equal app.getName(), 'test-name'
       app.setName 'Electron Test'
 
+  describe 'app.getLocale()', ->
+    it 'should not be empty', ->
+      assert.notEqual app.getLocale(), ''
+
   describe 'BrowserWindow events', ->
     w = null
     afterEach ->


### PR DESCRIPTION
This PR adds `app.getLocale()` API to get current locale in main process.

I think this is more reliable than the alternative way that uses [os-locale](https://github.com/sindresorhus/os-locale), written in #2274.