### PR TITLE
Fixed the mapNumbers require call

### DIFF
--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -79,7 +79,7 @@ exports.withLocalCallback = function() {
 
 ```javascript
 // renderer process
-var mapNumbers = require("remote").require("mapNumbers");
+var mapNumbers = require("remote").require("./mapNumbers");
 
 var withRendererCb = mapNumbers.withRendererCallback(function(x) {
   return x + 1;


### PR DESCRIPTION
Since mapNumber.js is a file, we should prefix it with "./", otherwise an error is thrown. :balloon: 