### PR TITLE
Move the converters for blink structures to another file 

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -15,6 +15,7 @@
 #include "atom/browser/web_view_guest_delegate.h"
 #include "atom/common/api/api_messages.h"
 #include "atom/common/api/event_emitter_caller.h"
+#include "atom/common/native_mate_converters/blink_converter.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/gfx_converter.h"
@@ -45,7 +46,6 @@
 #include "net/http/http_response_headers.h"
 #include "net/url_request/static_http_user_agent_settings.h"
 #include "net/url_request/url_request_context.h"
-#include "third_party/WebKit/public/web/WebDeviceEmulationParams.h"
 
 #include "atom/common/node_includes.h"
 
@@ -642,77 +642,10 @@ bool WebContents::IsDevToolsOpened() {
   return managed_web_contents()->IsDevToolsViewShowing();
 }
 
-void WebContents::EnableDeviceEmulation(const base::DictionaryValue& dict) {
+void WebContents::EnableDeviceEmulation(
+    const blink::WebDeviceEmulationParams& params) {
   if (type_ == REMOTE)
     return;
-
-  blink::WebDeviceEmulationParams params;
-
-  if (dict.HasKey("screenPosition")) {
-    std::string screen_position;
-    if (!dict.GetString("screenPosition", &screen_position))
-      return;
-
-    screen_position = base::StringToLowerASCII(screen_position);
-
-    if (screen_position == "mobile") {
-      params.screenPosition = blink::WebDeviceEmulationParams::Mobile;
-    } else if (screen_position == "desktop") {
-      params.screenPosition = blink::WebDeviceEmulationParams::Desktop;
-    } else {
-      return;
-    }
-  }
-
-  if (dict.HasKey("screenSize")) {
-    if (!dict.GetInteger("screenSize.width", &params.screenSize.width))
-      return;
-    if (!dict.GetInteger("screenSize.height", &params.screenSize.height))
-      return;
-  }
-
-  if (dict.HasKey("viewPosition")) {
-    if (!dict.GetInteger("viewPosition.x", &params.viewPosition.x))
-      return;
-    if (!dict.GetInteger("viewPosition.y", &params.viewPosition.y))
-      return;
-  }
-
-  if (dict.HasKey("deviceScaleFactor")) {
-    double device_scale_factor;
-    if (!dict.GetDouble("deviceScaleFactor", &device_scale_factor))
-      return;
-    params.deviceScaleFactor = static_cast<float>(device_scale_factor);
-  }
-
-  if (dict.HasKey("viewSize")) {
-    if (!dict.GetInteger("viewSize.width", &params.viewSize.width))
-      return;
-    if (!dict.GetInteger("viewSize.height", &params.viewSize.height))
-      return;
-  }
-
-  if (dict.HasKey("fitToView")) {
-    if (!dict.GetBoolean("fitToView", &params.fitToView))
-      return;
-  }
-
-  if (dict.HasKey("offset")) {
-    double x, y;
-    if (!dict.GetDouble("offset.x", &x))
-      return;
-    if (!dict.GetDouble("offset.y", &y))
-      return;
-    params.offset.x = static_cast<float>(x);
-    params.offset.y = static_cast<float>(y);
-  }
-
-  if (dict.HasKey("scale")) {
-    double scale;
-    if (!dict.GetDouble("scale", &scale))
-      return;
-    params.scale = static_cast<float>(scale);
-  }
 
   Send(new ViewMsg_EnableDeviceEmulation(routing_id(), params));
 }

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -15,6 +15,10 @@
 #include "native_mate/handle.h"
 #include "ui/gfx/image/image.h"
 
+namespace blink {
+struct WebDeviceEmulationParams;
+}
+
 namespace brightray {
 class InspectableWebContents;
 }
@@ -74,7 +78,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void CloseDevTools();
   bool IsDevToolsOpened();
   void ToggleDevTools();
-  void EnableDeviceEmulation(const base::DictionaryValue&);
+  void EnableDeviceEmulation(const blink::WebDeviceEmulationParams& params);
   void DisableDeviceEmulation();
   void InspectElement(int x, int y);
   void InspectServiceWorker();

--- a/atom/common/native_mate_converters/blink_converter.cc
+++ b/atom/common/native_mate_converters/blink_converter.cc
@@ -4,6 +4,8 @@
 
 #include "atom/common/native_mate_converters/blink_converter.h"
 
+#include <string>
+
 #include "base/strings/string_util.h"
 #include "native_mate/dictionary.h"
 #include "third_party/WebKit/public/web/WebDeviceEmulationParams.h"

--- a/atom/common/native_mate_converters/blink_converter.cc
+++ b/atom/common/native_mate_converters/blink_converter.cc
@@ -1,0 +1,65 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/common/native_mate_converters/blink_converter.h"
+
+#include "base/strings/string_util.h"
+#include "native_mate/dictionary.h"
+#include "third_party/WebKit/public/web/WebDeviceEmulationParams.h"
+
+namespace mate {
+
+bool Converter<blink::WebFloatPoint>::FromV8(
+    v8::Isolate* isolate, v8::Local<v8::Value> val, blink::WebFloatPoint* out) {
+  mate::Dictionary dict;
+  if (!ConvertFromV8(isolate, val, &dict))
+    return false;
+  return dict.Get("x", &out->x) && dict.Get("y", &out->y);
+}
+
+bool Converter<blink::WebPoint>::FromV8(
+    v8::Isolate* isolate, v8::Local<v8::Value> val, blink::WebPoint* out) {
+  mate::Dictionary dict;
+  if (!ConvertFromV8(isolate, val, &dict))
+    return false;
+  return dict.Get("x", &out->x) && dict.Get("y", &out->y);
+}
+
+bool Converter<blink::WebSize>::FromV8(
+    v8::Isolate* isolate, v8::Local<v8::Value> val, blink::WebSize* out) {
+  mate::Dictionary dict;
+  if (!ConvertFromV8(isolate, val, &dict))
+    return false;
+  return dict.Get("width", &out->width) && dict.Get("height", &out->height);
+}
+
+bool Converter<blink::WebDeviceEmulationParams>::FromV8(
+    v8::Isolate* isolate, v8::Local<v8::Value> val,
+    blink::WebDeviceEmulationParams* out) {
+  mate::Dictionary dict;
+  if (!ConvertFromV8(isolate, val, &dict))
+    return false;
+
+  std::string screen_position;
+  if (dict.Get("screenPosition", &screen_position)) {
+    screen_position = base::StringToLowerASCII(screen_position);
+    if (screen_position == "mobile")
+      out->screenPosition = blink::WebDeviceEmulationParams::Mobile;
+    else if (screen_position == "desktop")
+      out->screenPosition = blink::WebDeviceEmulationParams::Desktop;
+    else
+      return false;
+  }
+
+  dict.Get("screenSize", &out->screenSize);
+  dict.Get("viewPosition", &out->viewPosition);
+  dict.Get("deviceScaleFactor", &out->deviceScaleFactor);
+  dict.Get("viewSize", &out->viewSize);
+  dict.Get("fitToView", &out->fitToView);
+  dict.Get("offset", &out->offset);
+  dict.Get("scale", &out->scale);
+  return true;
+}
+
+}  // namespace mate

--- a/atom/common/native_mate_converters/blink_converter.h
+++ b/atom/common/native_mate_converters/blink_converter.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_COMMON_NATIVE_MATE_CONVERTERS_BLINK_CONVERTER_H_
+#define ATOM_COMMON_NATIVE_MATE_CONVERTERS_BLINK_CONVERTER_H_
+
+#include "native_mate/converter.h"
+
+namespace blink {
+struct WebDeviceEmulationParams;
+struct WebFloatPoint;
+struct WebPoint;
+struct WebSize;
+}
+
+namespace mate {
+
+template<>
+struct Converter<blink::WebFloatPoint> {
+  static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
+                     blink::WebFloatPoint* out);
+};
+
+template<>
+struct Converter<blink::WebPoint> {
+  static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
+                     blink::WebPoint* out);
+};
+
+template<>
+struct Converter<blink::WebSize> {
+  static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
+                     blink::WebSize* out);
+};
+
+template<>
+struct Converter<blink::WebDeviceEmulationParams> {
+  static bool FromV8(v8::Isolate* isolate, v8::Local<v8::Value> val,
+                     blink::WebDeviceEmulationParams* out);
+};
+
+}  // namespace mate
+
+#endif  // ATOM_COMMON_NATIVE_MATE_CONVERTERS_BLINK_CONVERTER_H_

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -286,6 +286,8 @@
       'atom/common/linux/application_info.cc',
       'atom/common/native_mate_converters/accelerator_converter.cc',
       'atom/common/native_mate_converters/accelerator_converter.h',
+      'atom/common/native_mate_converters/blink_converter.cc',
+      'atom/common/native_mate_converters/blink_converter.h',
       'atom/common/native_mate_converters/callback.h',
       'atom/common/native_mate_converters/file_path_converter.h',
       'atom/common/native_mate_converters/gfx_converter.cc',


### PR DESCRIPTION
It makes `api::WebContents` a bit cleaner, I want to control each file to have < 1000 lines.