### PR TITLE
Fix small typo in debug message.

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -94,7 +94,7 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
     if (base::FilePath(preload).IsAbsolute())
       command_line->AppendSwitchNative(switches::kPreloadScript, preload);
     else
-      LOG(ERROR) << "preload script must have abosulute path.";
+      LOG(ERROR) << "preload script must have absolute path.";
   } else if (web_preferences.GetString(switches::kPreloadUrl, &preload)) {
     // Translate to file path if there is "preload-url" option.
     base::FilePath preload_path;


### PR DESCRIPTION
The guidelines for contribution were very clear about including a screenshot/animated gif wherever possible, so...

![Here you go.](http://media.giphy.com/media/6e3jiIwMNxVte/giphy.gif)