### PR TITLE
browser: switch to set minimum version for TLS fallback

### DIFF
--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -6,6 +6,7 @@
 
 #include "atom/browser/atom_browser_main_parts.h"
 #include "atom/browser/atom_download_manager_delegate.h"
+#include "atom/browser/atom_ssl_config_service.h"
 #include "atom/browser/browser.h"
 #include "atom/browser/net/atom_url_request_job_factory.h"
 #include "atom/browser/net/asar/asar_protocol_handler.h"
@@ -154,6 +155,10 @@ content::BrowserPluginGuestManager* AtomBrowserContext::GetGuestManager() {
   if (!guest_manager_)
     guest_manager_.reset(new WebViewManager);
   return guest_manager_.get();
+}
+
+net::SSLConfigService* AtomBrowserContext::CreateSSLConfigService() {
+  return new AtomSSLConfigService;
 }
 
 void AtomBrowserContext::RegisterPrefs(PrefRegistrySimple* pref_registry) {

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -27,6 +27,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
       content::URLRequestInterceptorScopedVector* interceptors) override;
   net::HttpCache::BackendFactory* CreateHttpCacheBackendFactory(
       const base::FilePath& base_path) override;
+  net::SSLConfigService* CreateSSLConfigService() override;
 
   // content::BrowserContext:
   content::DownloadManagerDelegate* GetDownloadManagerDelegate() override;

--- a/atom/browser/atom_ssl_config_service.cc
+++ b/atom/browser/atom_ssl_config_service.cc
@@ -1,0 +1,47 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/atom_ssl_config_service.h"
+
+#include <string>
+
+#include "base/command_line.h"
+#include "atom/common/options_switches.h"
+#include "content/public/browser/browser_thread.h"
+#include "net/socket/ssl_client_socket.h"
+
+namespace atom {
+
+namespace {
+
+uint16 GetSSLProtocolVersion(const std::string& version_string) {
+  uint16 version = 0;  // Invalid
+  if (version_string == "tls1")
+    version = net::SSL_PROTOCOL_VERSION_TLS1;
+  else if (version_string == "tls1.1")
+    version = net::SSL_PROTOCOL_VERSION_TLS1_1;
+  else if (version_string == "tls1.2")
+    version = net::SSL_PROTOCOL_VERSION_TLS1_2;
+  return version;
+}
+
+}  // namespace
+
+AtomSSLConfigService::AtomSSLConfigService() {
+  auto cmd_line = base::CommandLine::ForCurrentProcess();
+  if (cmd_line->HasSwitch(switches::kSSLVersionFallbackMin)) {
+    auto version_string =
+        cmd_line->GetSwitchValueASCII(switches::kSSLVersionFallbackMin);
+    config_.version_fallback_min = GetSSLProtocolVersion(version_string);
+  }
+}
+
+AtomSSLConfigService::~AtomSSLConfigService() {
+}
+
+void AtomSSLConfigService::GetSSLConfig(net::SSLConfig* config) {
+  *config = config_;
+}
+
+}  // namespace atom

--- a/atom/browser/atom_ssl_config_service.h
+++ b/atom/browser/atom_ssl_config_service.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_ATOM_SSL_CONFIG_SERVICE_H_
+#define ATOM_BROWSER_ATOM_SSL_CONFIG_SERVICE_H_
+
+#include "net/ssl/ssl_config_service.h"
+
+namespace atom {
+
+class AtomSSLConfigService : public net::SSLConfigService {
+ public:
+  AtomSSLConfigService();
+  ~AtomSSLConfigService() override;
+
+  // net::SSLConfigService:
+  void GetSSLConfig(net::SSLConfig* config) override;
+
+ private:
+  net::SSLConfig config_;
+
+  DISALLOW_COPY_AND_ASSIGN(AtomSSLConfigService);
+};
+
+}   // namespace atom
+
+#endif  // ATOM_BROWSER_ATOM_SSL_CONFIG_SERVICE_H_

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -113,6 +113,10 @@ const char kDisableHttpCache[] = "disable-http-cache";
 // Register schemes to standard.
 const char kRegisterStandardSchemes[] = "register-standard-schemes";
 
+// The minimum SSL/TLS version ("tls1", "tls1.1", or "tls1.2") that
+// TLS fallback will accept.
+const char kSSLVersionFallbackMin[] = "ssl-version-fallback-min";
+
 // The browser process app model ID
 const char kAppUserModelId[] = "app-user-model-id";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -59,6 +59,7 @@ extern const char kPageVisibility[];
 
 extern const char kDisableHttpCache[];
 extern const char kRegisterStandardSchemes[];
+extern const char kSSLVersionFallbackMin[];
 
 extern const char kAppUserModelId[];
 

--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -87,6 +87,11 @@ Sets the `version` of the pepper flash plugin.
 
 Enables net log events to be saved and writes them to `path`.
 
+## --ssl-version-fallback-min=`version`
+
+Set the minimum SSL/TLS version ("tls1", "tls1.1" or "tls1.2") that TLS
+fallback will accept.
+
 ## --v=`log_level`
 
 Gives the default maximal active V-logging level; 0 is the default. Normally

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -129,6 +129,8 @@
       'atom/browser/atom_quota_permission_context.h',
       'atom/browser/atom_speech_recognition_manager_delegate.cc',
       'atom/browser/atom_speech_recognition_manager_delegate.h',
+      'atom/browser/atom_ssl_config_service.cc',
+      'atom/browser/atom_ssl_config_service.h',
       'atom/browser/bridge_task_runner.cc',
       'atom/browser/bridge_task_runner.h',
       'atom/browser/browser.cc',


### PR DESCRIPTION
Fixes #2849 

Depends on https://github.com/atom/brightray/pull/143