### PR TITLE
No more exposing setImmediate as local variable

### DIFF
--- a/atom/common/lib/init.coffee
+++ b/atom/common/lib/init.coffee
@@ -1,8 +1,7 @@
-process = global.process
-fs      = require 'fs'
-path    = require 'path'
-timers  = require 'timers'
-Module  = require 'module'
+fs     = require 'fs'
+path   = require 'path'
+timers = require 'timers'
+Module = require 'module'
 
 process.atomBinding = (name) ->
   try

--- a/atom/common/lib/init.coffee
+++ b/atom/common/lib/init.coffee
@@ -37,6 +37,8 @@ wrapWithActivateUvLoop = (func) ->
     process.activateUvLoop()
     func.apply this, arguments
 process.nextTick = wrapWithActivateUvLoop process.nextTick
+global.setImmediate = wrapWithActivateUvLoop timers.setImmediate
+global.clearImmediate = timers.clearImmediate
 
 if process.type is 'browser'
   # setTimeout needs to update the polling timeout of the event loop, when
@@ -45,10 +47,3 @@ if process.type is 'browser'
   # recalculate the timeout in browser process.
   global.setTimeout = wrapWithActivateUvLoop timers.setTimeout
   global.setInterval = wrapWithActivateUvLoop timers.setInterval
-  global.setImmediate = wrapWithActivateUvLoop timers.setImmediate
-  global.clearImmediate = wrapWithActivateUvLoop timers.clearImmediate
-else
-  # There are no setImmediate under renderer process by default, so we need to
-  # manually setup them here.
-  global.setImmediate = setImmediate
-  global.clearImmediate = clearImmediate

--- a/atom/renderer/api/lib/remote.coffee
+++ b/atom/renderer/api/lib/remote.coffee
@@ -1,4 +1,3 @@
-process = global.process
 ipc = require 'ipc'
 v8Util = process.atomBinding 'v8_util'
 CallbacksRegistry = require 'callbacks-registry'

--- a/atom/renderer/lib/init.coffee
+++ b/atom/renderer/lib/init.coffee
@@ -1,8 +1,7 @@
-process = global.process
-events  = require 'events'
-path    = require 'path'
-url     = require 'url'
-Module  = require 'module'
+events = require 'events'
+path   = require 'path'
+url    = require 'url'
+Module = require 'module'
 
 # We modified the original process.argv to let node.js load the
 # atom-renderer.js, we need to restore it here.

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -1,4 +1,3 @@
-process = global.process
 ipc = require 'ipc'
 remote = require 'remote'
 

--- a/spec/api-browser-window-spec.coffee
+++ b/spec/api-browser-window-spec.coffee
@@ -304,10 +304,7 @@ describe 'browser-window module', ->
         done()
       w.loadUrl url
 
-  describe 'beginFrameSubscription method', ->
-    # It is not very reliable on Travis CI.
-    return if process.env.TRAVIS is 'true'
-
+  xdescribe 'beginFrameSubscription method', ->
     it 'subscribes frame updates', (done) ->
       w.loadUrl "file://#{fixtures}/api/blank.html"
       w.webContents.beginFrameSubscription (data) ->

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -86,7 +86,7 @@ describe '<webview> tag', ->
 
     it 'preload script can still use "process" in required modules when nodeintegration is off', (done) ->
       webview.addEventListener 'console-message', (e) ->
-        assert.equal e.message, 'object function object'
+        assert.equal e.message, 'object undefined object'
         done()
       webview.setAttribute 'preload', "#{fixtures}/module/preload-node-off.js"
       webview.src = "file://#{fixtures}/api/blank.html"


### PR DESCRIPTION
It makes more troubles than benefits, and somehow it is slowing message loop down, resulting in `remote` calls being extremely slow sometimes.