### PR TITLE
Add allowpopups attribute for webview

### DIFF
--- a/atom/browser/lib/guest-view-manager.coffee
+++ b/atom/browser/lib/guest-view-manager.coffee
@@ -84,6 +84,8 @@ createGuest = (embedder, params) ->
     if params.allowtransparency?
       @setAllowTransparency params.allowtransparency
 
+    guest.allowPopups = params.allowpopups
+
   # Dispatch events to embedder.
   for event in supportedWebViewEvents
     do (event) ->

--- a/atom/browser/lib/guest-window-manager.coffee
+++ b/atom/browser/lib/guest-window-manager.coffee
@@ -41,7 +41,7 @@ createGuest = (embedder, url, frameName, options) ->
 ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPEN', (event, args...) ->
   [url, frameName, options] = args
   event.sender.emit 'new-window', event, url, frameName, 'new-window'
-  if event.sender.isGuest() or event.defaultPrevented
+  if (event.sender.isGuest() and not event.sender.allowPopups) or event.defaultPrevented
     event.returnValue = null
   else
     event.returnValue = createGuest event.sender, args...

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -70,7 +70,6 @@ window.open = (url, frameName='', features='') ->
   if guestId
     new BrowserWindowProxy(guestId)
   else
-    console.error 'It is not allowed to open new window from this WebContents'
     null
 
 # Use the dialog API to implement alert().

--- a/atom/renderer/lib/web-view/web-view-attributes.coffee
+++ b/atom/renderer/lib/web-view/web-view-attributes.coffee
@@ -216,6 +216,7 @@ WebViewImpl::setupWebViewAttributes = ->
   @attributes[webViewConstants.ATTRIBUTE_NODEINTEGRATION] = new BooleanAttribute(webViewConstants.ATTRIBUTE_NODEINTEGRATION, this)
   @attributes[webViewConstants.ATTRIBUTE_PLUGINS] = new BooleanAttribute(webViewConstants.ATTRIBUTE_PLUGINS, this)
   @attributes[webViewConstants.ATTRIBUTE_DISABLEWEBSECURITY] = new BooleanAttribute(webViewConstants.ATTRIBUTE_DISABLEWEBSECURITY, this)
+  @attributes[webViewConstants.ATTRIBUTE_ALLOWPOPUPS] = new BooleanAttribute(webViewConstants.ATTRIBUTE_ALLOWPOPUPS, this)
   @attributes[webViewConstants.ATTRIBUTE_PRELOAD] = new PreloadAttribute(this)
 
   autosizeAttributes = [

--- a/atom/renderer/lib/web-view/web-view-constants.coffee
+++ b/atom/renderer/lib/web-view/web-view-constants.coffee
@@ -13,6 +13,7 @@ module.exports =
   ATTRIBUTE_NODEINTEGRATION: 'nodeintegration'
   ATTRIBUTE_PLUGINS: 'plugins'
   ATTRIBUTE_DISABLEWEBSECURITY: 'disablewebsecurity'
+  ATTRIBUTE_ALLOWPOPUPS: 'allowpopups'
   ATTRIBUTE_PRELOAD: 'preload'
   ATTRIBUTE_USERAGENT: 'useragent'
 

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -149,6 +149,14 @@ This value can only be modified before the first navigation, since the session
 of an active renderer process cannot change. Subsequent attempts to modify the
 value will fail with a DOM exception.
 
+### `allowpopups`
+
+```html
+<webview src="https://www.github.com/" allowpopups></webview>
+```
+
+If "on", the guest page will be allowed to open new windows.
+
 ## Methods
 
 The `webview` tag has the following methods:
@@ -496,7 +504,7 @@ Returns:
 * `url` String
 * `frameName` String
 * `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
-  `new-window` and `other`
+  `new-window` and `other`.
 
 Fired when the guest page attempts to open a new browser window.
 

--- a/spec/fixtures/pages/window-open-hide.html
+++ b/spec/fixtures/pages/window-open-hide.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  var w = window.open('http://host', '', 'show=no');
+  if (w == null)
+    console.log('null');
+  else
+    console.log('window');
+</script>
+</body>
+</html>
+

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -201,6 +201,26 @@ describe '<webview> tag', ->
       webview.src = "file://#{fixtures}/pages/partition/one.html"
       document.body.appendChild webview
 
+  describe 'allowpopups attribute', ->
+    it 'can not open new window when not set', (done) ->
+      listener = (e) ->
+        assert.equal e.message, 'null'
+        webview.removeEventListener 'console-message', listener
+        done()
+      webview.addEventListener 'console-message', listener
+      webview.src = "file://#{fixtures}/pages/window-open-hide.html"
+      document.body.appendChild webview
+
+    it 'can open new window when set', (done) ->
+      listener = (e) ->
+        assert.equal e.message, 'window'
+        webview.removeEventListener 'console-message', listener
+        done()
+      webview.addEventListener 'console-message', listener
+      webview.setAttribute 'allowpopups', 'on'
+      webview.src = "file://#{fixtures}/pages/window-open-hide.html"
+      document.body.appendChild webview
+
   describe 'new-window event', ->
     it 'emits when window.open is called', (done) ->
       webview.addEventListener 'new-window', (e) ->


### PR DESCRIPTION
This attribute allows `window.open` to work in webview tag, fixes #1864.