### PR TITLE
Do not rely garbage collection to free memory of Buffer

### DIFF
--- a/spec/modules-spec.coffee
+++ b/spec/modules-spec.coffee
@@ -22,6 +22,10 @@ describe 'third-party module', ->
           assert.equal msg, 'ok'
           done()
 
+    describe 'ffi', ->
+      it 'does not crash', ->
+        require 'ffi'
+
   describe 'q', ->
     Q = require 'q'
 

--- a/spec/modules-spec.coffee
+++ b/spec/modules-spec.coffee
@@ -23,6 +23,7 @@ describe 'third-party module', ->
           done()
 
     describe 'ffi', ->
+      return if process.platform is 'darwin'
       it 'does not crash', ->
         require 'ffi'
 

--- a/spec/package.json
+++ b/spec/package.json
@@ -5,6 +5,7 @@
   "version": "0.1.0",
   "devDependencies": {
     "basic-auth": "^1.0.0",
+    "ffi": "2.0.0",
     "formidable": "1.0.16",
     "graceful-fs": "3.0.5",
     "mocha": "2.1.0",


### PR DESCRIPTION
It seems that when there are lots of `Buffer` created the garbage collection callback will be called early for some of them and makes the length of `Buffer` become zero. It is very likely a bug of V8, but for now we are just working around it by creating internalized ArrayBuffer when possible.

The Node.js part patch is: https://github.com/atom/node/commit/d64246490d697f387b888391b1aba65032703a0f.

Fixes #2809.