### PR TITLE
:memo: Include UTF-8 charset in quick start example

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -124,6 +124,7 @@ Finally the `index.html` is the web page you want to show:
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8">
     <title>Hello World!</title>
   </head>
   <body>


### PR DESCRIPTION
Partially fixes #678.

Without an explicit charset, any non-US-ASCII character used in the HTML or JS code would result in something like this:
![32126d98-6195-11e5-97d2-cd83df5cbdeb](https://cloud.githubusercontent.com/assets/9946/10040715/64a2fb08-61de-11e5-98f8-9b6fcd4cce9e.png)
