### PR TITLE
Remove GUID from Shell_NotifyIcon calls

### DIFF
--- a/atom/browser/ui/win/notify_icon.cc
+++ b/atom/browser/ui/win/notify_icon.cc
@@ -30,29 +30,6 @@ NotifyIcon::NotifyIcon(NotifyIconHost* host,
       message_id_(message),
       menu_model_(NULL),
       has_tray_app_id_hash_(false) {
-  // NB: If we have an App Model ID, we should propagate that to the tray.
-  // Doing this prevents duplicate items from showing up in the notification
-  // preferences (i.e. "Always Show / Show notifications only / etc")
-  PWSTR explicit_app_id;
-  if (SUCCEEDED(GetCurrentProcessExplicitAppUserModelID(&explicit_app_id))) {
-    // GUIDs and MD5 hashes are the same length. So convenient!
-    base::MD5Sum(explicit_app_id,
-                 sizeof(wchar_t) * wcslen(explicit_app_id),
-                 reinterpret_cast<base::MD5Digest*>(&tray_app_id_hash_));
-
-    // Set the GUID to version 4 as described in RFC 4122, section 4.4.
-    // The format of GUID version 4 must be like
-    // xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx, where y is one of [8, 9, A, B].
-    tray_app_id_hash_.Data3 &= 0x0fff;
-    tray_app_id_hash_.Data3 |= 0x4000;
-
-    // Set y to one of [8, 9, A, B].
-    tray_app_id_hash_.Data4[0] = 1;
-
-    has_tray_app_id_hash_ = true;
-    CoTaskMemFree(explicit_app_id);
-  }
-
   NOTIFYICONDATA icon_data;
   InitIconData(&icon_data);
   icon_data.uFlags |= NIF_MESSAGE;
@@ -202,13 +179,6 @@ void NotifyIcon::InitIconData(NOTIFYICONDATA* icon_data) {
   icon_data->cbSize = sizeof(NOTIFYICONDATA);
   icon_data->hWnd = window_;
   icon_data->uID = icon_id_;
-
-  if (has_tray_app_id_hash_) {
-    icon_data->uFlags |= NIF_GUID;
-    memcpy(reinterpret_cast<void*>(&icon_data->guidItem),
-           &tray_app_id_hash_,
-           sizeof(GUID));
-  }
 }
 
 }  // namespace atom

--- a/atom/browser/ui/win/notify_icon.cc
+++ b/atom/browser/ui/win/notify_icon.cc
@@ -28,8 +28,7 @@ NotifyIcon::NotifyIcon(NotifyIconHost* host,
       icon_id_(id),
       window_(window),
       message_id_(message),
-      menu_model_(NULL),
-      has_tray_app_id_hash_(false) {
+      menu_model_(NULL) {
   NOTIFYICONDATA icon_data;
   InitIconData(&icon_data);
   icon_data.uFlags |= NIF_MESSAGE;

--- a/atom/browser/ui/win/notify_icon.h
+++ b/atom/browser/ui/win/notify_icon.h
@@ -79,10 +79,6 @@ class NotifyIcon : public TrayIcon {
   // The context menu.
   ui::SimpleMenuModel* menu_model_;
 
-  // A hash of the app model ID
-  GUID tray_app_id_hash_;
-  bool has_tray_app_id_hash_;
-
   DISALLOW_COPY_AND_ASSIGN(NotifyIcon);
 };
 


### PR DESCRIPTION
This PR reverts #2328 and should resolve the Tray API :ghost: mysteriously :ghost: not working on Windows. https://github.com/atom/electron/issues/2468#issuecomment-142684129 has
the full, sad story

Fixes #2468 

## TODO:

- [ ] Make sure this builds
- [ ] Code Review