### PR TITLE
Fix inconsistent docs: downloadItem.getURL() => downloadItem.getUrl()

### DIFF
--- a/atom/browser/api/atom_api_download_item.cc
+++ b/atom/browser/api/atom_api_download_item.cc
@@ -30,7 +30,7 @@ struct Converter<content::DownloadItem::DownloadState> {
         download_state = "cancelled";
         break;
       case content::DownloadItem::INTERRUPTED:
-        download_state = "interrputed";
+        download_state = "interrupted";
         break;
       default:
         break;

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -39,7 +39,7 @@ Emits when the `downloadItem` gets updated.
   * `interrupted` - An error broke the connection with the file server.
 
 Emits when the download is in a terminal state. This includes a completed
-download, a cancelled download(via `downloadItem.cancel()`), and interrputed
+download, a cancelled download(via `downloadItem.cancel()`), and interrupted
 download that can't be resumed.
 
 ## Methods

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -66,7 +66,7 @@ Resumes the download that has been paused.
 
 Cancels the download operation.
 
-### `downloadItem.getURL()`
+### `downloadItem.getUrl()`
 
 Returns a `String` represents the origin url where the item is downloaded from.
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -28,7 +28,7 @@ Calling `event.preventDefault()` will cancel the download.
 ```javascript
 session.on('will-download', function(event, item, webContents) {
   event.preventDefault();
-  require('request')(item.getURL(), function(data) {
+  require('request')(item.getUrl(), function(data) {
     require('fs').writeFileSync('/somewhere', data);
   });
 });


### PR DESCRIPTION
I forgot to update the doc after renaming `downloadItem.getURL()` to `downloadItem.getUrl()` in #2840 .