### PR TITLE
Bump the external binaries version

### DIFF
--- a/script/update-external-binaries.py
+++ b/script/update-external-binaries.py
@@ -8,7 +8,7 @@ from lib.config import get_target_arch
 from lib.util import safe_mkdir, rm_rf, extract_zip, tempdir, download
 
 
-VERSION = 'v0.7.0'
+VERSION = 'v0.8.0'
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 FRAMEWORKS_URL = 'http://github.com/atom/atom-shell-frameworks/releases' \
                  '/download/' + VERSION


### PR DESCRIPTION
Use [0.8.0](https://github.com/atom/atom-shell-frameworks/releases/tag/v0.8.0).

This picks up the fix for https://github.com/atom/atom/issues/7061.