### PR TITLE
Option to specify button on a MouseEvent and text on a KeyboardEvent when using sendInputEvent

### DIFF
--- a/atom/common/native_mate_converters/blink_converter.cc
+++ b/atom/common/native_mate_converters/blink_converter.cc
@@ -166,7 +166,8 @@ bool Converter<blink::WebKeyboardEvent>::FromV8(
   if (shifted)
     out->modifiers |= blink::WebInputEvent::ShiftKey;
   out->setKeyIdentifierFromWindowsKeyCode();
-  if (out->type == blink::WebInputEvent::Char || out->type == blink::WebInputEvent::RawKeyDown) {
+  if (out->type == blink::WebInputEvent::Char
+  || out->type == blink::WebInputEvent::RawKeyDown) {
     out->text[0] = code;
     out->unmodifiedText[0] = code;
   }

--- a/atom/common/native_mate_converters/blink_converter.cc
+++ b/atom/common/native_mate_converters/blink_converter.cc
@@ -78,6 +78,21 @@ struct Converter<blink::WebInputEvent::Type> {
 };
 
 template<>
+struct Converter<blink::WebMouseEvent::Button> {
+  static bool FromV8(v8::Isolate* isolate, v8::Handle<v8::Value> val,
+                     blink::WebMouseEvent::Button* out) {
+    std::string button = base::StringToLowerASCII(V8ToString(val));
+    if (button == "left")
+      *out = blink::WebMouseEvent::Button::ButtonLeft;
+    else if (button == "middle")
+      *out = blink::WebMouseEvent::Button::ButtonMiddle;
+    else if (button == "right")
+      *out = blink::WebMouseEvent::Button::ButtonRight;
+    return true;
+  }
+};
+
+template<>
 struct Converter<blink::WebInputEvent::Modifiers> {
   static bool FromV8(v8::Isolate* isolate, v8::Handle<v8::Value> val,
                      blink::WebInputEvent::Modifiers* out) {
@@ -176,6 +191,7 @@ bool Converter<blink::WebMouseEvent>::FromV8(
     return false;
   if (!dict.Get("x", &out->x) || !dict.Get("y", &out->y))
     return false;
+  dict.Get("button", &out->button);
   dict.Get("globalX", &out->globalX);
   dict.Get("globalY", &out->globalY);
   dict.Get("movementX", &out->movementX);

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -534,13 +534,13 @@ Sends an input `event` to the page.
 For keyboard events, the `event` object also have following properties:
 
 * `keyCode` String (**required**) - A single character that will be sent as
-  keyboard event. Can be any ASCII character on the keyboard, like `a`, `1`
-  and `=`.
+  keyboard event. Can be any UTF-8 character.
 
 For mouse events, the `event` object also have following properties:
 
 * `x` Integer (**required**)
 * `y` Integer (**required**)
+* `button` String - The button pressed, can be `left`, `middle`, `right`
 * `globalX` Integer
 * `globalY` Integer
 * `movementX` Integer


### PR DESCRIPTION
I've added the option to specify the button field of the WebMouseEvent that was being sent, because without that my example (selecting text with sent events) didn't work - I also set the text and unmodifiedtext fields on Char and RawKeyDown events, because without that the actual "typed" key didn't appear in my inputs. I also set the type of the keyCode to char16 and removed the failing condition on an undefined VKEY, because without this I wouldn't have been able to type characters other than the ones on the english keyboard.