### PR TITLE
Add MAS build

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -301,6 +301,12 @@
             'vendor/crashpad/client/client.gyp:crashpad_client',
             'vendor/crashpad/handler/handler.gyp:crashpad_handler',
           ],
+          'link_settings': {
+            # Do not link with QTKit for mas build.
+            'libraries': [
+              '$(SDKROOT)/System/Library/Frameworks/QTKit.framework',
+            ],
+          },
         }],  # OS=="mac" and mas_build==0
         ['OS=="mac" and mas_build==1', {
           'defines': [

--- a/atom.gyp
+++ b/atom.gyp
@@ -64,9 +64,6 @@
               'files': [
                 '<(PRODUCT_DIR)/<(product_name) Helper.app',
                 '<(PRODUCT_DIR)/<(product_name) Framework.framework',
-                'external_binaries/Squirrel.framework',
-                'external_binaries/ReactiveCocoa.framework',
-                'external_binaries/Mantle.framework',
               ],
             },
             {
@@ -109,7 +106,21 @@
                 '<@(locale_dirs)',
               ],
             },
-          ]
+          ],
+          'conditions': [
+            ['mas_build==0', {
+              'copies': [
+                {
+                  'destination': '<(PRODUCT_DIR)/<(product_name).app/Contents/Frameworks',
+                  'files': [
+                    'external_binaries/Squirrel.framework',
+                    'external_binaries/ReactiveCocoa.framework',
+                    'external_binaries/Mantle.framework',
+                  ],
+                },
+              ],
+            }],
+          ],
         }, {  # OS=="mac"
           'dependencies': [
             'make_locale_paks',
@@ -296,6 +307,7 @@
             'MAS_BUILD',
           ],
           'sources!': [
+            'atom/browser/auto_updater_mac.mm',
             'atom/common/crash_reporter/crash_reporter_mac.h',
             'atom/common/crash_reporter/crash_reporter_mac.mm',
           ],
@@ -402,9 +414,6 @@
             'libraries': [
               '$(SDKROOT)/System/Library/Frameworks/Carbon.framework',
               '$(SDKROOT)/System/Library/Frameworks/QuartzCore.framework',
-              'external_binaries/Squirrel.framework',
-              'external_binaries/ReactiveCocoa.framework',
-              'external_binaries/Mantle.framework',
             ],
           },
           'mac_bundle': 1,
@@ -481,6 +490,13 @@
           ],
           'conditions': [
             ['mas_build==0', {
+              'link_settings': {
+                'libraries': [
+                  'external_binaries/Squirrel.framework',
+                  'external_binaries/ReactiveCocoa.framework',
+                  'external_binaries/Mantle.framework',
+                ],
+              },
               'copies': [
                 {
                   'destination': '<(PRODUCT_DIR)/<(product_name) Framework.framework/Versions/A/Resources',

--- a/atom.gyp
+++ b/atom.gyp
@@ -285,12 +285,21 @@
             'vendor/breakpad/breakpad.gyp:breakpad_sender',
           ],
         }],  # OS=="win"
-        ['OS=="mac"', {
+        ['OS=="mac" and mas_build==0', {
           'dependencies': [
             'vendor/crashpad/client/client.gyp:crashpad_client',
             'vendor/crashpad/handler/handler.gyp:crashpad_handler',
           ],
-        }],  # OS=="mac"
+        }],  # OS=="mac" and mas_build==0
+        ['OS=="mac" and mas_build==1', {
+          'defines': [
+            'MAS_BUILD',
+          ],
+          'sources!': [
+            'atom/common/crash_reporter/crash_reporter_mac.h',
+            'atom/common/crash_reporter/crash_reporter_mac.mm',
+          ],
+        }],  # OS=="mac" and mas_build==1
         ['OS=="linux"', {
           'link_settings': {
             'ldflags': [
@@ -439,12 +448,6 @@
                 '<@(copied_libraries)',
               ],
             },
-            {
-              'destination': '<(PRODUCT_DIR)/<(product_name) Framework.framework/Versions/A/Resources',
-              'files': [
-                '<(PRODUCT_DIR)/crashpad_handler',
-              ],
-            },
           ],
           'postbuilds': [
             {
@@ -475,6 +478,18 @@
                 'Libraries',
               ],
             },
+          ],
+          'conditions': [
+            ['mas_build==0', {
+              'copies': [
+                {
+                  'destination': '<(PRODUCT_DIR)/<(product_name) Framework.framework/Versions/A/Resources',
+                  'files': [
+                    '<(PRODUCT_DIR)/crashpad_handler',
+                  ],
+                },
+              ],
+            }],
           ],
         },  # target framework
         {

--- a/atom/browser/auto_updater.cc
+++ b/atom/browser/auto_updater.cc
@@ -16,4 +16,12 @@ void AutoUpdater::SetDelegate(AutoUpdaterDelegate* delegate) {
   delegate_ = delegate;
 }
 
+#if defined(OS_MACOSX) && defined(MAS_BUILD)
+void AutoUpdater::SetFeedURL(const std::string& url) {
+}
+
+void AutoUpdater::CheckForUpdates() {
+}
+#endif
+
 }  // namespace auto_updater

--- a/atom/browser/resources/mac/Info.plist
+++ b/atom/browser/resources/mac/Info.plist
@@ -20,6 +20,8 @@
   <string>0.33.7</string>
   <key>CFBundleShortVersionString</key>
   <string>0.33.7</string>
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.developer-tools</string>
   <key>LSMinimumSystemVersion</key>
   <string>10.8.0</string>
   <key>NSMainNibFile</key>

--- a/atom/browser/resources/mac/Info.plist
+++ b/atom/browser/resources/mac/Info.plist
@@ -18,6 +18,8 @@
   <string>atom.icns</string>
   <key>CFBundleVersion</key>
   <string>0.33.7</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.33.7</string>
   <key>LSMinimumSystemVersion</key>
   <string>10.8.0</string>
   <key>NSMainNibFile</key>

--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -72,6 +72,10 @@ void AtomBindings::BindTo(v8::Isolate* isolate,
   // Do not warn about deprecated APIs.
   dict.Set("noDeprecation", true);
 
+#if defined(MAS_BUILD)
+  dict.Set("mas", true);
+#endif
+
   mate::Dictionary versions;
   if (dict.Get("versions", &versions)) {
     versions.Set(ATOM_PROJECT_NAME, ATOM_VERSION_STRING);

--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -64,4 +64,23 @@ CrashReporter::GetUploadedReports(const std::string& path) {
   return result;
 }
 
+#if defined(OS_MACOSX) && defined(MAS_BUILD)
+void CrashReporter::InitBreakpad(const std::string& product_name,
+                                 const std::string& version,
+                                 const std::string& company_name,
+                                 const std::string& submit_url,
+                                 bool auto_submit,
+                                 bool skip_system_crash_handler) {
+}
+
+void CrashReporter::SetUploadParameters() {
+}
+
+// static
+CrashReporter* CrashReporter::GetInstance() {
+  static CrashReporter crash_reporter;
+  return &crash_reporter;
+}
+#endif
+
 }  // namespace crash_reporter

--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -64,7 +64,6 @@ CrashReporter::GetUploadedReports(const std::string& path) {
   return result;
 }
 
-#if defined(OS_MACOSX) && defined(MAS_BUILD)
 void CrashReporter::InitBreakpad(const std::string& product_name,
                                  const std::string& version,
                                  const std::string& company_name,
@@ -76,6 +75,7 @@ void CrashReporter::InitBreakpad(const std::string& product_name,
 void CrashReporter::SetUploadParameters() {
 }
 
+#if defined(OS_MACOSX) && defined(MAS_BUILD)
 // static
 CrashReporter* CrashReporter::GetInstance() {
   static CrashReporter crash_reporter;

--- a/atom/common/crash_reporter/crash_reporter.h
+++ b/atom/common/crash_reporter/crash_reporter.h
@@ -40,8 +40,8 @@ class CrashReporter {
                             const std::string& company_name,
                             const std::string& submit_url,
                             bool auto_submit,
-                            bool skip_system_crash_handler) = 0;
-  virtual void SetUploadParameters() = 0;
+                            bool skip_system_crash_handler);
+  virtual void SetUploadParameters();
 
   StringMap upload_parameters_;
   bool is_browser_;

--- a/atom/common/resources/mac/Info.plist
+++ b/atom/common/resources/mac/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleExecutable</key>
-	<string>${PRODUCT_NAME} Framework</string>
 	<key>CFBundleIdentifier</key>
 	<string>${ATOM_BUNDLE_ID}</string>
 	<key>CFBundleName</key>

--- a/atom/common/resources/mac/Info.plist
+++ b/atom/common/resources/mac/Info.plist
@@ -5,7 +5,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>${ATOM_BUNDLE_ID}</string>
 	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME} Framework</string>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundleExecutable</key>
+	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>

--- a/script/bump-version.py
+++ b/script/bump-version.py
@@ -106,10 +106,11 @@ def update_info_plist(version):
     line = lines[i]
     if 'CFBundleVersion' in line:
       lines[i + 1] = '  <string>{0}</string>\n'.format(version)
+    if 'CFBundleShortVersionString' in line:
+      lines[i + 1] = '  <string>{0}</string>\n'.format(version)
 
-      with open(info_plist, 'w') as f:
-        f.write(''.join(lines))
-      return
+  with open(info_plist, 'w') as f:
+    f.write(''.join(lines))
 
 
 def tag_version(version):

--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -8,7 +8,8 @@ import sys
 import stat
 
 from lib.config import LIBCHROMIUMCONTENT_COMMIT, BASE_URL, PLATFORM, \
-                       get_target_arch, get_chromedriver_version
+                       get_target_arch, get_chromedriver_version, \
+                       get_platform_key
 from lib.util import scoped_cwd, rm_rf, get_atom_shell_version, make_zip, \
                      execute, atom_gyp
 
@@ -170,7 +171,8 @@ def create_symbols():
 
 def create_dist_zip():
   dist_name = '{0}-{1}-{2}-{3}.zip'.format(PROJECT_NAME, ATOM_SHELL_VERSION,
-                                           PLATFORM, get_target_arch())
+                                           get_platform_key(),
+                                           get_target_arch())
   zip_file = os.path.join(SOURCE_ROOT, 'dist', dist_name)
 
   with scoped_cwd(DIST_DIR):
@@ -182,7 +184,7 @@ def create_dist_zip():
 
 
 def create_chrome_binary_zip(binary, version):
-  dist_name = '{0}-{1}-{2}-{3}.zip'.format(binary, version, PLATFORM,
+  dist_name = '{0}-{1}-{2}-{3}.zip'.format(binary, version, get_platform_key(),
                                            get_target_arch())
   zip_file = os.path.join(SOURCE_ROOT, 'dist', dist_name)
 
@@ -198,7 +200,7 @@ def create_chrome_binary_zip(binary, version):
 def create_symbols_zip():
   dist_name = '{0}-{1}-{2}-{3}-symbols.zip'.format(PROJECT_NAME,
                                                    ATOM_SHELL_VERSION,
-                                                   PLATFORM,
+                                                   get_platform_key(),
                                                    get_target_arch())
   zip_file = os.path.join(SOURCE_ROOT, 'dist', dist_name)
 

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -20,6 +20,13 @@ PLATFORM = {
 verbose_mode = False
 
 
+def get_platform_key():
+  if os.environ.has_key('MAS_BUILD'):
+    return 'mas'
+  else:
+    return PLATFORM
+
+
 def get_target_arch():
   try:
     target_arch_path = os.path.join(__file__, '..', '..', '..', 'vendor',

--- a/script/update.py
+++ b/script/update.py
@@ -55,11 +55,17 @@ def run_gyp(target_arch, component):
   # Avoid using the old gyp lib in system.
   env['PYTHONPATH'] = os.path.pathsep.join([gyp_pylib,
                                             env.get('PYTHONPATH', '')])
+  # Whether to build for Mac App Store.
+  if os.environ.has_key('MAS_BUILD'):
+    mas_build = 1
+  else:
+    mas_build = 0
   defines = [
     '-Dlibchromiumcontent_component={0}'.format(component),
     '-Dtarget_arch={0}'.format(target_arch),
     '-Dhost_arch={0}'.format(get_host_arch()),
     '-Dlibrary=static_library',
+    '-Dmas_build={0}'.format(mas_build),
   ]
   return subprocess.call([python, gyp, '-f', 'ninja', '--depth', '.',
                           'atom.gyp', '-Icommon.gypi'] + defines, env=env)

--- a/script/upload.py
+++ b/script/upload.py
@@ -7,7 +7,8 @@ import subprocess
 import sys
 import tempfile
 
-from lib.config import PLATFORM, get_target_arch, get_chromedriver_version
+from lib.config import PLATFORM, get_target_arch, get_chromedriver_version, \
+                       get_platform_key
 from lib.util import atom_gyp, execute, get_atom_shell_version, parse_version, \
                      scoped_cwd
 from lib.github import GitHub
@@ -24,14 +25,14 @@ OUT_DIR = os.path.join(SOURCE_ROOT, 'out', 'R')
 DIST_DIR = os.path.join(SOURCE_ROOT, 'dist')
 DIST_NAME = '{0}-{1}-{2}-{3}.zip'.format(PROJECT_NAME,
                                          ATOM_SHELL_VERSION,
-                                         PLATFORM,
+                                         get_platform_key(),
                                          get_target_arch())
 SYMBOLS_NAME = '{0}-{1}-{2}-{3}-symbols.zip'.format(PROJECT_NAME,
                                                     ATOM_SHELL_VERSION,
-                                                    PLATFORM,
+                                                    get_platform_key(),
                                                     get_target_arch())
 MKSNAPSHOT_NAME = 'mksnapshot-{0}-{1}-{2}.zip'.format(ATOM_SHELL_VERSION,
-                                                      PLATFORM,
+                                                      get_platform_key(),
                                                       get_target_arch())
 
 
@@ -85,7 +86,7 @@ def main():
   # Upload chromedriver and mksnapshot for minor version update.
   if parse_version(args.version)[2] == '0':
     chromedriver = 'chromedriver-{0}-{1}-{2}.zip'.format(
-        get_chromedriver_version(), PLATFORM, get_target_arch())
+        get_chromedriver_version(), get_platform_key(), get_target_arch())
     upload_atom_shell(github, release, os.path.join(DIST_DIR, chromedriver))
     upload_atom_shell(github, release, os.path.join(DIST_DIR, MKSNAPSHOT_NAME))
 

--- a/spec/api-crash-reporter-spec.coffee
+++ b/spec/api-crash-reporter-spec.coffee
@@ -18,6 +18,9 @@ describe 'crash-reporter module', ->
   # It is not working on 64bit Windows.
   return if process.platform is 'win32' and process.arch is 'x64'
 
+  # It is not working for mas build.
+  return if process.mas
+
   # The crash-reporter test is not reliable on CI machine.
   isCI = remote.process.argv[2] == '--ci'
   return if isCI


### PR DESCRIPTION
This PR adds a new MAS build which removes usages of private API calls of OS X and can be published to Mac App Store.

* [x] Disable auto updater
* [x] Disable crash reporter
* [x] Remove private API calls in libchromiumcontent
* [x] Verify it can be published to Mac App Store
* [ ] Add a guide on using MAS build

Fixes #249.