### PR TITLE
Fix window state events on Windows

### DIFF
--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -142,6 +142,8 @@ class NativeWindowViews : public NativeWindow,
   // MessageHandlerDelegate:
   bool PreHandleMSG(
       UINT message, WPARAM w_param, LPARAM l_param, LRESULT* result) override;
+
+  void HandleSizeEvent(WPARAM w_param, LPARAM l_param);
 #endif
 
   // NativeWindow:
@@ -178,9 +180,9 @@ class NativeWindowViews : public NativeWindow,
 #elif defined(OS_WIN)
   // Weak ref.
   AtomDesktopWindowTreeHostWin* atom_desktop_window_tree_host_win_;
-  // Records window was whether restored from minimized state or maximized
-  // state.
-  bool is_minimized_;
+
+  ui::WindowShowState last_window_state_;
+
   // In charge of running taskbar related APIs.
   TaskbarHost taskbar_host_;
 #endif


### PR DESCRIPTION
This commit fixes the issue we had with window state events (maximize, minimize etc.) not firing when triggered through Aero Snap.
Instead of relying on WM_COMMAND to figure out the window state, which doesn't work with Aero Snap, we now listen to WM_SIZE which does work.

This resolves #1381.