### PR TITLE
Update docs v0.33

### DIFF
--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -33,7 +33,7 @@ By setting the `transparent` option to `true`, you can also make the frameless
 window transparent:
 
 ```javascript
-var win = new BrowserWindow({ transparent: true, frame: false });
+var win = new BrowserWindow({ width: 800, height: 600, transparent: true, frame: false });
 ```
 
 ### Limitations

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -8,7 +8,8 @@ image file path as a `String`:
 
 ```javascript
 var appIcon = new Tray('/Users/somebody/images/icon.png');
-var window = new BrowserWindow({icon: '/Users/somebody/images/window.png'});
+var windowIcon = new NativeImage('/Users/somebody/images/window.png');
+var window = new BrowserWindow({ width: 800, height: 600, icon: windowIcon});
 ```
 
 Or read the image from the clipboard which returns a `NativeImage`:

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -46,8 +46,10 @@ app.on('ready', function() {
 
   if (externalDisplay) {
     mainWindow = new BrowserWindow({
+      width: 800,
+      height: 600,
       x: externalDisplay.bounds.x + 50,
-      y: externalDisplay.bounds.y + 50,
+      y: externalDisplay.bounds.y + 50
     });
   }
 });


### PR DESCRIPTION
I was guided by the following [options for BrowserWindow constructor] (https://github.com/atom/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions).
In 0.33 version options for BrowserWindow constructor require "width" and "height" props. Also "icon" property must be NativeImage.