### PR TITLE
Move devtools methods to WebContents

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -7,6 +7,7 @@
 #include <set>
 
 #include "atom/browser/api/atom_api_session.h"
+#include "atom/browser/api/atom_api_window.h"
 #include "atom/browser/atom_browser_client.h"
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/atom_browser_main_parts.h"
@@ -914,6 +915,13 @@ v8::Local<v8::Value> WebContents::GetWebPreferences(v8::Isolate* isolate) {
   return mate::ConvertToV8(isolate, *web_preferences->web_preferences());
 }
 
+v8::Local<v8::Value> WebContents::GetOwnerBrowserWindow() {
+  if (owner_window())
+    return Window::From(isolate(), owner_window());
+  else
+    return v8::Null(isolate());
+}
+
 v8::Local<v8::Value> WebContents::Session(v8::Isolate* isolate) {
   return v8::Local<v8::Value>::New(isolate, session_);
 }
@@ -981,6 +989,7 @@ mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
         .SetMethod("setAllowTransparency", &WebContents::SetAllowTransparency)
         .SetMethod("isGuest", &WebContents::IsGuest)
         .SetMethod("getWebPreferences", &WebContents::GetWebPreferences)
+        .SetMethod("getOwnerBrowserWindow", &WebContents::GetOwnerBrowserWindow)
         .SetMethod("hasServiceWorker", &WebContents::HasServiceWorker)
         .SetMethod("unregisterServiceWorker",
                    &WebContents::UnregisterServiceWorker)

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -506,6 +506,11 @@ void WebContents::DevToolsOpened() {
       isolate(), managed_web_contents()->GetDevToolsWebContents());
   devtools_web_contents_.Reset(isolate(), handle.ToV8());
 
+  // Inherit owner window in devtools.
+  if (owner_window())
+    handle->SetOwnerWindow(managed_web_contents()->GetDevToolsWebContents(),
+                           owner_window());
+
   Emit("devtools-opened");
 }
 

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -26,6 +26,7 @@
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brightray/browser/inspectable_web_contents.h"
+#include "brightray/browser/inspectable_web_contents_view.h"
 #include "chrome/browser/printing/print_view_manager_basic.h"
 #include "chrome/browser/printing/print_preview_message_handler.h"
 #include "content/common/view_messages.h"
@@ -227,6 +228,8 @@ WebContents::WebContents(v8::Isolate* isolate,
   Observe(web_contents);
   AttachAsUserData(web_contents);
   InitWithWebContents(web_contents);
+
+  managed_web_contents()->GetView()->SetDelegate(this);
 
   // Save the preferences in C++.
   base::DictionaryValue web_preferences;
@@ -491,6 +494,28 @@ void WebContents::DidUpdateFaviconURL(
   Emit("page-favicon-updated", unique_urls);
 }
 
+void WebContents::DevToolsFocused() {
+  Emit("devtools-focused");
+}
+
+void WebContents::DevToolsOpened() {
+  v8::Locker locker(isolate());
+  v8::HandleScope handle_scope(isolate());
+  auto handle = WebContents::CreateFrom(
+      isolate(), managed_web_contents()->GetDevToolsWebContents());
+  devtools_web_contents_.Reset(isolate(), handle.ToV8());
+
+  Emit("devtools-opened");
+}
+
+void WebContents::DevToolsClosed() {
+  v8::Locker locker(isolate());
+  v8::HandleScope handle_scope(isolate());
+  devtools_web_contents_.Reset();
+
+  Emit("devtools-closed");
+}
+
 bool WebContents::OnMessageReceived(const IPC::Message& message) {
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(WebContents, message)
@@ -698,10 +723,6 @@ void WebContents::InspectServiceWorker() {
   }
 }
 
-v8::Local<v8::Value> WebContents::Session(v8::Isolate* isolate) {
-  return v8::Local<v8::Value>::New(isolate, session_);
-}
-
 void WebContents::HasServiceWorker(
     const base::Callback<void(bool)>& callback) {
   auto context = GetServiceWorkerContext(web_contents());
@@ -893,6 +914,17 @@ v8::Local<v8::Value> WebContents::GetWebPreferences(v8::Isolate* isolate) {
   return mate::ConvertToV8(isolate, *web_preferences->web_preferences());
 }
 
+v8::Local<v8::Value> WebContents::Session(v8::Isolate* isolate) {
+  return v8::Local<v8::Value>::New(isolate, session_);
+}
+
+v8::Local<v8::Value> WebContents::DevToolsWebContents(v8::Isolate* isolate) {
+  if (devtools_web_contents_.IsEmpty())
+    return v8::Null(isolate);
+  else
+    return v8::Local<v8::Value>::New(isolate, devtools_web_contents_);
+}
+
 mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
   if (template_.IsEmpty())
@@ -957,7 +989,9 @@ mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
         .SetMethod("_printToPDF", &WebContents::PrintToPDF)
         .SetMethod("addWorkSpace", &WebContents::AddWorkSpace)
         .SetMethod("removeWorkSpace", &WebContents::RemoveWorkSpace)
-        .SetProperty("session", &WebContents::Session)
+        .SetProperty("session", &WebContents::Session, true)
+        .SetProperty("devToolsWebContents",
+                     &WebContents::DevToolsWebContents, true)
         .Build());
 
   return mate::ObjectTemplateBuilder(

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -134,6 +134,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
   // Returns the web preferences of current WebContents.
   v8::Local<v8::Value> GetWebPreferences(v8::Isolate* isolate);
 
+  // Returns the owner window.
+  v8::Local<v8::Value> GetOwnerBrowserWindow();
+
   // Properties.
   v8::Local<v8::Value> Session(v8::Isolate* isolate);
   v8::Local<v8::Value> DevToolsWebContents(v8::Isolate* isolate);

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -83,7 +83,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void DisableDeviceEmulation();
   void InspectElement(int x, int y);
   void InspectServiceWorker();
-  v8::Local<v8::Value> Session(v8::Isolate* isolate);
   void HasServiceWorker(const base::Callback<void(bool)>&);
   void UnregisterServiceWorker(const base::Callback<void(bool)>&);
   void SetAudioMuted(bool muted);
@@ -134,6 +133,10 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   // Returns the web preferences of current WebContents.
   v8::Local<v8::Value> GetWebPreferences(v8::Isolate* isolate);
+
+  // Properties.
+  v8::Local<v8::Value> Session(v8::Isolate* isolate);
+  v8::Local<v8::Value> DevToolsWebContents(v8::Isolate* isolate);
 
  protected:
   explicit WebContents(content::WebContents* web_contents);
@@ -218,6 +221,11 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void PluginCrashed(const base::FilePath& plugin_path,
                      base::ProcessId plugin_pid) override;
 
+  // brightray::InspectableWebContentsViewDelegate:
+  void DevToolsFocused() override;
+  void DevToolsOpened() override;
+  void DevToolsClosed() override;
+
  private:
   enum Type {
     BROWSER_WINDOW,  // Used by BrowserWindow.
@@ -237,6 +245,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
                              IPC::Message* message);
 
   v8::Global<v8::Value> session_;
+  v8::Global<v8::Value> devtools_web_contents_;
 
   scoped_ptr<WebViewGuestDelegate> guest_delegate_;
 

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -92,6 +92,7 @@ Window::Window(v8::Isolate* isolate, const mate::Dictionary& options) {
   web_contents->SetOwnerWindow(window_.get());
   window_->InitFromOptions(options);
   window_->AddObserver(this);
+  AttachAsUserData(window_.get());
 }
 
 Window::~Window() {
@@ -590,6 +591,16 @@ void Window::BuildPrototype(v8::Isolate* isolate,
 #endif
       .SetProperty("id", &Window::ID, true)
       .SetProperty("webContents", &Window::WebContents, true);
+}
+
+// static
+v8::Local<v8::Value> Window::From(v8::Isolate* isolate,
+                                  NativeWindow* native_window) {
+  auto existing = TrackableObject::FromWrappedClass(isolate, native_window);
+  if (existing)
+    return existing->GetWrapper(isolate);
+  else
+    return v8::Null(isolate);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -184,28 +184,6 @@ void Window::OnRendererResponsive() {
   Emit("responsive");
 }
 
-void Window::OnDevToolsFocus() {
-  Emit("devtools-focused");
-}
-
-void Window::OnDevToolsOpened() {
-  v8::Locker locker(isolate());
-  v8::HandleScope handle_scope(isolate());
-  auto handle = WebContents::CreateFrom(
-      isolate(), api_web_contents_->GetDevToolsWebContents());
-  devtools_web_contents_.Reset(isolate(), handle.ToV8());
-
-  Emit("devtools-opened");
-}
-
-void Window::OnDevToolsClosed() {
-  v8::Locker locker(isolate());
-  v8::HandleScope handle_scope(isolate());
-  devtools_web_contents_.Reset();
-
-  Emit("devtools-closed");
-}
-
 void Window::OnExecuteWindowsCommand(const std::string& command_name) {
   Emit("app-command", command_name);
 }
@@ -540,13 +518,6 @@ v8::Local<v8::Value> Window::WebContents(v8::Isolate* isolate) {
     return v8::Local<v8::Value>::New(isolate, web_contents_);
 }
 
-v8::Local<v8::Value> Window::DevToolsWebContents(v8::Isolate* isolate) {
-  if (devtools_web_contents_.IsEmpty())
-    return v8::Null(isolate);
-  else
-    return v8::Local<v8::Value>::New(isolate, devtools_web_contents_);
-}
-
 // static
 void Window::BuildPrototype(v8::Isolate* isolate,
                             v8::Local<v8::ObjectTemplate> prototype) {
@@ -618,8 +589,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
                  &Window::ShowDefinitionForSelection)
 #endif
       .SetProperty("id", &Window::ID, true)
-      .SetProperty("webContents", &Window::WebContents, true)
-      .SetProperty("devToolsWebContents", &Window::DevToolsWebContents, true);
+      .SetProperty("webContents", &Window::WebContents, true);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -69,9 +69,6 @@ class Window : public mate::TrackableObject<Window>,
   void OnWindowLeaveHtmlFullScreen() override;
   void OnRendererUnresponsive() override;
   void OnRendererResponsive() override;
-  void OnDevToolsFocus() override;
-  void OnDevToolsOpened() override;
-  void OnDevToolsClosed() override;
   void OnExecuteWindowsCommand(const std::string& command_name) override;
 
   // mate::Wrappable:
@@ -150,10 +147,8 @@ class Window : public mate::TrackableObject<Window>,
 
   int32_t ID() const;
   v8::Local<v8::Value> WebContents(v8::Isolate* isolate);
-  v8::Local<v8::Value> DevToolsWebContents(v8::Isolate* isolate);
 
   v8::Global<v8::Value> web_contents_;
-  v8::Global<v8::Value> devtools_web_contents_;
   v8::Global<v8::Value> menu_;
 
   api::WebContents* api_web_contents_;

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -43,6 +43,10 @@ class Window : public mate::TrackableObject<Window>,
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::ObjectTemplate> prototype);
 
+  // Returns the BrowserWindow object from |native_window|.
+  static v8::Local<v8::Value> From(v8::Isolate* isolate,
+                                   NativeWindow* native_window);
+
   NativeWindow* window() const { return window_.get(); }
 
  protected:

--- a/atom/browser/api/lib/browser-window.coffee
+++ b/atom/browser/api/lib/browser-window.coffee
@@ -48,6 +48,15 @@ BrowserWindow::_init = ->
   # Notify the creation of the window.
   app.emit 'browser-window-created', {}, this
 
+  # Be compatible with old APIs.
+  @webContents.on 'devtools-focused', => @emit 'devtools-focused'
+  @webContents.on 'devtools-opened', => @emit 'devtools-opened'
+  @webContents.on 'devtools-closed', => @emit 'devtools-closed'
+  Object.defineProperty this, 'devToolsWebContents',
+    enumerable: true,
+    configurable: false,
+    get: -> @webContents.devToolsWebContents
+
 BrowserWindow.getFocusedWindow = ->
   windows = BrowserWindow.getAllWindows()
   return window for window in windows when window.isFocused()

--- a/atom/browser/api/lib/menu.coffee
+++ b/atom/browser/api/lib/menu.coffee
@@ -79,7 +79,11 @@ Menu::_init = ->
         v8Util.setHiddenValue group[0], 'checked', true unless checked
 
 Menu::popup = (window, x, y) ->
-  throw new TypeError('Invalid window') unless window?.constructor is BrowserWindow
+  unless window?.constructor is BrowserWindow
+    # Shift.
+    y = x
+    x = window
+    window = BrowserWindow.getFocusedWindow()
   if x? and y?
     @_popupAt(window, x, y)
   else

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -21,6 +21,14 @@
 #include "content/public/browser/render_view_host.h"
 #include "storage/browser/fileapi/isolated_context.h"
 
+#if defined(TOOLKIT_VIEWS)
+#include "atom/browser/native_window_views.h"
+#endif
+
+#if defined(USE_X11)
+#include "atom/browser/browser.h"
+#endif
+
 using content::BrowserThread;
 
 namespace atom {
@@ -354,6 +362,23 @@ void CommonWebContentsDelegate::OnDevToolsAppendToFile(
   web_contents_->CallClientFunction(
       "DevToolsAPI.appendedToURL", &url_value, nullptr, nullptr);
 }
+
+#if defined(TOOLKIT_VIEWS)
+gfx::ImageSkia CommonWebContentsDelegate::GetDevToolsWindowIcon() {
+  if (!owner_window())
+    return gfx::ImageSkia();
+  return static_cast<views::WidgetDelegate*>(static_cast<NativeWindowViews*>(
+      owner_window()))->GetWindowAppIcon();
+}
+#endif
+
+#if defined(USE_X11)
+void CommonWebContentsDelegate::GetDevToolsWindowWMClass(
+    std::string* name, std::string* class_name) {
+  *class_name = Browser::Get()->GetName();
+  *name = base::StringToLowerASCII(*class_name);
+}
+#endif
 
 void CommonWebContentsDelegate::SetHtmlApiFullscreen(bool enter_fullscreen) {
   // Window is already in fullscreen mode, save the state.

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -136,7 +136,11 @@ void CommonWebContentsDelegate::InitWithWebContents(
 }
 
 void CommonWebContentsDelegate::SetOwnerWindow(NativeWindow* owner_window) {
-  content::WebContents* web_contents = GetWebContents();
+  SetOwnerWindow(GetWebContents(), owner_window);
+}
+
+void CommonWebContentsDelegate::SetOwnerWindow(
+    content::WebContents* web_contents, NativeWindow* owner_window) {
   owner_window_ = owner_window->GetWeakPtr();
   NativeWindowRelay* relay = new NativeWindowRelay(owner_window_);
   web_contents->SetUserData(relay->key, relay);

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -34,6 +34,8 @@ class CommonWebContentsDelegate
 
   // Set the window as owner window.
   void SetOwnerWindow(NativeWindow* owner_window);
+  void SetOwnerWindow(content::WebContents* web_contents,
+                      NativeWindow* owner_window);
 
   // Destroy the managed InspectableWebContents object.
   void DestroyWebContents();

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -12,6 +12,7 @@
 #include "brightray/browser/default_web_contents_delegate.h"
 #include "brightray/browser/inspectable_web_contents_impl.h"
 #include "brightray/browser/inspectable_web_contents_delegate.h"
+#include "brightray/browser/inspectable_web_contents_view_delegate.h"
 
 namespace atom {
 
@@ -21,7 +22,8 @@ class WebDialogHelper;
 
 class CommonWebContentsDelegate
     : public brightray::DefaultWebContentsDelegate,
-      public brightray::InspectableWebContentsDelegate {
+      public brightray::InspectableWebContentsDelegate,
+      public brightray::InspectableWebContentsViewDelegate {
  public:
   CommonWebContentsDelegate();
   virtual ~CommonWebContentsDelegate();
@@ -85,6 +87,15 @@ class CommonWebContentsDelegate
   void DevToolsAddFileSystem(const base::FilePath& path) override;
   void DevToolsRemoveFileSystem(
       const base::FilePath& file_system_path) override;
+
+  // brightray::InspectableWebContentsViewDelegate:
+#if defined(TOOLKIT_VIEWS)
+  gfx::ImageSkia GetDevToolsWindowIcon() override;
+#endif
+#if defined(USE_X11)
+  void GetDevToolsWindowWMClass(
+      std::string* name, std::string* class_name) override;
+#endif
 
  private:
   // Callback for when DevToolsSaveToFile has completed.

--- a/atom/browser/lib/rpc-server.coffee
+++ b/atom/browser/lib/rpc-server.coffee
@@ -106,16 +106,9 @@ ipc.on 'ATOM_BROWSER_GLOBAL', (event, name) ->
   catch e
     event.returnValue = errorToMeta e
 
-ipc.on 'ATOM_BROWSER_CURRENT_WINDOW', (event, guestInstanceId) ->
+ipc.on 'ATOM_BROWSER_CURRENT_WINDOW', (event) ->
   try
-    BrowserWindow = require 'browser-window'
-    if guestInstanceId?
-      guestViewManager = require './guest-view-manager'
-      window = BrowserWindow.fromWebContents guestViewManager.getEmbedder(guestInstanceId)
-    else
-      window = BrowserWindow.fromWebContents event.sender
-      window = BrowserWindow.fromDevToolsWebContents event.sender unless window?
-    event.returnValue = valueToMeta event.sender, window
+    event.returnValue = valueToMeta event.sender, event.sender.getOwnerBrowserWindow()
   catch e
     event.returnValue = errorToMeta e
 

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -76,8 +76,6 @@ NativeWindow::NativeWindow(
       aspect_ratio_(0.0),
       inspectable_web_contents_(inspectable_web_contents),
       weak_factory_(this) {
-  inspectable_web_contents->GetView()->SetDelegate(this);
-
   options.Get(switches::kFrame, &has_frame_);
   options.Get(switches::kTransparent, &transparent_);
   options.Get(switches::kEnableLargerThanScreen, &enable_larger_than_screen_);
@@ -416,18 +414,6 @@ void NativeWindow::NotifyWindowExecuteWindowsCommand(
     const std::string& command) {
   FOR_EACH_OBSERVER(NativeWindowObserver, observers_,
                     OnExecuteWindowsCommand(command));
-}
-
-void NativeWindow::DevToolsFocused() {
-  FOR_EACH_OBSERVER(NativeWindowObserver, observers_, OnDevToolsFocus());
-}
-
-void NativeWindow::DevToolsOpened() {
-  FOR_EACH_OBSERVER(NativeWindowObserver, observers_, OnDevToolsOpened());
-}
-
-void NativeWindow::DevToolsClosed() {
-  FOR_EACH_OBSERVER(NativeWindowObserver, observers_, OnDevToolsClosed());
 }
 
 void NativeWindow::RenderViewCreated(

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -15,6 +15,7 @@
 #include "base/memory/scoped_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
+#include "base/supports_user_data.h"
 #include "content/public/browser/readback_types.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_contents_user_data.h"
@@ -49,7 +50,8 @@ namespace atom {
 
 struct DraggableRegion;
 
-class NativeWindow : public content::WebContentsObserver {
+class NativeWindow : public base::SupportsUserData,
+                     public content::WebContentsObserver {
  public:
   using CapturePageCallback = base::Callback<void(const SkBitmap& bitmap)>;
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -15,7 +15,6 @@
 #include "base/memory/scoped_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
-#include "brightray/browser/inspectable_web_contents_view_delegate.h"
 #include "content/public/browser/readback_types.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_contents_user_data.h"
@@ -50,8 +49,7 @@ namespace atom {
 
 struct DraggableRegion;
 
-class NativeWindow : public content::WebContentsObserver,
-                     public brightray::InspectableWebContentsViewDelegate {
+class NativeWindow : public content::WebContentsObserver {
  public:
   using CapturePageCallback = base::Callback<void(const SkBitmap& bitmap)>;
 
@@ -233,11 +231,6 @@ class NativeWindow : public content::WebContentsObserver,
  protected:
   NativeWindow(brightray::InspectableWebContents* inspectable_web_contents,
                const mate::Dictionary& options);
-
-  // brightray::InspectableWebContentsViewDelegate:
-  void DevToolsFocused() override;
-  void DevToolsOpened() override;
-  void DevToolsClosed() override;
 
   // content::WebContentsObserver:
   void RenderViewCreated(content::RenderViewHost* render_view_host) override;

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -55,11 +55,6 @@ class NativeWindowObserver {
   virtual void OnWindowEnterHtmlFullScreen() {}
   virtual void OnWindowLeaveHtmlFullScreen() {}
 
-  // Redirect devtools events.
-  virtual void OnDevToolsFocus() {}
-  virtual void OnDevToolsOpened() {}
-  virtual void OnDevToolsClosed() {}
-
   // Called when renderer is hung.
   virtual void OnRendererUnresponsive() {}
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -823,18 +823,6 @@ bool NativeWindowViews::ExecuteWindowsCommand(int command_id) {
 }
 #endif
 
-gfx::ImageSkia NativeWindowViews::GetDevToolsWindowIcon() {
-  return GetWindowAppIcon();
-}
-
-#if defined(USE_X11)
-void NativeWindowViews::GetDevToolsWindowWMClass(
-    std::string* name, std::string* class_name) {
-  *class_name = Browser::Get()->GetName();
-  *name = base::StringToLowerASCII(*class_name);
-}
-#endif
-
 #if defined(OS_WIN)
 bool NativeWindowViews::PreHandleMSG(
     UINT message, WPARAM w_param, LPARAM l_param, LRESULT* result) {

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -131,13 +131,6 @@ class NativeWindowViews : public NativeWindow,
   bool ExecuteWindowsCommand(int command_id) override;
 #endif
 
-  // brightray::InspectableWebContentsViewDelegate:
-  gfx::ImageSkia GetDevToolsWindowIcon() override;
-#if defined(USE_X11)
-  void GetDevToolsWindowWMClass(
-      std::string* name, std::string* class_name) override;
-#endif
-
 #if defined(OS_WIN)
   // MessageHandlerDelegate:
   bool PreHandleMSG(

--- a/atom/renderer/api/lib/remote.coffee
+++ b/atom/renderer/api/lib/remote.coffee
@@ -130,7 +130,7 @@ exports.require = (module) ->
 windowCache = null
 exports.getCurrentWindow = ->
   return windowCache if windowCache?
-  meta = ipc.sendSync 'ATOM_BROWSER_CURRENT_WINDOW', process.guestInstanceId
+  meta = ipc.sendSync 'ATOM_BROWSER_CURRENT_WINDOW'
   windowCache = metaToValue meta
 
 # Get current WebContents object.

--- a/atom/renderer/lib/inspector.coffee
+++ b/atom/renderer/lib/inspector.coffee
@@ -44,7 +44,7 @@ createMenu = (x, y, items, document) ->
 showFileChooserDialog = (callback) ->
   remote = require 'remote'
   dialog = remote.require 'dialog'
-  files = dialog.showOpenDialog remote.getCurrentWindow(), null
+  files = dialog.showOpenDialog {}
   callback pathToHtml5FileObject files[0] if files?
 
 pathToHtml5FileObject = (path) ->

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -231,18 +231,6 @@ Emitted when the window enters full screen state triggered by html api.
 
 Emitted when the window leaves full screen state triggered by html api.
 
-### Event: 'devtools-opened'
-
-Emitted when DevTools is opened.
-
-### Event: 'devtools-closed'
-
-Emitted when DevTools is closed.
-
-### Event: 'devtools-focused'
-
-Emitted when DevTools is focused / opened.
-
 ### Event: 'app-command':
 
 Emitted when an [App Command](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646275(v=vs.85).aspx)
@@ -316,16 +304,6 @@ operations will be done via it.
 
 See the [`webContents` documentation](web-contents.md) for its methods and
 events.
-
-**Note:** Users should never store this object because it may become `null`
-when the renderer process (web page) has crashed.
-
-### `win.devToolsWebContents`
-
-Get the `WebContents` of DevTools for this window.
-
-**Note:** Users should never store this object because it may become `null`
-when the DevTools has been closed.
 
 ### `win.id`
 
@@ -594,41 +572,6 @@ bar will become grey when set to `true`.
 ### `win.IsDocumentEdited()` _OS X_
 
 Whether the window's document has been edited.
-
-### `win.openDevTools([options])`
-
-* `options` Object (optional). Properties:
-  * `detach` Boolean - opens DevTools in a new window
-
-Opens the developer tools.
-
-### `win.closeDevTools()`
-
-Closes the developer tools.
-
-### `win.isDevToolsOpened()`
-
-Returns whether the developer tools are opened.
-
-### `win.toggleDevTools()`
-
-Toggles the developer tools.
-
-### `win.isDevToolsFocused()`
-
-Returns whether the developer tools is focused.
-
-### `win.inspectElement(x, y)`
-
-* `x` Integer
-* `y` Integer
-
-Starts inspecting element at position (`x`, `y`).
-
-### `win.inspectServiceWorker()`
-
-Opens the developer tools for the service worker context present in the web
-contents.
 
 ### `win.focusOnWebView()`
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -237,9 +237,9 @@ Generally, the `template` is just an array of `options` for constructing a
 You can also attach other fields to the element of the `template` and they
 will become properties of the constructed menu items.
 
-### `Menu.popup(browserWindow[, x, y])`
+### `Menu.popup([browserWindow, x, y])`
 
-* `browserWindow` BrowserWindow
+* `browserWindow` BrowserWindow (optional)
 * `x` Number (optional)
 * `y` Number (**required** if `x` is used)
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -154,6 +154,18 @@ Emitted when a plugin process has crashed.
 
 Emitted when `webContents` is destroyed.
 
+### Event: 'devtools-opened'
+
+Emitted when DevTools is opened.
+
+### Event: 'devtools-closed'
+
+Emitted when DevTools is closed.
+
+### Event: 'devtools-focused'
+
+Emitted when DevTools is focused / opened.
+
 ## Instance Methods
 
 The `webContents` object has the following instance methods:
@@ -441,6 +453,40 @@ Adds the specified path to DevTools workspace.
 
 Removes the specified path from DevTools workspace.
 
+### `webContents.openDevTools([options])`
+
+* `options` Object (optional). Properties:
+  * `detach` Boolean - opens DevTools in a new window
+
+Opens the developer tools.
+
+### `webContents.closeDevTools()`
+
+Closes the developer tools.
+
+### `webContents.isDevToolsOpened()`
+
+Returns whether the developer tools are opened.
+
+### `webContents.toggleDevTools()`
+
+Toggles the developer tools.
+
+### `webContents.isDevToolsFocused()`
+
+Returns whether the developer tools is focused.
+
+### `webContents.inspectElement(x, y)`
+
+* `x` Integer
+* `y` Integer
+
+Starts inspecting element at position (`x`, `y`).
+
+### `webContents.inspectServiceWorker()`
+
+Opens the developer tools for the service worker context.
+
 ### `webContents.send(channel[, args...])`
 
 * `channel` String
@@ -574,3 +620,14 @@ is in 32bit ARGB format).
 ### `webContents.endFrameSubscription()`
 
 End subscribing for frame presentation events.
+
+## Instance Properties
+
+`WebContents` objects also have the following properties:
+
+### `webContents.devToolsWebContents`
+
+Get the `WebContents` of DevTools for this `WebContents`.
+
+**Note:** Users should never store this object because it may become `null`
+when the DevTools has been closed.


### PR DESCRIPTION
This PR moves `devtools-xxx` events and the `devToolsWebContents` property from `BrowserWindow` to `WebContents`, making the devtools opened for webview also own a JavaScript object.

This also fixes devtools opened for webview not able to use `remote` module, closes #1456, closes #2896.

