### PR TITLE
Disable logging unless --enable-logging is specified

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -27,10 +27,10 @@ AtomMainDelegate::~AtomMainDelegate() {
 }
 
 bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
-  // Disable logging out to debug.log on Windows
   logging::LoggingSettings settings;
 #if defined(OS_WIN)
 #if defined(DEBUG)
+  // Print logging to debug.log on Windows
   settings.logging_dest = logging::LOG_TO_ALL;
   settings.log_file = L"debug.log";
   settings.lock_log = logging::LOCK_LOG_FILE;
@@ -41,6 +41,12 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
 #else  // defined(OS_WIN)
   settings.logging_dest = logging::LOG_TO_SYSTEM_DEBUG_LOG;
 #endif  // !defined(OS_WIN)
+
+  // Only enable logging when --enable-logging is specified.
+  auto command_line = base::CommandLine::ForCurrentProcess();
+  if (!command_line->HasSwitch(switches::kEnableLogging))
+    settings.logging_dest = logging::LOG_NONE;
+
   logging::InitLogging(settings);
 
   // Logging with pid and timestamp.

--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -89,15 +89,21 @@ Enables net log events to be saved and writes them to `path`.
 
 ## --ssl-version-fallback-min=`version`
 
-Set the minimum SSL/TLS version ("tls1", "tls1.1" or "tls1.2") that TLS
+Sets the minimum SSL/TLS version ("tls1", "tls1.1" or "tls1.2") that TLS
 fallback will accept.
+
+## --enable-logging
+
+Prints Chromium's logging into console.
+
+This switch can not be used in `app.commandLine.appendSwitch` since it is parsed earlier than user's app is loaded.
 
 ## --v=`log_level`
 
 Gives the default maximal active V-logging level; 0 is the default. Normally
 positive values are used for V-logging levels.
 
-Passing `--v=-1` will disable logging.
+This switch only works when `--enable-logging` is also passed.
 
 ## --vmodule=`pattern`
 
@@ -109,10 +115,4 @@ Any pattern containing a forward or backward slash will be tested against the
 whole pathname and not just the module. E.g. `*/foo/bar/*=2` would change the
 logging level for all code in the source files under a `foo/bar` directory.
 
-To disable all chromium related logs and only enable your application logs you
-can do:
-
-```javascript
-app.commandLine.appendSwitch('v', -1);
-app.commandLine.appendSwitch('vmodule', 'console=0');
-```
+This switch only works when `--enable-logging` is also passed.


### PR DESCRIPTION
This PR turns off Chromium's logging by default unless `--enable-logging` is specified. The Chromium's logging is quite low-level and is only useful for Electron developers, so disabling it by default should provide a better experience.

Also on the technical side the logging mechanism is initialized before user's app is loaded, by making logging opt-in is the only way to disable logging in users' apps.

Closes #2417.