### PR TITLE
Prevent Node from adding paths outside the app to search paths

### DIFF
--- a/atom/browser/lib/init.coffee
+++ b/atom/browser/lib/init.coffee
@@ -7,13 +7,13 @@ Module = require 'module'
 # we need to restore it here.
 process.argv.splice 1, 1
 
+# Import common settings.
+require path.resolve(__dirname, '..', '..', 'common', 'lib', 'init')
+
 # Add browser/api/lib to module search paths, which contains javascript part of
 # Electron's built-in libraries.
 globalPaths = Module.globalPaths
 globalPaths.push path.resolve(__dirname, '..', 'api', 'lib')
-
-# Import common settings.
-require path.resolve(__dirname, '..', '..', 'common', 'lib', 'init')
 
 if process.platform is 'win32'
   # Redirect node's console to use our own implementations, since node can not

--- a/atom/browser/lib/init.coffee
+++ b/atom/browser/lib/init.coffee
@@ -7,6 +7,9 @@ Module = require 'module'
 # we need to restore it here.
 process.argv.splice 1, 1
 
+# Clear search paths.
+require path.resolve(__dirname, '..', '..', 'common', 'lib', 'reset-search-paths')
+
 # Import common settings.
 require path.resolve(__dirname, '..', '..', 'common', 'lib', 'init')
 

--- a/atom/common/lib/init.coffee
+++ b/atom/common/lib/init.coffee
@@ -9,18 +9,9 @@ process.atomBinding = (name) ->
   catch e
     process.binding "atom_common_#{name}" if /No such module/.test e.message
 
-# Global module search paths.
+# Clear node's global search paths.
 globalPaths = Module.globalPaths
-
-# Don't lookup modules in user-defined search paths, see http://git.io/vf8sF.
-homeDir =
-  if process.platform is 'win32'
-    process.env.USERPROFILE
-  else
-    process.env.HOME
-if homeDir  # Node only add user-defined search paths when $HOME is defined.
-  userModulePath = path.resolve homeDir, '.node_modules'
-  globalPaths.splice globalPaths.indexOf(userModulePath), 2
+globalPaths.length = 0
 
 # Add common/api/lib to module search paths.
 globalPaths.push path.resolve(__dirname, '..', 'api', 'lib')

--- a/atom/common/lib/init.coffee
+++ b/atom/common/lib/init.coffee
@@ -9,12 +9,8 @@ process.atomBinding = (name) ->
   catch e
     process.binding "atom_common_#{name}" if /No such module/.test e.message
 
-# Clear node's global search paths.
-globalPaths = Module.globalPaths
-globalPaths.length = 0
-
 # Add common/api/lib to module search paths.
-globalPaths.push path.resolve(__dirname, '..', 'api', 'lib')
+Module.globalPaths.push path.resolve(__dirname, '..', 'api', 'lib')
 
 # setImmediate and process.nextTick makes use of uv_check and uv_prepare to
 # run the callbacks, however since we only run uv loop on requests, the

--- a/atom/common/lib/reset-search-paths.coffee
+++ b/atom/common/lib/reset-search-paths.coffee
@@ -1,0 +1,29 @@
+path   = require 'path'
+Module = require 'module'
+
+# Clear Node's global search paths.
+Module.globalPaths.length = 0
+
+# Clear current and parent(init.coffee)'s search paths.
+module.paths = []
+module.parent.paths = []
+
+# Prevent Node from adding paths outside this app to search paths.
+Module._nodeModulePaths = (from) ->
+  from = path.resolve from
+
+  # If "from" is outside the app then we do nothing.
+  skipOutsidePaths = from.startsWith process.resourcesPath
+
+  # Following logoic is copied from module.js.
+  splitRe = if process.platform is 'win32' then /[\/\\]/ else /\//
+  paths = []
+
+  parts = from.split splitRe
+  for part, tip in parts by -1
+    continue if part is 'node_modules'
+    dir = parts.slice(0, tip + 1).join path.sep
+    break if skipOutsidePaths and not dir.startsWith process.resourcesPath
+    paths.push path.join(dir, 'node_modules')
+
+  paths

--- a/atom/renderer/lib/init.coffee
+++ b/atom/renderer/lib/init.coffee
@@ -11,9 +11,6 @@ process.argv.splice 1, 1
 # of Atom's built-in libraries.
 globalPaths = Module.globalPaths
 globalPaths.push path.resolve(__dirname, '..', 'api', 'lib')
-# And also app.
-globalPaths.push path.join(process.resourcesPath, 'app')
-globalPaths.push path.join(process.resourcesPath, 'app.asar')
 
 # Import common settings.
 require path.resolve(__dirname, '..', '..', 'common', 'lib', 'init')

--- a/atom/renderer/lib/init.coffee
+++ b/atom/renderer/lib/init.coffee
@@ -7,6 +7,9 @@ Module = require 'module'
 # atom-renderer.js, we need to restore it here.
 process.argv.splice 1, 1
 
+# Clear search paths.
+require path.resolve(__dirname, '..', '..', 'common', 'lib', 'reset-search-paths')
+
 # Import common settings.
 require path.resolve(__dirname, '..', '..', 'common', 'lib', 'init')
 

--- a/atom/renderer/lib/init.coffee
+++ b/atom/renderer/lib/init.coffee
@@ -7,13 +7,13 @@ Module = require 'module'
 # atom-renderer.js, we need to restore it here.
 process.argv.splice 1, 1
 
+# Import common settings.
+require path.resolve(__dirname, '..', '..', 'common', 'lib', 'init')
+
 # Add renderer/api/lib to require's search paths, which contains javascript part
 # of Atom's built-in libraries.
 globalPaths = Module.globalPaths
 globalPaths.push path.resolve(__dirname, '..', 'api', 'lib')
-
-# Import common settings.
-require path.resolve(__dirname, '..', '..', 'common', 'lib', 'init')
 
 # The global variable will be used by ipc for event dispatching
 v8Util = process.atomBinding 'v8_util'

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -37,6 +37,7 @@
       'atom/common/api/lib/native-image.coffee',
       'atom/common/api/lib/shell.coffee',
       'atom/common/lib/init.coffee',
+      'atom/common/lib/reset-search-paths.coffee',
       'atom/renderer/lib/chrome-api.coffee',
       'atom/renderer/lib/init.coffee',
       'atom/renderer/lib/inspector.coffee',


### PR DESCRIPTION
The module system of Node tends to iterate every parent folder of the `require`d module and add everyone of them to search paths, it makes sense for Node, but in Electron this mechanism may happen to override app's modules with unrelated ones when user's system has lots of Node modules installed.

A classic problem is users have third party `dialog` module installed somewhere, resulting in `require('dialog')` calls in app not working.

This PR solves this problem by limiting the propagated paths to be inside the `process.resourcesPath`, so packaged app can avoid accidentally using modules installed in user's machine. And for `require` calls that explicitly use modules outside the app, there will be no limitation, otherwise unexpected behaviors may happen.

Fixes #2626.