### PR TITLE
Translations of some of the Electron docs API in Spanish

### DIFF
--- a/docs-translations/es/README.md
+++ b/docs-translations/es/README.md
@@ -10,15 +10,15 @@
 
 ## Tutoriales
 
-* [Introducción](../../docs/tutorial/quick-start.md)
-* [Integración con el entorno de escritorio](../../docs/tutorial/desktop-environment-integration.md)
-* [Detección del evento en línea/fuera de línea](../../docs/tutorial/online-offline-events.md)
+* [Introducción](tutorial/quick-start.md)
+* [Integración con el entorno de escritorio](tutorial/desktop-environment-integration.md)
+* [Detección del evento en línea/fuera de línea](tutorial/online-offline-events.md)
 
 ## API
 
-* [Sinopsis](../../docs/api/synopsis.md)
-* [Proceso](../../docs/api/process.md)
-* [Parámetros CLI soportados (Chrome)](../../docs/api/chrome-command-line-switches.md)
+* [Sinopsis](api/synopsis.md)
+* [Proceso](api/process.md)
+* [Parámetros CLI soportados (Chrome)](api/chrome-command-line-switches.md)
 
 Elementos DOM customizados:
 

--- a/docs-translations/es/api/chrome-command-line-switches.md
+++ b/docs-translations/es/api/chrome-command-line-switches.md
@@ -1,0 +1,119 @@
+# Parámetros CLI soportados (Chrome)
+
+Esta página lista las líneas de comandos usadas por el navegador Chrome que también son 
+soportadas por Electron. Puedes usar [app.commandLine.appendSwitch][append-switch] para
+anexarlas en el script principal de tu aplicación antes de que el evento [ready][ready] del
+modulo [app][app] sea emitido:
+
+```javascript
+var app = require('app');
+app.commandLine.appendSwitch('remote-debugging-port', '8315');
+app.commandLine.appendSwitch('host-rules', 'MAP * 127.0.0.1');
+
+app.on('ready', function() {
+  // Your code here
+});
+```
+
+## --client-certificate=`path`
+
+Establece el `path` del archivo de certificado del cliente.
+
+## --ignore-connections-limit=`domains`
+
+Ignora el límite de conexiones para la lista de `domains` separados por `,`.
+
+## --disable-http-cache
+
+Deshabilita la cacheé del disco para las peticiones HTTP.
+
+## --remote-debugging-port=`port`
+
+Habilita la depuración remota a través de HTTP en el puerto especificado.
+
+## --proxy-server=`address:port`
+
+Usa un servidor proxy especificado, que sobreescribe la configuración del sistema.
+Este cambio solo afecta peticiones HTTP y HTTPS.
+
+## --proxy-pac-url=`url`
+
+Utiliza el script PAC en la `url` especificada.
+
+## --no-proxy-server
+
+No usa un servidor proxy y siempre establece conexiones directas. Anula cualquier 
+otra bandera de servidor proxy bandera que se pase.
+
+## --host-rules=`rules`
+
+Una lista separada por comas de `rules` (reglas) que controlan cómo se asignan los
+nombres de host.
+
+Por ejemplo:
+
+* `MAP * 127.0.0.1` Obliga a todos los nombres de host a ser asignados a 127.0.0.1
+* `MAP *.google.com proxy` Obliga todos los subdominios google.com a resolverse con
+  "proxy".
+* `MAP test.com [::1]:77` Obliga a  resolver "test.com" con un bucle invertido de IPv6. 
+  También obligará a que el puerto de la dirección respuesta sea 77.
+* `MAP * baz, EXCLUDE www.google.com` Reasigna todo a "baz", excepto a "www.google.com".
+
+Estas asignaciones especifican el host final en una petición de red (Anfitrión de la conexión TCP
+y de resolución de conexión directa, y el `CONNECT` en una conexión proxy HTTP, y el host final de 
+la conexión proxy `SOCKS`).
+
+## --host-resolver-rules=`rules`
+
+Como `--host-rules` pero estas `rules` solo se aplican al solucionador.
+
+[app]: app.md
+[append-switch]: app.md#appcommandlineappendswitchswitch-value
+[ready]: app.md#event-ready
+
+## --ignore-certificate-errors
+
+Ignora errores de certificado relacionados.
+
+## --ppapi-flash-path=`path`
+
+Asigna la ruta `path` del pepper flash plugin.
+
+## --ppapi-flash-version=`version`
+
+Asigna la versión `version` del pepper flash plugin.
+
+## --log-net-log=`path`
+
+Permite guardar y escribir eventos de registros de red en `path`.
+
+## --ssl-version-fallback-min=`version`
+
+Establece la versión mínima de SSL/TLS ("tls1", "tls1.1" o "tls1.2") que 
+el repliegue de TLC aceptará.
+
+## --enable-logging
+
+Imprime el registro de Chromium en consola.
+
+Este cambio no puede ser usado en `app.commandLine.appendSwitch` ya que se analiza antes de que la 
+aplicación del usuario este cargada.
+
+## --v=`log_level`
+
+Da el maximo nivel activo de V-logging por defecto; 0 es el predeterminado. Valores positivos
+son normalmente usados para los niveles de V-logging.
+
+Este modificador sólo funciona cuando también se pasa `--enable-logging`.
+
+## --vmodule=`pattern`
+
+Da los niveles máximos de V-logging por módulo para sobreescribir el valor dado por 
+`--v`. Ej. `my_module=2,foo*=3` cambiaria el nivel de registro para todo el código
+el archivos de origen `my_module.*` y `foo*.*`.
+
+Cualquier patron que contiene un slash o un slash invertido será probado contra toda la ruta
+y no sólo con el módulo. Ej. `*/foo/bar/*=2` cambiaría el nivel de registro para todo el código
+en los archivos origen bajo un directorio `foo/bar`.
+
+Este modificador sólo funciona cuando también se pasa `--enable-logging`.

--- a/docs-translations/es/api/process.md
+++ b/docs-translations/es/api/process.md
@@ -1,0 +1,47 @@
+# process
+
+El objeto `process` en Electron tiene las siguientes diferencias con respecto 
+al node convencional: 
+
+* `process.type` String - El tipo del proceso puede ser `browser` (ej. proceso
+   principal) o `renderer`.
+* `process.versions['electron']` String - Versión de Electron.
+* `process.versions['chrome']` String - Versión de Chromium.
+* `process.resourcesPath` String - Ruta al código fuente JavaScript.
+
+## Events
+
+### Event: 'loaded'
+
+Se emite cuando Electron ha cargado su script de inicialización interna y
+está comenzando a cargar la página web o el script principal.
+
+Puede ser usado por el script precargado para añadir de nuevo los símbolos globales 
+de Node eliminados, al alcance global cuando la integración de Node está apagada:
+
+```js
+// preload.js
+var _setImmediate = setImmediate;
+var _clearImmediate = clearImmediate;
+process.once('loaded', function() {
+  global.setImmediate = _setImmediate;
+  global.clearImmediate = _clearImmediate;
+});
+```
+
+## Methods
+
+El objeto `process` tiene los siguientes métodos:
+
+### `process.hang`
+
+Interrumpe el hilo principal del proceso actual.
+
+
+### process.setFdLimit(maxDescriptors) _OS X_ _Linux_
+
+* `maxDescriptors` Integer
+
+Establece el límite dinámico del descriptor del archivo en `maxDescriptors`
+o en el límite estricto del Sistema Operativo, el que sea menor para el 
+proceso actual.

--- a/docs-translations/es/api/synopsis.md
+++ b/docs-translations/es/api/synopsis.md
@@ -1,0 +1,47 @@
+# Synopsis
+
+Todos los [Módulos integrados de Node.js](http://nodejs.org/api/) se encuentran
+disponibles en Electron y módulos de terceros son támbien totalmente compatibles
+(incluyendo los [módulos nativos](../tutorial/using-native-node-modules.md)).
+
+Electron también provee algunos módulos integrados adicionales para desarrollar 
+aplicaciones nativas de escritorio. Algunos módulos sólo se encuentran disponibles
+en el proceso principal, algunos sólo en el proceso renderer (pagina web), y
+algunos pueden ser usados en ambos procesos.
+
+La regla básica es: Si un módulo es 
+[GUI](https://es.wikipedia.org/wiki/Interfaz_gráfica_de_usuario) o de bajo nivel, 
+entonces solo estará disponible en el proceso principal. Necesitas familiarizarte 
+con el concepto de [scripts para proceso principal vs scripts para proceso renderer]
+(../tutorial/quick-start.md#the-main-process) para ser capaz de usar esos módulos.
+
+El script del proceso principal es como un script normal de Node.js:
+
+```javascript
+var app = require('app');
+var BrowserWindow = require('browser-window');
+
+var window = null;
+
+app.on('ready', function() {
+  window = new BrowserWindow({width: 800, height: 600});
+  window.loadUrl('https://github.com');
+});
+```
+
+El proceso renderer no es diferente de una página web normal, excepto por la 
+capacidad extra de utilizar módulos de node:
+
+```html
+<!DOCTYPE html>
+<html>
+  <body>
+    <script>
+      var remote = require('remote');
+      console.log(remote.require('app').getVersion());
+    </script>
+  </body>
+</html>
+```
+
+Para ejecutar tu aplicación, lee [Ejecutar la aplicación](../tutorial/quick-start.md#run-your-app).


### PR DESCRIPTION
Translations to spanish of this API files:
- synopsis
- process
- chrome-command-line-switches
And update of the readme file in spanish.