### PR TITLE
Minor style update to the global-shortcut documentation

### DIFF
--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -62,4 +62,4 @@ Unregisters the global shortcut of `accelerator`.
 
 ### `globalShortcut.unregisterAll()`
 
-Unregisters all the global shortcuts.
+Unregisters all of the global shortcuts.

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -16,7 +16,7 @@ app.on('ready', function() {
   // Register a 'ctrl+x' shortcut listener.
   var ret = globalShortcut.register('ctrl+x', function() {
     console.log('ctrl+x is pressed');
-  })
+  });
 
   if (!ret) {
     console.log('registration failed');


### PR DESCRIPTION
This pull request contains two tiny adjustments to the `global-shortcut` documentation. Notably, adding a semicolon to a line that didn't have one in an attempt to keep the style consistent.