### PR TITLE
Fix Text to Speech on OS X 10.11

### DIFF
--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -43,11 +43,20 @@
   atom::Browser::Get()->OpenURL(base::SysNSStringToUTF8(url));
 }
 
+- (bool)voiceOverEnabled {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults addSuiteNamed:@"com.apple.universalaccess"];
+  [defaults synchronize];
+
+  return [defaults boolForKey:@"voiceOverOnOffKey"];
+}
+
 - (void)accessibilitySetValue:(id)value forAttribute:(NSString *)attribute {
   // Undocumented attribute that VoiceOver happens to set while running.
   // Chromium uses this too, even though it's not exactly right.
   if ([attribute isEqualToString:@"AXEnhancedUserInterface"]) {
-    [self updateAccessibilityEnabled:[value boolValue]];
+    bool enableAccessibility = ([self voiceOverEnabled] && [value boolValue]);
+    [self updateAccessibilityEnabled:enableAccessibility];
   }
   return [super accessibilitySetValue:value forAttribute:attribute];
 }

--- a/atom/common/platform_util_mac.mm
+++ b/atom/common/platform_util_mac.mm
@@ -20,7 +20,7 @@ void ShowItemInFolder(const base::FilePath& full_path) {
   DCHECK([NSThread isMainThread]);
   NSString* path_string = base::SysUTF8ToNSString(full_path.value());
   if (!path_string || ![[NSWorkspace sharedWorkspace] selectFile:path_string
-                                        inFileViewerRootedAtPath:nil])
+                                        inFileViewerRootedAtPath:@""])
     LOG(WARNING) << "NSWorkspace failed to select file " << full_path.value();
 }
 


### PR DESCRIPTION
On previous versions of OS X, our detection of VoiceOver being enabled and disabled worked correctly, which ensured that the "Speak selected text" functionality of OS X used the "clipboard copy" fallback. In 10.11, that method started showing VoiceOver as active when using this method, even when it's not enabled.

This patch fixes a compile error on OS X, and ensures that we only activate VoiceOver when the system preference is also enabled.

/cc https://github.com/atom/atom/issues/3288