### PR TITLE
Allow "released callback" errors to be traced to remote calls

### DIFF
--- a/atom/browser/lib/rpc-server.coffee
+++ b/atom/browser/lib/rpc-server.coffee
@@ -69,7 +69,9 @@ unwrapArgs = (sender, args) ->
           rendererReleased = true
 
         ret = ->
-          throw new Error('Calling a callback of released renderer view') if rendererReleased
+          if rendererReleased
+            throw new Error("Attempting to call a function in a renderer window
+             that has been closed or released. Function provided here: #{meta.id}.")
           sender.send 'ATOM_RENDERER_CALLBACK', meta.id, valueToMeta(sender, arguments)
         v8Util.setDestructor ret, ->
           return if rendererReleased

--- a/atom/common/api/lib/callbacks-registry.coffee
+++ b/atom/common/api/lib/callbacks-registry.coffee
@@ -11,6 +11,20 @@ class CallbacksRegistry
 
   add: (callback) ->
     id = Math.random().toString()
+
+    # Capture the location of the function and put it in the ID string,
+    # so that release errors can be tracked down easily.
+    regexp = /at (.*)/gi
+    stackString = (new Error).stack
+
+    while (match = regexp.exec(stackString)) isnt null
+      [x, location] = match
+      continue if location.indexOf('(native)') isnt -1
+      continue if location.indexOf('atom.asar') isnt -1
+      [x, filenameAndLine] = /([^/^\)]*)\)?$/gi.exec(location)
+      id = "#{filenameAndLine} (#{id})"
+      break
+
     @callbacks[id] = callback
     id
 


### PR DESCRIPTION
It's very difficult to understand and trace `Calling a callback of released renderer view` errors, which are caused by passing functions to `remote` and then releasing the window.

These changes make it easy to debug and fix these by changing the "ID" used to track the functions. The callbacks-registry uses `(new Error).stack` to identify the file and line number where the function was passed to a remote call, and includes that in the ID.

index.html:
```
      var callback = function() {
        console.log("Run some code!");
      };
      app.on('browser-window-focus', callback); << line 16
```

The new exceptions look like this:

![image](https://cloud.githubusercontent.com/assets/1037212/10531948/19f92302-736d-11e5-84f5-04c502775b9a.png)

