### PR TITLE
replace Mac with OS X

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,7 +66,7 @@
 * [Source Code Directory Structure](development/source-code-directory-structure.md)
 * [Technical Differences to NW.js (formerly node-webkit)](development/atom-shell-vs-node-webkit.md)
 * [Build System Overview](development/build-system-overview.md)
-* [Build Instructions (Mac)](development/build-instructions-osx.md)
+* [Build Instructions (OS X)](development/build-instructions-osx.md)
 * [Build Instructions (Windows)](development/build-instructions-windows.md)
 * [Build Instructions (Linux)](development/build-instructions-linux.md)
 * [Setting Up Symbol Server in debugger](development/setting-up-symbol-server.md)

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -13,7 +13,7 @@ var BrowserWindow = require('browser-window');
 var win = new BrowserWindow({ width: 800, height: 600, frame: false });
 ```
 
-### Alternatives on Mac
+### Alternatives on OS X
 
 On Mac OS X 10.10 Yosemite and newer, there's an alternative way to specify
 a chromeless window. Instead of setting `frame` to `false` which disables


### PR DESCRIPTION
Commit 691d8dd replaced "Mac" with "OS X". This commit replaces some
other occurrences.