### PR TITLE
Optionally allow NTLM authentication for all domains

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -291,7 +291,8 @@ mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(
       .SetMethod("getPath", &App::GetPath)
       .SetMethod("setDesktopName", &App::SetDesktopName)
       .SetMethod("setAppUserModelId", &App::SetAppUserModelId)
-      .SetMethod("allowNTLMCredentialsForAllDomains", &App::AllowNTLMCredentialsForAllDomains)
+      .SetMethod("allowNTLMCredentialsForAllDomains",
+                 &App::AllowNTLMCredentialsForAllDomains)
       .SetMethod("getLocale", &App::GetLocale)
       .SetProperty("defaultSession", &App::DefaultSession);
 }

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -251,6 +251,12 @@ void App::SetAppUserModelId(const std::string& app_id) {
 #endif
 }
 
+void App::AllowNTLMCredentialsForAllDomains(bool should_allow) {
+  auto browser_context = static_cast<AtomBrowserContext*>(
+        AtomBrowserMainParts::Get()->browser_context());
+  browser_context->AllowNTLMCredentialsForAllDomains(should_allow);
+}
+
 std::string App::GetLocale() {
   return l10n_util::GetApplicationLocale("");
 }

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -291,6 +291,7 @@ mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(
       .SetMethod("getPath", &App::GetPath)
       .SetMethod("setDesktopName", &App::SetDesktopName)
       .SetMethod("setAppUserModelId", &App::SetAppUserModelId)
+      .SetMethod("allowNTLMCredentialsForAllDomains", &App::AllowNTLMCredentialsForAllDomains)
       .SetMethod("getLocale", &App::GetLocale)
       .SetProperty("defaultSession", &App::DefaultSession);
 }

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -66,7 +66,7 @@ class App : public mate::EventEmitter,
   void SetDesktopName(const std::string& desktop_name);
   void SetAppUserModelId(const std::string& app_id);
   void AllowNTLMCredentialsForAllDomains(bool should_allow);
-
+  
   std::string GetLocale();
   v8::Local<v8::Value> DefaultSession(v8::Isolate* isolate);
 

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -66,7 +66,7 @@ class App : public mate::EventEmitter,
   void SetDesktopName(const std::string& desktop_name);
   void SetAppUserModelId(const std::string& app_id);
   void AllowNTLMCredentialsForAllDomains(bool should_allow);
-  
+
   std::string GetLocale();
   v8::Local<v8::Value> DefaultSession(v8::Isolate* isolate);
 

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -65,6 +65,8 @@ class App : public mate::EventEmitter,
 
   void SetDesktopName(const std::string& desktop_name);
   void SetAppUserModelId(const std::string& app_id);
+  void AllowNTLMCredentialsForAllDomains(bool should_allow);
+
   std::string GetLocale();
   v8::Local<v8::Value> DefaultSession(v8::Isolate* isolate);
 

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -60,8 +60,8 @@ std::string RemoveWhitespace(const std::string& str) {
 AtomBrowserContext::AtomBrowserContext(const std::string& partition,
                                        bool in_memory)
     : brightray::BrowserContext(partition, in_memory),
-      job_factory_(new AtomURLRequestJobFactory) {
-}
+      job_factory_(new AtomURLRequestJobFactory),
+      allow_ntlm_everywhere_(false) : { }
 
 AtomBrowserContext::~AtomBrowserContext() {
 }
@@ -166,6 +166,12 @@ void AtomBrowserContext::RegisterPrefs(PrefRegistrySimple* pref_registry) {
                                       base::FilePath());
   pref_registry->RegisterFilePathPref(prefs::kDownloadDefaultDirectory,
                                       base::FilePath());
+}
+
+
+bool AtomBrowserContext::AllowNTLMCredentialsForDomain(const GURL& auth_origin) {
+  if (allow_ntlm_everywhere_) return true;
+  return brightray::URLRequestContextGetter::Delegate::AllowNTLMCredentialsForDomain(auth_origin);
 }
 
 }  // namespace atom

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -61,7 +61,7 @@ AtomBrowserContext::AtomBrowserContext(const std::string& partition,
                                        bool in_memory)
     : brightray::BrowserContext(partition, in_memory),
       job_factory_(new AtomURLRequestJobFactory),
-      allow_ntlm_everywhere_(false) { 
+      allow_ntlm_everywhere_(false) {
 }
 
 AtomBrowserContext::~AtomBrowserContext() {
@@ -170,9 +170,11 @@ void AtomBrowserContext::RegisterPrefs(PrefRegistrySimple* pref_registry) {
 }
 
 
-bool AtomBrowserContext::AllowNTLMCredentialsForDomain(const GURL& auth_origin) {
+bool AtomBrowserContext::AllowNTLMCredentialsForDomain
+    (const GURL& auth_origin) {
   if (allow_ntlm_everywhere_) return true;
-  return brightray::URLRequestContextGetter::Delegate::AllowNTLMCredentialsForDomain(auth_origin);
+  return brightray::URLRequestContextGetter
+    ::Delegate::AllowNTLMCredentialsForDomain(auth_origin);
 }
 
 

--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -61,7 +61,8 @@ AtomBrowserContext::AtomBrowserContext(const std::string& partition,
                                        bool in_memory)
     : brightray::BrowserContext(partition, in_memory),
       job_factory_(new AtomURLRequestJobFactory),
-      allow_ntlm_everywhere_(false) : { }
+      allow_ntlm_everywhere_(false) { 
+}
 
 AtomBrowserContext::~AtomBrowserContext() {
 }
@@ -172,6 +173,11 @@ void AtomBrowserContext::RegisterPrefs(PrefRegistrySimple* pref_registry) {
 bool AtomBrowserContext::AllowNTLMCredentialsForDomain(const GURL& auth_origin) {
   if (allow_ntlm_everywhere_) return true;
   return brightray::URLRequestContextGetter::Delegate::AllowNTLMCredentialsForDomain(auth_origin);
+}
+
+
+void AtomBrowserContext::AllowNTLMCredentialsForAllDomains(bool should_allow) {
+  allow_ntlm_everywhere_ = should_allow;
 }
 
 }  // namespace atom

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -28,6 +28,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
   net::HttpCache::BackendFactory* CreateHttpCacheBackendFactory(
       const base::FilePath& base_path) override;
   net::SSLConfigService* CreateSSLConfigService() override;
+  bool AllowNTLMCredentialsForDomain(const GURL& auth_origin) override;
 
   // content::BrowserContext:
   content::DownloadManagerDelegate* GetDownloadManagerDelegate() override;
@@ -44,6 +45,8 @@ class AtomBrowserContext : public brightray::BrowserContext {
 
   // Managed by brightray::BrowserContext.
   AtomURLRequestJobFactory* job_factory_;
+  
+  bool allow_ntlm_everywhere_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomBrowserContext);
 };

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -19,7 +19,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
  public:
   AtomBrowserContext(const std::string& partition, bool in_memory);
   ~AtomBrowserContext() override;
-
+  
   // brightray::URLRequestContextGetter::Delegate:
   std::string GetUserAgent() override;
   net::URLRequestJobFactory* CreateURLRequestJobFactory(
@@ -36,6 +36,8 @@ class AtomBrowserContext : public brightray::BrowserContext {
 
   // brightray::BrowserContext:
   void RegisterPrefs(PrefRegistrySimple* pref_registry) override;
+  
+  void AllowNTLMCredentialsForAllDomains(bool should_allow);
 
   AtomURLRequestJobFactory* job_factory() const { return job_factory_; }
 

--- a/atom/browser/atom_browser_context.h
+++ b/atom/browser/atom_browser_context.h
@@ -19,7 +19,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
  public:
   AtomBrowserContext(const std::string& partition, bool in_memory);
   ~AtomBrowserContext() override;
-  
+
   // brightray::URLRequestContextGetter::Delegate:
   std::string GetUserAgent() override;
   net::URLRequestJobFactory* CreateURLRequestJobFactory(
@@ -36,7 +36,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
 
   // brightray::BrowserContext:
   void RegisterPrefs(PrefRegistrySimple* pref_registry) override;
-  
+
   void AllowNTLMCredentialsForAllDomains(bool should_allow);
 
   AtomURLRequestJobFactory* job_factory() const { return job_factory_; }
@@ -47,7 +47,7 @@ class AtomBrowserContext : public brightray::BrowserContext {
 
   // Managed by brightray::BrowserContext.
   AtomURLRequestJobFactory* job_factory_;
-  
+
   bool allow_ntlm_everywhere_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomBrowserContext);


### PR DESCRIPTION
This PR along with https://github.com/atom/brightray/pull/157, adds a new API to app:

```
app.allowNTLMCredentialsForAllDomains(true | false);
```

We are discovering that many domains are incorrectly configured, so that NTLM will not be implicitly passed to a web server because Windows (via [IInternetSecurityManager::MapUrlToZone](https://msdn.microsoft.com/en-us/library/ms537133(v=vs.85).aspx)) will decide it isn't inside the local domain. This PR allows app developers to say, "Don't care about URLs, always send NTLM if asked". If this method is not called, the preexisting behavior will be used

We actually set up an in-house Domain Controller to test this, it appears to be :gem: