### PR TITLE
Fix: tray NotfiyDropFiles typo

### DIFF
--- a/atom/browser/ui/tray_icon.cc
+++ b/atom/browser/ui/tray_icon.cc
@@ -55,7 +55,7 @@ void TrayIcon::NotifyRightClicked(const gfx::Rect& bounds, int modifiers) {
                     OnRightClicked(bounds, modifiers));
 }
 
-void TrayIcon::NotfiyDropFiles(const std::vector<std::string>& files) {
+void TrayIcon::NotifyDropFiles(const std::vector<std::string>& files) {
   FOR_EACH_OBSERVER(TrayIconObserver, observers_, OnDropFiles(files));
 }
 

--- a/atom/browser/ui/tray_icon.h
+++ b/atom/browser/ui/tray_icon.h
@@ -61,7 +61,7 @@ class TrayIcon {
   void NotifyBalloonClosed();
   void NotifyRightClicked(const gfx::Rect& bounds = gfx::Rect(),
                           int modifiers = 0);
-  void NotfiyDropFiles(const std::vector<std::string>& files);
+  void NotifyDropFiles(const std::vector<std::string>& files);
 
  protected:
   TrayIcon();

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -265,7 +265,7 @@ const CGFloat kVerticalTitleMargin = 2;
     NSArray* files = [pboard propertyListForType:NSFilenamesPboardType];
     for (NSString* file in files)
       dropFiles.push_back(base::SysNSStringToUTF8(file));
-    trayIcon_->NotfiyDropFiles(dropFiles);
+    trayIcon_->NotifyDropFiles(dropFiles);
     return YES;
   }
   return NO;


### PR DESCRIPTION
Tiny fix for a typo in the tray. Changes NotfiyDropFiles into NotifyDropFiles.