### PR TITLE
Fix: honor fs.readFileSync contract for empty packed asar file

### DIFF
--- a/atom/common/lib/asar.coffee
+++ b/atom/common/lib/asar.coffee
@@ -263,7 +263,9 @@ exports.wrapFsWithAsar = (fs) ->
 
     info = archive.getFileInfo filePath
     notFoundError asarPath, filePath unless info
-    return new Buffer(0) if info.size is 0
+
+    if info.size is 0
+      return if options then '' else new Buffer(0)
 
     if info.unpacked
       realPath = archive.copyFileOut filePath


### PR DESCRIPTION
Return `''`(empty) string if encoding provided and `new Buffer(0)` otherwise.