### PR TITLE
Add links to electron-quick-start Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ contains documents describing how to build and contribute to Electron.
 - [Simplified Chinese](https://github.com/atom/electron/tree/master/docs-translations/zh-CN)
 - [Traditional Chinese](https://github.com/atom/electron/tree/master/docs-translations/zh-TW)
 
+## Quick Start
+
+Clone and run the [`atom/electron-quick-start`](https://github.com/atom/electron-quick-start)
+repository to see a minimal Electron app in action.
+
 ## Community
 
 You can ask questions and interact with the community in the following

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -188,3 +188,19 @@ it from [here](https://github.com/atom/electron/releases).
 After you're done writing your app, you can create a distribution by
 following the [Application Distribution](./application-distribution.md) guide
 and then executing the packaged app.
+
+### Try this Example
+
+Clone and run the code in this tutorial by using the [`atom/electron-quick-start`](https://github.com/atom/electron-quick-start)
+repository.
+
+**Note**: Running this requires [Git](https://git-scm.com) and [Node.js](https://nodejs.org/en/download/) (which includes [npm](https://npmjs.org)) on your system.
+
+```bash
+# Clone the repository
+$ git clone https://github.com/atom/electron-quick-start
+# Go into the repository
+$ cd electron-quick-start
+# Install dependencies and run the app
+$ npm install && npm start
+```


### PR DESCRIPTION
I created a repository based on the Quick Start Tutorial, [`electron-quick-start`](https://github.com/atom/electron-quick-start) to save people the step of copying and pasting the code from the tutorial. It makes going from 0 to Electron app :dash: ... hopefully that emoji means fast.

This PR adds links to that in 2 places:

- A brief mention on the Electron main `README`.
- In the Quick Start tutorial itself there is a slightly longer mention that includes the command line instructions.