### PR TITLE
Update Quick Start HTML

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -130,8 +130,9 @@ Finally the `index.html` is the web page you want to show:
   </head>
   <body>
     <h1>Hello World!</h1>
-    We are using Node.js <script>document.write(process.version)</script>
-    and Electron <script>document.write(process.versions['electron'])</script>.
+    We are using node <script>document.write(process.versions.node)</script>,
+    Chrome <script>document.write(process.versions.chrome)</script>,
+    and Electron <script>document.write(process.versions.electron)</script>.
   </body>
 </html>
 ```


### PR DESCRIPTION
This updates the HTML in the Quick Start tutorial to what's now in `electron-quick-start` per https://github.com/atom/electron-quick-start/pull/1

> Minor tweaks to show the Chrome version in `index.html`, `io.js` -> `node`, and also a few formatting tweaks.
