### PR TITLE
Add a few environment variables helpful for debugging

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -71,10 +71,13 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
   // Logging with pid and timestamp.
   logging::SetLogItems(true, false, true, false);
 
-#if defined(DEBUG) && defined(OS_LINUX)
   // Enable convient stack printing.
-  base::debug::EnableInProcessStackDumping();
+  bool enable_stack_dumping = env->HasVar("ELECTRON_ENABLE_STACK_DUMPING");
+#if defined(DEBUG) && defined(OS_LINUX)
+  enable_stack_dumping = true;
 #endif
+  if (enable_stack_dumping)
+    base::debug::EnableInProcessStackDumping();
 
   return brightray::MainDelegate::BasicStartupComplete(exit_code);
 }

--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -59,7 +59,9 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
 #endif  // !defined(OS_WIN)
 
   // Only enable logging when --enable-logging is specified.
-  if (!command_line->HasSwitch(switches::kEnableLogging)) {
+  scoped_ptr<base::Environment> env(base::Environment::Create());
+  if (!command_line->HasSwitch(switches::kEnableLogging) &&
+      !env->HasVar("ELECTRON_ENABLE_LOGGING")) {
     settings.logging_dest = logging::LOG_NONE;
     logging::SetMinLogLevel(logging::LOG_NUM_SEVERITIES);
   }

--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -100,7 +100,9 @@ Specify comma-separated list of SSL cipher suites to disable.
 
 Prints Chromium's logging into console.
 
-This switch can not be used in `app.commandLine.appendSwitch` since it is parsed earlier than user's app is loaded.
+This switch can not be used in `app.commandLine.appendSwitch` since it is parsed
+earlier than user's app is loaded, but you can set the `ELECTRON_ENABLE_LOGGING`
+environment variable to achieve the same effect.
 
 ## --v=`log_level`
 


### PR DESCRIPTION
* `ELECTRON_ENABLE_LOGGING`: same with `--enable-debugging`
* `ELECTRON_ENABLE_STACK_DUMPING`: enable dumping stack trace to console when crashing