### PR TITLE
use webContents.openDevTools for quick start guide

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -107,7 +107,7 @@ app.on('ready', function() {
   mainWindow.loadUrl('file://' + __dirname + '/index.html');
 
   // Open the DevTools.
-  mainWindow.openDevTools();
+  mainWindow.webContents.openDevTools();
 
   // Emitted when the window is closed.
   mainWindow.on('closed', function() {


### PR DESCRIPTION
`mainWindow.openDevTools()` has been deprecated in favor of `mainWindow.webContents.openDevTools()` (see https://github.com/atom/electron/issues/3125#issuecomment-148975593). This change should be reflected in the quick start guide.