### PR TITLE
osx: Implement draggable region with mouseDownCanMoveWindow

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -43,26 +43,6 @@ DEFINE_WEB_CONTENTS_USER_DATA_KEY(atom::NativeWindowRelay);
 
 namespace atom {
 
-namespace {
-
-// Convert draggable regions in raw format to SkRegion format. Caller is
-// responsible for deleting the returned SkRegion instance.
-scoped_ptr<SkRegion> DraggableRegionsToSkRegion(
-    const std::vector<DraggableRegion>& regions) {
-  scoped_ptr<SkRegion> sk_region(new SkRegion);
-  for (const DraggableRegion& region : regions) {
-    sk_region->op(
-        region.bounds.x(),
-        region.bounds.y(),
-        region.bounds.right(),
-        region.bounds.bottom(),
-        region.draggable ? SkRegion::kUnion_Op : SkRegion::kDifference_Op);
-  }
-  return sk_region.Pass();
-}
-
-}  // namespace
-
 NativeWindow::NativeWindow(
     brightray::InspectableWebContents* inspectable_web_contents,
     const mate::Dictionary& options)
@@ -478,6 +458,20 @@ void NativeWindow::NotifyWindowExecuteWindowsCommand(
     const std::string& command) {
   FOR_EACH_OBSERVER(NativeWindowObserver, observers_,
                     OnExecuteWindowsCommand(command));
+}
+
+scoped_ptr<SkRegion> NativeWindow::DraggableRegionsToSkRegion(
+    const std::vector<DraggableRegion>& regions) {
+  scoped_ptr<SkRegion> sk_region(new SkRegion);
+  for (const DraggableRegion& region : regions) {
+    sk_region->op(
+        region.bounds.x(),
+        region.bounds.y(),
+        region.bounds.right(),
+        region.bounds.bottom(),
+        region.draggable ? SkRegion::kUnion_Op : SkRegion::kDifference_Op);
+  }
+  return sk_region.Pass();
 }
 
 void NativeWindow::RenderViewCreated(

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -241,9 +241,18 @@ class NativeWindow : public base::SupportsUserData,
   NativeWindow(brightray::InspectableWebContents* inspectable_web_contents,
                const mate::Dictionary& options);
 
+  // Convert draggable regions in raw format to SkRegion format. Caller is
+  // responsible for deleting the returned SkRegion instance.
+  scoped_ptr<SkRegion> DraggableRegionsToSkRegion(
+      const std::vector<DraggableRegion>& regions);
+
   // Converts between content size to window size.
   virtual gfx::Size ContentSizeToWindowSize(const gfx::Size& size) = 0;
   virtual gfx::Size WindowSizeToContentSize(const gfx::Size& size) = 0;
+
+  // Called when the window needs to update its draggable region.
+  virtual void UpdateDraggableRegions(
+      const std::vector<DraggableRegion>& regions);
 
   // content::WebContentsObserver:
   void RenderViewCreated(content::RenderViewHost* render_view_host) override;
@@ -252,10 +261,6 @@ class NativeWindow : public base::SupportsUserData,
   bool OnMessageReceived(const IPC::Message& message) override;
 
  private:
-  // Called when the window needs to update its draggable region.
-  void UpdateDraggableRegions(
-      const std::vector<DraggableRegion>& regions);
-
   // Schedule a notification unresponsive event.
   void ScheduleUnresponsiveEvent(int ms);
 

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -71,12 +71,10 @@ class NativeWindowMac : public NativeWindow {
   void SetVisibleOnAllWorkspaces(bool visible) override;
   bool IsVisibleOnAllWorkspaces() override;
 
-  // Returns true if |point| in local Cocoa coordinate system falls within
-  // the draggable region.
-  bool IsWithinDraggableRegion(NSPoint point) const;
-
-  // Called to handle a mouse event.
-  void HandleMouseEvent(NSEvent* event);
+  // Refresh the DraggableRegion views.
+  void UpdateDraggableRegionViews() {
+    UpdateDraggableRegionViews(draggable_regions_);
+  }
 
  protected:
   // NativeWindow:
@@ -84,17 +82,24 @@ class NativeWindowMac : public NativeWindow {
       content::WebContents*,
       const content::NativeWebKeyboardEvent&) override;
 
+  // Return a vector of non-draggable regions that fill a window of size
+  // |width| by |height|, but leave gaps where the window should be draggable.
+  std::vector<gfx::Rect> CalculateNonDraggableRegions(
+      const std::vector<DraggableRegion>& regions, int width, int height);
+
  private:
   // NativeWindow:
   gfx::Size ContentSizeToWindowSize(const gfx::Size& size) override;
   gfx::Size WindowSizeToContentSize(const gfx::Size& size) override;
+  void UpdateDraggableRegions(
+      const std::vector<DraggableRegion>& regions) override;
 
   void InstallView();
   void UninstallView();
 
   // Install the drag view, which will cover the whole window and decides
   // whehter we can drag.
-  void InstallDraggableRegionView();
+  void UpdateDraggableRegionViews(const std::vector<DraggableRegion>& regions);
 
   base::scoped_nsobject<AtomNSWindow> window_;
   base::scoped_nsobject<AtomNSWindowDelegate> window_delegate_;
@@ -102,16 +107,14 @@ class NativeWindowMac : public NativeWindow {
   // The view that will fill the whole frameless window.
   base::scoped_nsobject<FullSizeContentView> content_view_;
 
+  std::vector<DraggableRegion> draggable_regions_;
+
   bool is_kiosk_;
 
   NSInteger attention_request_id_;  // identifier from requestUserAttention
 
   // The presentation options before entering kiosk mode.
   NSApplicationPresentationOptions kiosk_options_;
-
-  // Mouse location since the last mouse event, in screen coordinates. This is
-  // used in custom drag to compute the window movement.
-  NSPoint last_mouse_offset_;
 
   DISALLOW_COPY_AND_ASSIGN(NativeWindowMac);
 };


### PR DESCRIPTION
Previously we implemented draggable region by tracking mouse position, it is buggy and causing some problems. But it is also interesting that this didn't cause troubles until recently.

Fixes #3160.