### PR TITLE
debugger: expose v8debug

### DIFF
--- a/atom/browser/javascript_environment.cc
+++ b/atom/browser/javascript_environment.cc
@@ -4,6 +4,7 @@
 
 #include "atom/browser/javascript_environment.h"
 
+#include "base/command_line.h"
 #include "gin/array_buffer.h"
 #include "gin/v8_initializer.h"
 
@@ -20,6 +21,12 @@ JavascriptEnvironment::JavascriptEnvironment()
 }
 
 bool JavascriptEnvironment::Initialize() {
+  auto cmd = base::CommandLine::ForCurrentProcess();
+  if (cmd->HasSwitch("debug-brk")) {
+    // Need to be called before v8::Initialize().
+    const char expose_debug_as[] = "--expose_debug_as=v8debug";
+    v8::V8::SetFlagsFromString(expose_debug_as, sizeof(expose_debug_as) - 1);
+  }
   gin::IsolateHolder::Initialize(gin::IsolateHolder::kNonStrictMode,
                                  gin::ArrayBufferAllocator::SharedInstance());
   return true;

--- a/atom/browser/node_debugger.cc
+++ b/atom/browser/node_debugger.cc
@@ -35,17 +35,14 @@ NodeDebugger::NodeDebugger(v8::Isolate* isolate)
       weak_factory_(this) {
   bool use_debug_agent = false;
   int port = 5858;
-  bool wait_for_connection = false;
 
   std::string port_str;
   base::CommandLine* cmd = base::CommandLine::ForCurrentProcess();
   if (cmd->HasSwitch("debug")) {
     use_debug_agent = true;
     port_str = cmd->GetSwitchValueASCII("debug");
-  }
-  if (cmd->HasSwitch("debug-brk")) {
+  } else if (cmd->HasSwitch("debug-brk")) {
     use_debug_agent = true;
-    wait_for_connection = true;
     port_str = cmd->GetSwitchValueASCII("debug-brk");
   }
 
@@ -55,9 +52,6 @@ NodeDebugger::NodeDebugger(v8::Isolate* isolate)
 
     isolate_->SetData(kIsolateSlot, this);
     v8::Debug::SetMessageHandler(DebugMessageHandler);
-
-    if (wait_for_connection)
-      v8::Debug::DebugBreak(isolate_);
 
     uv_async_init(uv_default_loop(), &weak_up_ui_handle_, ProcessMessageInUI);
 


### PR DESCRIPTION
Fixes #2741 

this lets node to handle `--debug-brk` and will now break at `browser/init.js` . There is a caveat `node-inspector` will error out with
```
Page.getResourceContent failed.
Error: ENOTDIR: not a directory, open '<path>/out/D/resources/atom.asar/browser/lib/init.js'
```

thats because `fs` module in node-inspector will not recognize asar archive, this can be easily workaround by running node-inspector with electron as node runtime.

```shell
export ATOM_SHELL_INTERNAL_RUN_AS_NODE=1
<path>/electron <path>/bin/node-inspector
```