### PR TITLE
Update web-contents.md

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -36,6 +36,7 @@ Returns:
 
 This event is like `did-finish-load` but emitted when the load failed or was
 cancelled, e.g. `window.stop()` is invoked.
+The full list of error codes and their meaning is available [here](https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h).
 
 ### Event: 'did-frame-finish-load'
 


### PR DESCRIPTION
The `did-fail-load` event returns an error code and error description. The error description is at least sometimes empty (e.g. when the error code is -102 on Windows), so you're left with an error code without knowing what happened. So I add a link to Chromium's net_error_list.h.