### PR TITLE
Fix calling showItemInFolder in renderer

### DIFF
--- a/atom/common/api/lib/shell.coffee
+++ b/atom/common/api/lib/shell.coffee
@@ -1,4 +1,5 @@
 module.exports = process.atomBinding 'shell'
 
 if process.platform is 'win32' and process.type is 'renderer'
-  module.exports.showItemInFolder = require('remote').process.atomBinding('shell').showItemInFolder
+  module.exports.showItemInFolder = (item) ->
+    require('remote').require('shell').showItemInFolder item


### PR DESCRIPTION
The remote method always assumes the existence of the remote object but doesn't keep a reference to it, so if we only keep the reference of a remote method we will get into troubles once the remote object is
garbage collected.

We should probably fix this in remote module, but since most things are already working quite good, I'm using the work-around for now.

Fix #3139.