### PR TITLE
Add toggleMenuBarOnAltPressed option to BrowserWindow.

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -492,6 +492,14 @@ bool Window::IsMenuBarVisible() {
   return window_->IsMenuBarVisible();
 }
 
+void Window::SetToggleMenuBarOnAltPressed(bool toggle_on_alt_pressed) {
+  window_->SetToggleMenuBarOnAltPressed(toggle_on_alt_pressed);
+}
+
+bool Window::DoesToggleMenuBarOnAltPressed() {
+  return window_->DoesToggleMenuBarOnAltPressed();
+}
+
 #if defined(OS_MACOSX)
 void Window::ShowDefinitionForSelection() {
   window_->ShowDefinitionForSelection();
@@ -586,6 +594,10 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isMenuBarAutoHide", &Window::IsMenuBarAutoHide)
       .SetMethod("setMenuBarVisibility", &Window::SetMenuBarVisibility)
       .SetMethod("isMenuBarVisible", &Window::IsMenuBarVisible)
+      .SetMethod("setToggleMenuBarOnAltPressed",
+                 &Window::SetToggleMenuBarOnAltPressed)
+      .SetMethod("doesToggleMenuBarOnAltPressed",
+                 &Window::DoesToggleMenuBarOnAltPressed)
       .SetMethod("setVisibleOnAllWorkspaces",
                  &Window::SetVisibleOnAllWorkspaces)
       .SetMethod("isVisibleOnAllWorkspaces",

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -141,6 +141,8 @@ class Window : public mate::TrackableObject<Window>,
   bool IsMenuBarAutoHide();
   void SetMenuBarVisibility(bool visible);
   bool IsMenuBarVisible();
+  void SetToggleMenuBarOnAltPressed(bool toggle_on_alt_pressed);
+  bool DoesToggleMenuBarOnAltPressed();
   void SetAspectRatio(double aspect_ratio, mate::Arguments* args);
 
 #if defined(OS_MACOSX)

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -320,6 +320,13 @@ bool NativeWindow::IsMenuBarVisible() {
   return true;
 }
 
+void NativeWindow::SetToggleMenuBarOnAltPressed(bool toggle_on_alt_pressed) {
+}
+
+bool NativeWindow::DoesToggleMenuBarOnAltPressed() {
+  return false;
+}
+
 double NativeWindow::GetAspectRatio() {
   return aspect_ratio_;
 }

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -171,6 +171,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsMenuBarAutoHide();
   virtual void SetMenuBarVisibility(bool visible);
   virtual bool IsMenuBarVisible();
+  virtual void SetToggleMenuBarOnAltPressed(bool toggle_on_alt_pressed);
+  virtual bool DoesToggleMenuBarOnAltPressed();
 
   // Set the aspect ratio when resizing window.
   double GetAspectRatio();

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -129,11 +129,14 @@ NativeWindowViews::NativeWindowViews(
       menu_bar_autohide_(false),
       menu_bar_visible_(false),
       menu_bar_alt_pressed_(false),
+      toggle_menu_bar_on_alt_pressed_(true),
       keyboard_event_handler_(new views::UnhandledKeyboardEventHandler),
       use_content_size_(false),
       resizable_(true) {
   options.Get(switches::kTitle, &title_);
   options.Get(switches::kAutoHideMenuBar, &menu_bar_autohide_);
+  options.Get(switches::kToggleMenuBarOnAltPressed,
+              &toggle_menu_bar_on_alt_pressed_);
 
 #if defined(OS_WIN)
   // On Windows we rely on the CanResize() to indicate whether window can be
@@ -651,6 +654,15 @@ bool NativeWindowViews::IsMenuBarVisible() {
   return menu_bar_visible_;
 }
 
+void NativeWindowViews::SetToggleMenuBarOnAltPressed(
+  bool toggle_on_alt_pressed) {
+  toggle_menu_bar_on_alt_pressed_ = toggle_on_alt_pressed;
+}
+
+bool NativeWindowViews::DoesToggleMenuBarOnAltPressed() {
+  return toggle_menu_bar_on_alt_pressed_;
+}
+
 void NativeWindowViews::SetVisibleOnAllWorkspaces(bool visible) {
   window_->SetVisibleOnAllWorkspaces(visible);
 }
@@ -868,7 +880,9 @@ void NativeWindowViews::HandleKeyboardEvent(
              menu_bar_alt_pressed_) {
     // When a single Alt is released right after a Alt is pressed:
     menu_bar_alt_pressed_ = false;
-    SetMenuBarVisibility(!menu_bar_visible_);
+    if (toggle_menu_bar_on_alt_pressed_) {
+      SetMenuBarVisibility(!menu_bar_visible_);
+    }
   } else {
     // When any other keys except single Alt have been pressed/released:
     menu_bar_alt_pressed_ = false;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -87,6 +87,8 @@ class NativeWindowViews : public NativeWindow,
   bool IsMenuBarAutoHide() override;
   void SetMenuBarVisibility(bool visible) override;
   bool IsMenuBarVisible() override;
+  void SetToggleMenuBarOnAltPressed(bool toggle_on_alt_pressed) override;
+  bool DoesToggleMenuBarOnAltPressed() override;
   void SetVisibleOnAllWorkspaces(bool visible) override;
   bool IsVisibleOnAllWorkspaces() override;
 
@@ -162,6 +164,7 @@ class NativeWindowViews : public NativeWindow,
   bool menu_bar_autohide_;
   bool menu_bar_visible_;
   bool menu_bar_alt_pressed_;
+  bool toggle_menu_bar_on_alt_pressed_;
 
 #if defined(USE_X11)
   scoped_ptr<GlobalMenuBarX11> global_menu_bar_;

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -54,6 +54,9 @@ const char kZoomFactor[] = "zoom-factor";
 // The menu bar is hidden unless "Alt" is pressed.
 const char kAutoHideMenuBar[] = "auto-hide-menu-bar";
 
+// Toggle the menu bar visiblity when "Alt" is pressed
+const char kToggleMenuBarOnAltPressed[] = "toggle-menu-bar-on-alt-pressed";
+
 // Enable window to be resized larger than screen.
 const char kEnableLargerThanScreen[] = "enable-larger-than-screen";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -34,6 +34,7 @@ extern const char kTitleBarStyle[];
 extern const char kWebPreferences[];
 extern const char kZoomFactor[];
 extern const char kAutoHideMenuBar[];
+extern const char kToggleMenuBarOnAltPressed[];
 extern const char kEnableLargerThanScreen[];
 extern const char kDarkTheme[];
 extern const char kDirectWrite[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -59,6 +59,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
 * `disable-auto-hide-cursor` Boolean - Whether to hide cursor when typing.
 * `auto-hide-menu-bar` Boolean - Auto hide the menu bar unless the `Alt`
   key is pressed.
+* `toggle-menu-bar-on-alt-pressed` Boolean - Avoid showing the menu bar when
+   the `Alt` key is pressed.
 * `enable-larger-than-screen` Boolean - Enable the window to be resized larger
   than screen.
 * `background-color` String - Window's background color as Hexadecimal value,
@@ -701,6 +703,16 @@ can still bring up the menu bar by pressing the single `Alt` key.
 ### `win.isMenuBarVisible()`
 
 Returns whether the menu bar is visible.
+
+### `win.setToggleMenuBarOnAltPressed(toggle_on_alt_pressed)`
+
+* `toggle_on_alt_pressed` Boolean
+
+Sets whether the menu bar visibility should toggle when `Alt` key is pressed.
+
+### `win.doesToggleMenuBarOnAltPressed()`
+
+Returns whether the menu bar is toggle when `Alt` key is pressed.
 
 ### `win.setVisibleOnAllWorkspaces(visible)`
 

--- a/spec/api-browser-window-spec.coffee
+++ b/spec/api-browser-window-spec.coffee
@@ -130,6 +130,15 @@ describe 'browser-window module', ->
     it 'returns the window with id', ->
       assert.equal w.id, BrowserWindow.fromId(w.id).id
 
+  describe 'BrowserWindow.setToggleMenuBarOnAltPressed(toggle)', ->
+    return if process.platform is 'darwin'
+    it 'should change the value of toggleOnAltPressed', ->
+      w.destroy()
+      w = new BrowserWindow(show: true, frame: false)
+      assert(w.doesToggleMenuBarOnAltPressed())
+      w.setToggleMenuBarOnAltPressed(false)
+      assert.equal(false, w.doesToggleMenuBarOnAltPressed())
+
   describe 'BrowserWindow.setResizable(resizable)', ->
     it 'does not change window size for frameless window', ->
       w.destroy()


### PR DESCRIPTION
Hi,

I recently started using Atom and had some issues with the `Alt` key
toggling menu bar, so I added an option to disable this behavior.

The option can be passed when instanciating a `BrowserWindow`,
or be changed using the `setToggleMenuBarOnAltPressed`method
on a `BrowserWindow` instance.
I also added a `doesToggleMenuBarOnAltPressed` method
to retrieve the current value of the option.
The option is disabled by default, so this will not break or change the behavior of
existing apps.


### Background

In some apps, such as Atom, the menu bar can be restored in other ways,
and as it is not something that is done so often (at least for my usage),
I think this option makes sense.

I will explain my issue in Atom, which is my actual motivation for this option.
I use [XMonad](http://xmonad.org/), and my shortcut to change window focus is `alt+j`.
When I press `alt`, [`menu_bar_alt_pressed` becomes true](https://github.com/atom/electron/blob/master/atom/browser/native_window_views.cc#L864).
Then, when I press `j`, the keydown event is intercepted by XMonad,
and the focus changes to some other app, let's say my browser.
As Atom did not receive the `j` keydown event, `menu_bar_alt_pressed` is still true.
When I then want to go back go Atom, I press `alt+j` again. I usually release the
`j` button instantly, and the `alt` after, so the `j` keyup is not handled by atom, but
the `alt` keyup event is, which makes [the condition for toggling the menu bar](https://github.com/atom/electron/blob/master/atom/browser/native_window_views.cc#L867) true.
So basically each time I change focus to some other app and go back to Atom,
the menu bar is toggled, which is a little annoying.
