### PR TITLE
Add extra headers option to webContents.loadUrl

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -618,6 +618,10 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
   if (options.Get("userAgent", &user_agent))
     SetUserAgent(user_agent);
 
+  std::string extra_headers;
+  if (options.Get("extraHeaders", &extra_headers))
+    params.extra_headers = extra_headers;
+
   params.transition_type = ui::PAGE_TRANSITION_TYPED;
   params.should_clear_history_list = true;
   params.override_user_agent = content::NavigationController::UA_OVERRIDE_TRUE;

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -183,6 +183,7 @@ See [session documentation](session.md) for this object's methods.
 * `options` Object (optional), properties:
   * `httpReferrer` String - A HTTP Referrer url.
   * `userAgent` String - A user agent originating the request.
+  * `extraHeaders` String - Extra headers separated by "\n"
 
 Loads the `url` in the window, the `url` must contain the protocol prefix,
 e.g. the `http://` or `file://`.


### PR DESCRIPTION
webContents.loadUrl options to specifiy/override HTTP headers.

```javascript
webContents.loadUrl('https://www.example.com', {
  extraHeaders: 'Accept-Encoding: gzip;q=0,deflate;q=0'
});
```