### PR TITLE
Win: Remove adding default file filter(*.*) in a save dialog.

### DIFF
--- a/atom/browser/ui/file_dialog_win.cc
+++ b/atom/browser/ui/file_dialog_win.cc
@@ -34,12 +34,6 @@ bool IsDirectory(const base::FilePath& path) {
 void ConvertFilters(const Filters& filters,
                     std::vector<std::wstring>* buffer,
                     std::vector<COMDLG_FILTERSPEC>* filterspec) {
-  if (filters.empty()) {
-    COMDLG_FILTERSPEC spec = { L"All Files (*.*)", L"*.*" };
-    filterspec->push_back(spec);
-    return;
-  }
-
   buffer->reserve(filters.size() * 2);
   for (size_t i = 0; i < filters.size(); ++i) {
     const Filter& filter = filters[i];


### PR DESCRIPTION
Fixes #3216.

But since the save dialog and open dialog share the same code, the PR also affects the behavior of open dialog. The file extension component(see below) in open dialog will not show any more if no `filter` is set.

![image](https://cloud.githubusercontent.com/assets/2557445/10750208/a076526c-7cad-11e5-880b-2b171d491e14.png)
 