### PR TITLE
Fix documentation for module types available in the renderer process

### DIFF
--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -3,7 +3,7 @@
 The `remote` module provides a simple way to do inter-process communication
 (IPC) between the renderer process (web page) and the main process.
 
-In Electron, GUI-related modules (such as `dialog`, `menu` etc.) are only available in the main process, not in the renderer process. In order to use them from the render process, the ipc module is necessary to send inter-process messages to the main process. With the `remote` module, you can invoke methods of the main process object without explicitly sending inter-process messages, similar to Java's [RMI](http://en.wikipedia.org/wiki/Java_remote_method_invocation).
+In Electron, GUI-related modules (such as `dialog`, `menu` etc.) are only available in the main process, not in the renderer process. In order to use them from the renderer process, the `ipc` module is necessary to send inter-process messages to the main process. With the `remote` module, you can invoke methods of the main process object without explicitly sending inter-process messages, similar to Java's [RMI](http://en.wikipedia.org/wiki/Java_remote_method_invocation).
 
 An example of creating a browser window from a renderer process:
 

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -3,12 +3,7 @@
 The `remote` module provides a simple way to do inter-process communication
 (IPC) between the renderer process (web page) and the main process.
 
-In Electron, only GUI-related modules are available in the renderer process.
-Without the `remote` module, users who want to call a main process API in
-the renderer process will have to explicitly send inter-process messages
-to the main process. With the `remote` module, you can invoke methods of the
-main process object without explicitly sending inter-process messages, similar
-to Java's [RMI](http://en.wikipedia.org/wiki/Java_remote_method_invocation).
+In Electron, GUI-related modules (such as `dialog`, `menu` etc.) are only available in the main process, not in the renderer process. In order to use them from the render process, the ipc module is necessary to send inter-process messages to the main process. With the `remote` module, you can invoke methods of the main process object without explicitly sending inter-process messages, similar to Java's [RMI](http://en.wikipedia.org/wiki/Java_remote_method_invocation).
 
 An example of creating a browser window from a renderer process:
 

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -3,7 +3,7 @@
 The `remote` module provides a simple way to do inter-process communication
 (IPC) between the renderer process (web page) and the main process.
 
-In Electron, only GUI-unrelated modules are available in the renderer process.
+In Electron, only GUI-related modules are available in the renderer process.
 Without the `remote` module, users who want to call a main process API in
 the renderer process will have to explicitly send inter-process messages
 to the main process. With the `remote` module, you can invoke methods of the


### PR DESCRIPTION
The doc previously stated `only GUI-unrelated` modules are available to the renderer process. I think it should be `only GUI-related`