### PR TITLE
Add support for basic auth

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -19,6 +19,7 @@
 #include "atom/browser/browser.h"
 #include "atom/browser/login_handler.h"
 #include "atom/common/native_mate_converters/callback.h"
+#include "atom/common/native_mate_converters/content_converter.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/node_includes.h"
 #include "atom/common/options_switches.h"
@@ -241,9 +242,9 @@ void App::OnSelectCertificate(
 }
 
 void App::OnLogin(LoginHandler* login_handler) {
-  bool prevent_default =
-      Emit("login", base::Bind(&PassLoginInformation,
-                               make_scoped_refptr(login_handler)));
+  bool prevent_default = Emit(
+      "login", login_handler->request(), login_handler->auth_info(),
+      base::Bind(&PassLoginInformation, make_scoped_refptr(login_handler)));
 
   // Default behavior is to alwasy cancel the auth.
   if (!prevent_default)

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -244,6 +244,7 @@ void App::OnSelectCertificate(
 void App::OnLogin(LoginHandler* login_handler) {
   bool prevent_default = Emit(
       "login", login_handler->request(), login_handler->auth_info(),
+      api::WebContents::CreateFrom(isolate(), login_handler->GetWebContents()),
       base::Bind(&PassLoginInformation, make_scoped_refptr(login_handler)));
 
   // Default behavior is to alwasy cancel the auth.

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -50,6 +50,7 @@ class App : public mate::EventEmitter,
       content::WebContents* web_contents,
       net::SSLCertRequestInfo* cert_request_info,
       scoped_ptr<content::ClientCertificateDelegate> delegate) override;
+  void OnLogin(LoginHandler* login_handler) override;
 
   // content::GpuDataManagerObserver:
   void OnGpuProcessCrashed(base::TerminationStatus exit_code) override;

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -12,26 +12,11 @@
 #include "atom/browser/net/url_request_fetch_job.h"
 #include "atom/browser/net/url_request_string_job.h"
 #include "atom/common/native_mate_converters/callback.h"
+#include "atom/common/native_mate_converters/content_converter.h"
 #include "atom/common/node_includes.h"
 #include "native_mate/dictionary.h"
 
 using content::BrowserThread;
-
-namespace mate {
-
-template<>
-struct Converter<const net::URLRequest*> {
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   const net::URLRequest* val) {
-    return mate::ObjectTemplateBuilder(isolate)
-        .SetValue("method", val->method())
-        .SetValue("url", val->url().spec())
-        .SetValue("referrer", val->referrer())
-        .Build()->NewInstance();
-  }
-};
-
-}  // namespace mate
 
 namespace atom {
 

--- a/atom/browser/atom_resource_dispatcher_host_delegate.cc
+++ b/atom/browser/atom_resource_dispatcher_host_delegate.cc
@@ -4,6 +4,7 @@
 
 #include "atom/browser/atom_resource_dispatcher_host_delegate.h"
 
+#include "atom/browser/login_handler.h"
 #include "atom/common/platform_util.h"
 #include "content/public/browser/browser_thread.h"
 #include "net/base/escape.h"
@@ -27,6 +28,13 @@ bool AtomResourceDispatcherHostDelegate::HandleExternalProtocol(
   BrowserThread::PostTask(BrowserThread::UI, FROM_HERE,
       base::Bind(base::IgnoreResult(platform_util::OpenExternal), escaped_url));
   return true;
+}
+
+content::ResourceDispatcherHostLoginDelegate*
+AtomResourceDispatcherHostDelegate::CreateLoginDelegate(
+    net::AuthChallengeInfo* auth_info,
+    net::URLRequest* request) {
+  return new LoginHandler(auth_info, request);
 }
 
 }  // namespace atom

--- a/atom/browser/atom_resource_dispatcher_host_delegate.h
+++ b/atom/browser/atom_resource_dispatcher_host_delegate.h
@@ -21,6 +21,9 @@ class AtomResourceDispatcherHostDelegate
                               bool is_main_frame,
                               ui::PageTransition transition,
                               bool has_user_gesture) override;
+  content::ResourceDispatcherHostLoginDelegate* CreateLoginDelegate(
+      net::AuthChallengeInfo* auth_info,
+      net::URLRequest* request) override;
 };
 
 }  // namespace atom

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -134,6 +134,10 @@ void Browser::ClientCertificateSelector(
                                         delegate.Pass()));
 }
 
+void Browser::RequestLogin(LoginHandler* login_handler) {
+  FOR_EACH_OBSERVER(BrowserObserver, observers_, OnLogin(login_handler));
+}
+
 void Browser::NotifyAndShutdown() {
   if (is_shutdown_)
     return;

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -29,6 +29,8 @@ class MenuModel;
 
 namespace atom {
 
+class LoginHandler;
+
 // This class is used for control application-wide operations.
 class Browser : public WindowListObserver {
  public:
@@ -121,6 +123,9 @@ class Browser : public WindowListObserver {
       content::WebContents* web_contents,
       net::SSLCertRequestInfo* cert_request_info,
       scoped_ptr<content::ClientCertificateDelegate> delegate);
+
+  // Request basic auth login.
+  void RequestLogin(LoginHandler* login_handler);
 
   void AddObserver(BrowserObserver* obs) {
     observers_.AddObserver(obs);

--- a/atom/browser/browser_observer.h
+++ b/atom/browser/browser_observer.h
@@ -20,6 +20,8 @@ class SSLCertRequestInfo;
 
 namespace atom {
 
+class LoginHandler;
+
 class BrowserObserver {
  public:
   // The browser is about to close all windows.
@@ -56,6 +58,9 @@ class BrowserObserver {
       content::WebContents* web_contents,
       net::SSLCertRequestInfo* cert_request_info,
       scoped_ptr<content::ClientCertificateDelegate> delegate) {}
+
+  // The browser requests HTTP login.
+  virtual void OnLogin(LoginHandler* login_handler) {}
 
  protected:
   virtual ~BrowserObserver() {}

--- a/atom/browser/login_handler.cc
+++ b/atom/browser/login_handler.cc
@@ -4,19 +4,76 @@
 
 #include "atom/browser/login_handler.h"
 
+#include "atom/browser/browser.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/resource_dispatcher_host.h"
 #include "net/base/auth.h"
+#include "net/url_request/url_request.h"
+
+using content::BrowserThread;
 
 namespace atom {
 
+namespace {
+
+// Helper to remove the ref from an net::URLRequest to the LoginHandler.
+// Should only be called from the IO thread, since it accesses an
+// net::URLRequest.
+void ResetLoginHandlerForRequest(net::URLRequest* request) {
+  content::ResourceDispatcherHost::Get()->ClearLoginDelegateForRequest(request);
+}
+
+}  // namespace
+
 LoginHandler::LoginHandler(net::AuthChallengeInfo* auth_info,
                            net::URLRequest* request)
-    : auth_info_(auth_info), request_(request), weak_factory_(this) {
+    : auth_info_(auth_info), request_(request) {
+  BrowserThread::PostTask(BrowserThread::UI, FROM_HERE,
+                          base::Bind(&Browser::RequestLogin,
+                                     base::Unretained(Browser::Get()),
+                                     make_scoped_refptr(this)));
 }
 
 LoginHandler::~LoginHandler() {
 }
 
+void LoginHandler::Login(const base::string16& username,
+                         const base::string16& password) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  BrowserThread::PostTask(
+      BrowserThread::IO, FROM_HERE,
+      base::Bind(&LoginHandler::DoLogin, this, username, password));
+}
+
+void LoginHandler::CancelAuth() {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  BrowserThread::PostTask(BrowserThread::IO, FROM_HERE,
+                          base::Bind(&LoginHandler::DoCancelAuth, this));
+}
+
 void LoginHandler::OnRequestCancelled() {
+  request_ = nullptr;
+}
+
+void LoginHandler::DoCancelAuth() {
+  DCHECK_CURRENTLY_ON(BrowserThread::IO);
+
+  if (request_) {
+    request_->CancelAuth();
+    // Verify that CancelAuth doesn't destroy the request via our delegate.
+    DCHECK(request_ != nullptr);
+    ResetLoginHandlerForRequest(request_);
+  }
+}
+
+void LoginHandler::DoLogin(const base::string16& username,
+                           const base::string16& password) {
+  DCHECK_CURRENTLY_ON(BrowserThread::IO);
+
+  if (request_) {
+    request_->SetAuth(net::AuthCredentials(username, password));
+    ResetLoginHandlerForRequest(request_);
+  }
 }
 
 }  // namespace atom

--- a/atom/browser/login_handler.cc
+++ b/atom/browser/login_handler.cc
@@ -1,0 +1,22 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/login_handler.h"
+
+#include "net/base/auth.h"
+
+namespace atom {
+
+LoginHandler::LoginHandler(net::AuthChallengeInfo* auth_info,
+                           net::URLRequest* request)
+    : auth_info_(auth_info), request_(request), weak_factory_(this) {
+}
+
+LoginHandler::~LoginHandler() {
+}
+
+void LoginHandler::OnRequestCancelled() {
+}
+
+}  // namespace atom

--- a/atom/browser/login_handler.h
+++ b/atom/browser/login_handler.h
@@ -26,6 +26,9 @@ class LoginHandler : public content::ResourceDispatcherHostLoginDelegate {
   // Login with |username| and |password|, must be called on UI thread.
   void Login(const base::string16& username, const base::string16& password);
 
+  const net::AuthChallengeInfo* auth_info() const { return auth_info_.get(); }
+  const net::URLRequest* request() const { return request_; }
+
  protected:
   ~LoginHandler() override;
 

--- a/atom/browser/login_handler.h
+++ b/atom/browser/login_handler.h
@@ -5,7 +5,7 @@
 #ifndef ATOM_BROWSER_LOGIN_HANDLER_H_
 #define ATOM_BROWSER_LOGIN_HANDLER_H_
 
-#include "base/memory/weak_ptr.h"
+#include "base/strings/string16.h"
 #include "content/public/browser/resource_dispatcher_host_login_delegate.h"
 
 namespace net {
@@ -15,9 +15,16 @@ class URLRequest;
 
 namespace atom {
 
+// Handles the HTTP basic auth, must be created on IO thread.
 class LoginHandler : public content::ResourceDispatcherHostLoginDelegate {
  public:
   LoginHandler(net::AuthChallengeInfo* auth_info, net::URLRequest* request);
+
+  // The auth is cancelled, must be called on UI thread.
+  void CancelAuth();
+
+  // Login with |username| and |password|, must be called on UI thread.
+  void Login(const base::string16& username, const base::string16& password);
 
  protected:
   ~LoginHandler() override;
@@ -26,14 +33,16 @@ class LoginHandler : public content::ResourceDispatcherHostLoginDelegate {
   void OnRequestCancelled() override;
 
  private:
+  // Must be called on IO thread.
+  void DoCancelAuth();
+  void DoLogin(const base::string16& username, const base::string16& password);
+
   // Who/where/what asked for the authentication.
   scoped_refptr<net::AuthChallengeInfo> auth_info_;
 
   // The request that wants login data.
   // This should only be accessed on the IO loop.
   net::URLRequest* request_;
-
-  base::WeakPtrFactory<LoginHandler> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(LoginHandler);
 };

--- a/atom/browser/login_handler.h
+++ b/atom/browser/login_handler.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_LOGIN_HANDLER_H_
+#define ATOM_BROWSER_LOGIN_HANDLER_H_
+
+#include "base/memory/weak_ptr.h"
+#include "content/public/browser/resource_dispatcher_host_login_delegate.h"
+
+namespace net {
+class AuthChallengeInfo;
+class URLRequest;
+}
+
+namespace atom {
+
+class LoginHandler : public content::ResourceDispatcherHostLoginDelegate {
+ public:
+  LoginHandler(net::AuthChallengeInfo* auth_info, net::URLRequest* request);
+
+ protected:
+  ~LoginHandler() override;
+
+  // content::ResourceDispatcherHostLoginDelegate:
+  void OnRequestCancelled() override;
+
+ private:
+  // Who/where/what asked for the authentication.
+  scoped_refptr<net::AuthChallengeInfo> auth_info_;
+
+  // The request that wants login data.
+  // This should only be accessed on the IO loop.
+  net::URLRequest* request_;
+
+  base::WeakPtrFactory<LoginHandler> weak_factory_;
+
+  DISALLOW_COPY_AND_ASSIGN(LoginHandler);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_LOGIN_HANDLER_H_

--- a/atom/browser/login_handler.h
+++ b/atom/browser/login_handler.h
@@ -6,6 +6,7 @@
 #define ATOM_BROWSER_LOGIN_HANDLER_H_
 
 #include "base/strings/string16.h"
+#include "base/synchronization/lock.h"
 #include "content/public/browser/resource_dispatcher_host_login_delegate.h"
 
 namespace content {
@@ -47,6 +48,14 @@ class LoginHandler : public content::ResourceDispatcherHostLoginDelegate {
   // Must be called on IO thread.
   void DoCancelAuth();
   void DoLogin(const base::string16& username, const base::string16& password);
+
+  // Marks authentication as handled and returns the previous handled
+  // state.
+  bool TestAndSetAuthHandled();
+
+  // True if we've handled auth (Login or CancelAuth has been called).
+  bool handled_auth_;
+  mutable base::Lock handled_auth_lock_;
 
   // Who/where/what asked for the authentication.
   scoped_refptr<net::AuthChallengeInfo> auth_info_;

--- a/atom/browser/login_handler.h
+++ b/atom/browser/login_handler.h
@@ -8,6 +8,10 @@
 #include "base/strings/string16.h"
 #include "content/public/browser/resource_dispatcher_host_login_delegate.h"
 
+namespace content {
+class WebContents;
+}
+
 namespace net {
 class AuthChallengeInfo;
 class URLRequest;
@@ -19,6 +23,10 @@ namespace atom {
 class LoginHandler : public content::ResourceDispatcherHostLoginDelegate {
  public:
   LoginHandler(net::AuthChallengeInfo* auth_info, net::URLRequest* request);
+
+  // Returns the WebContents associated with the request, must be called on UI
+  // thread.
+  content::WebContents* GetWebContents() const;
 
   // The auth is cancelled, must be called on UI thread.
   void CancelAuth();
@@ -46,6 +54,10 @@ class LoginHandler : public content::ResourceDispatcherHostLoginDelegate {
   // The request that wants login data.
   // This should only be accessed on the IO loop.
   net::URLRequest* request_;
+
+  // Cached from the net::URLRequest, in case it goes NULL on us.
+  int render_process_host_id_;
+  int render_frame_id_;
 
   DISALLOW_COPY_AND_ASSIGN(LoginHandler);
 };

--- a/atom/browser/net/js_asker.cc
+++ b/atom/browser/net/js_asker.cc
@@ -16,18 +16,7 @@ namespace internal {
 namespace {
 
 // The callback which is passed to |handler|.
-void HandlerCallback(const ResponseCallback& callback,
-                     v8::Local<v8::Object> state,
-                     mate::Arguments* args) {
-  v8::Isolate* isolate = args->isolate();
-
-  // Check if the callback has already been called.
-  v8::Local<v8::String> called_symbol = mate::StringToSymbol(isolate, "called");
-  if (state->Has(called_symbol))
-    return;  // no nothing
-  else
-    state->Set(called_symbol, v8::Boolean::New(isolate, true));
-
+void HandlerCallback(const ResponseCallback& callback, mate::Arguments* args) {
   // If there is no argument passed then we failed.
   v8::Local<v8::Value> value;
   if (!args->GetNext(&value)) {
@@ -57,10 +46,9 @@ void AskForOptions(v8::Isolate* isolate,
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   v8::Context::Scope context_scope(context);
-  v8::Local<v8::Object> state = v8::Object::New(isolate);
   handler.Run(request,
               mate::ConvertToV8(isolate,
-                                base::Bind(&HandlerCallback, callback, state)));
+                                base::Bind(&HandlerCallback, callback)));
 }
 
 bool IsErrorOptions(base::Value* value, int* error) {

--- a/atom/browser/net/js_asker.cc
+++ b/atom/browser/net/js_asker.cc
@@ -8,7 +8,6 @@
 
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/v8_value_converter.h"
-#include "native_mate/function_template.h"
 
 namespace atom {
 
@@ -16,18 +15,12 @@ namespace internal {
 
 namespace {
 
-struct CallbackHolder {
-  ResponseCallback callback;
-};
-
-// Cached JavaScript version of |HandlerCallback|.
-v8::Persistent<v8::FunctionTemplate> g_handler_callback_;
-
 // The callback which is passed to |handler|.
-void HandlerCallback(v8::Isolate* isolate,
-                     v8::Local<v8::External> external,
+void HandlerCallback(const ResponseCallback& callback,
                      v8::Local<v8::Object> state,
                      mate::Arguments* args) {
+  v8::Isolate* isolate = args->isolate();
+
   // Check if the callback has already been called.
   v8::Local<v8::String> called_symbol = mate::StringToSymbol(isolate, "called");
   if (state->Has(called_symbol))
@@ -36,14 +29,11 @@ void HandlerCallback(v8::Isolate* isolate,
     state->Set(called_symbol, v8::Boolean::New(isolate, true));
 
   // If there is no argument passed then we failed.
-  scoped_ptr<CallbackHolder> holder(
-      static_cast<CallbackHolder*>(external->Value()));
-  CHECK(holder);
   v8::Local<v8::Value> value;
   if (!args->GetNext(&value)) {
     content::BrowserThread::PostTask(
         content::BrowserThread::IO, FROM_HERE,
-        base::Bind(holder->callback, false, nullptr));
+        base::Bind(callback, false, nullptr));
     return;
   }
 
@@ -53,42 +43,7 @@ void HandlerCallback(v8::Isolate* isolate,
   scoped_ptr<base::Value> options(converter.FromV8Value(value, context));
   content::BrowserThread::PostTask(
       content::BrowserThread::IO, FROM_HERE,
-      base::Bind(holder->callback, true, base::Passed(&options)));
-}
-
-// func.bind(func, arg1, arg2).
-// NB(zcbenz): Using C++11 version crashes VS.
-v8::Local<v8::Value> BindFunctionWith(v8::Isolate* isolate,
-                                      v8::Local<v8::Context> context,
-                                      v8::Local<v8::Function> func,
-                                      v8::Local<v8::Value> arg1,
-                                      v8::Local<v8::Value> arg2) {
-  v8::MaybeLocal<v8::Value> bind = func->Get(mate::StringToV8(isolate, "bind"));
-  CHECK(!bind.IsEmpty());
-  v8::Local<v8::Function> bind_func =
-      v8::Local<v8::Function>::Cast(bind.ToLocalChecked());
-  v8::Local<v8::Value> converted[] = { func, arg1, arg2 };
-  return bind_func->Call(
-      context, func, arraysize(converted), converted).ToLocalChecked();
-}
-
-// Generate the callback that will be passed to |handler|.
-v8::MaybeLocal<v8::Value> GenerateCallback(v8::Isolate* isolate,
-                                           v8::Local<v8::Context> context,
-                                           const ResponseCallback& callback) {
-  // The FunctionTemplate is cached.
-  if (g_handler_callback_.IsEmpty())
-    g_handler_callback_.Reset(
-        isolate,
-        mate::CreateFunctionTemplate(isolate, base::Bind(&HandlerCallback)));
-
-  v8::Local<v8::FunctionTemplate> handler_callback =
-      v8::Local<v8::FunctionTemplate>::New(isolate, g_handler_callback_);
-  CallbackHolder* holder = new CallbackHolder;
-  holder->callback = callback;
-  return BindFunctionWith(isolate, context, handler_callback->GetFunction(),
-                          v8::External::New(isolate, holder),
-                          v8::Object::New(isolate));
+      base::Bind(callback, true, base::Passed(&options)));
 }
 
 }  // namespace
@@ -102,16 +57,10 @@ void AskForOptions(v8::Isolate* isolate,
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   v8::Context::Scope context_scope(context);
-  // We don't convert the callback to C++ directly because creating
-  // FunctionTemplate will cause memory leak since V8 never releases it. So we
-  // have to create the function object in JavaScript to work around it.
-  v8::MaybeLocal<v8::Value> wrapped_callback = GenerateCallback(
-      isolate, context, callback);
-  if (wrapped_callback.IsEmpty()) {
-    callback.Run(false, nullptr);
-    return;
-  }
-  handler.Run(request, wrapped_callback.ToLocalChecked());
+  v8::Local<v8::Object> state = v8::Object::New(isolate);
+  handler.Run(request,
+              mate::ConvertToV8(isolate,
+                                base::Bind(&HandlerCallback, callback, state)));
 }
 
 bool IsErrorOptions(base::Value* value, int* error) {

--- a/atom/common/native_mate_converters/callback.cc
+++ b/atom/common/native_mate_converters/callback.cc
@@ -1,0 +1,62 @@
+// Copyright (c) 2015 GitHub, Inc. All rights reserved.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/common/native_mate_converters/callback.h"
+
+namespace mate {
+
+namespace internal {
+
+namespace {
+
+struct TranslaterHolder {
+  Translater translater;
+};
+
+// Cached JavaScript version of |CallTranslater|.
+v8::Persistent<v8::FunctionTemplate> g_call_translater;
+
+void CallTranslater(v8::Local<v8::External> external, mate::Arguments* args) {
+  TranslaterHolder* holder = static_cast<TranslaterHolder*>(external->Value());
+  holder->translater.Run(args);
+}
+
+// func.bind(func, arg1).
+// NB(zcbenz): Using C++11 version crashes VS.
+v8::Local<v8::Value> BindFunctionWith(v8::Isolate* isolate,
+                                      v8::Local<v8::Context> context,
+                                      v8::Local<v8::Function> func,
+                                      v8::Local<v8::Value> arg1) {
+  v8::MaybeLocal<v8::Value> bind = func->Get(mate::StringToV8(isolate, "bind"));
+  CHECK(!bind.IsEmpty());
+  v8::Local<v8::Function> bind_func =
+      v8::Local<v8::Function>::Cast(bind.ToLocalChecked());
+  v8::Local<v8::Value> converted[] = { func, arg1 };
+  return bind_func->Call(
+      context, func, arraysize(converted), converted).ToLocalChecked();
+}
+
+}  // namespace
+
+v8::Local<v8::Value> CreateFunctionFromTranslater(
+    v8::Isolate* isolate, const Translater& translater) {
+  // The FunctionTemplate is cached.
+  if (g_call_translater.IsEmpty())
+    g_call_translater.Reset(
+        isolate,
+        mate::CreateFunctionTemplate(isolate, base::Bind(&CallTranslater)));
+
+  v8::Local<v8::FunctionTemplate> call_translater =
+      v8::Local<v8::FunctionTemplate>::New(isolate, g_call_translater);
+  TranslaterHolder* holder = new TranslaterHolder;
+  holder->translater = translater;
+  return BindFunctionWith(isolate,
+                          isolate->GetCurrentContext(),
+                          call_translater->GetFunction(),
+                          v8::External::New(isolate, holder));
+}
+
+}  // namespace internal
+
+}  // namespace mate

--- a/atom/common/native_mate_converters/callback.cc
+++ b/atom/common/native_mate_converters/callback.cc
@@ -4,21 +4,22 @@
 
 #include "atom/common/native_mate_converters/callback.h"
 
+#include "native_mate/wrappable.h"
+
 namespace mate {
 
 namespace internal {
 
 namespace {
 
-struct TranslaterHolder {
+struct TranslaterHolder : public Wrappable {
   Translater translater;
 };
 
 // Cached JavaScript version of |CallTranslater|.
 v8::Persistent<v8::FunctionTemplate> g_call_translater;
 
-void CallTranslater(v8::Local<v8::External> external, mate::Arguments* args) {
-  TranslaterHolder* holder = static_cast<TranslaterHolder*>(external->Value());
+void CallTranslater(TranslaterHolder* holder, mate::Arguments* args) {
   holder->translater.Run(args);
 }
 
@@ -54,7 +55,7 @@ v8::Local<v8::Value> CreateFunctionFromTranslater(
   return BindFunctionWith(isolate,
                           isolate->GetCurrentContext(),
                           call_translater->GetFunction(),
-                          v8::External::New(isolate, holder));
+                          holder->GetWrapper(isolate));
 }
 
 }  // namespace internal

--- a/atom/common/native_mate_converters/callback.h
+++ b/atom/common/native_mate_converters/callback.h
@@ -101,21 +101,16 @@ struct NativeFunctionInvoker<ReturnType(ArgTypes...)> {
   }
 };
 
-// Create a static function that accepts generic callback.
-template <typename Sig>
-Translater ConvertToTranslater(const base::Callback<Sig>& val) {
-  return base::Bind(&NativeFunctionInvoker<Sig>::Go, val);
-}
-
 }  // namespace internal
 
 template<typename Sig>
-struct Converter<base::Callback<Sig> > {
+struct Converter<base::Callback<Sig>> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const base::Callback<Sig>& val) {
     // We don't use CreateFunctionTemplate here because it creates a new
     // FunctionTemplate everytime, which is cached by V8 and causes leaks.
-    internal::Translater translater = internal::ConvertToTranslater(val);
+    internal::Translater translater = base::Bind(
+        &internal::NativeFunctionInvoker<Sig>::Go, val);
     return internal::CreateFunctionFromTranslater(isolate, translater);
   }
   static bool FromV8(v8::Isolate* isolate,

--- a/atom/common/native_mate_converters/content_converter.cc
+++ b/atom/common/native_mate_converters/content_converter.cc
@@ -17,7 +17,7 @@ v8::Local<v8::Value> Converter<const net::URLRequest*>::ToV8(
   dict.Set("url", val->url().spec());
   dict.Set("referrer", val->referrer());
   return mate::ConvertToV8(isolate, dict);
-};
+}
 
 // static
 v8::Local<v8::Value> Converter<const net::AuthChallengeInfo*>::ToV8(
@@ -29,6 +29,6 @@ v8::Local<v8::Value> Converter<const net::AuthChallengeInfo*>::ToV8(
   dict.Set("port", static_cast<uint32_t>(val->challenger.port()));
   dict.Set("realm", val->realm);
   return mate::ConvertToV8(isolate, dict);
-};
+}
 
 }  // namespace mate

--- a/atom/common/native_mate_converters/content_converter.cc
+++ b/atom/common/native_mate_converters/content_converter.cc
@@ -1,0 +1,34 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/common/native_mate_converters/content_converter.h"
+
+#include "native_mate/dictionary.h"
+#include "net/url_request/url_request.h"
+
+namespace mate {
+
+// static
+v8::Local<v8::Value> Converter<const net::URLRequest*>::ToV8(
+    v8::Isolate* isolate, const net::URLRequest* val) {
+  mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+  dict.Set("method", val->method());
+  dict.Set("url", val->url().spec());
+  dict.Set("referrer", val->referrer());
+  return mate::ConvertToV8(isolate, dict);
+};
+
+// static
+v8::Local<v8::Value> Converter<const net::AuthChallengeInfo*>::ToV8(
+    v8::Isolate* isolate, const net::AuthChallengeInfo* val) {
+  mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+  dict.Set("isProxy", val->is_proxy);
+  dict.Set("scheme", val->scheme);
+  dict.Set("host", val->challenger.host());
+  dict.Set("port", static_cast<uint32_t>(val->challenger.port()));
+  dict.Set("realm", val->realm);
+  return mate::ConvertToV8(isolate, dict);
+};
+
+}  // namespace mate

--- a/atom/common/native_mate_converters/content_converter.h
+++ b/atom/common/native_mate_converters/content_converter.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_COMMON_NATIVE_MATE_CONVERTERS_CONTENT_CONVERTER_H_
+#define ATOM_COMMON_NATIVE_MATE_CONVERTERS_CONTENT_CONVERTER_H_
+
+#include "native_mate/converter.h"
+
+namespace net {
+class AuthChallengeInfo;
+class URLRequest;
+}
+
+namespace mate {
+
+template<>
+struct Converter<const net::URLRequest*> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const net::URLRequest* val);
+};
+
+template<>
+struct Converter<const net::AuthChallengeInfo*> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const net::AuthChallengeInfo* val);
+};
+
+}  // namespace mate
+
+#endif  // ATOM_COMMON_NATIVE_MATE_CONVERTERS_CONTENT_CONVERTER_H_

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -133,17 +133,22 @@ Emitted when a new [browserWindow](browser-window.md) is created.
 
 ### Event: 'select-certificate'
 
-Emitted when a client certificate is requested.
-
 Returns:
 
 * `event` Event
-* `webContents` [WebContents](browser-window.md#class-webcontents)
-* `url` String
+* `webContents` [WebContents](web-contents.md)
+* `url` URL
 * `certificateList` [Objects]
   * `data` PEM encoded data
   * `issuerName` Issuer's Common Name
 * `callback` Function
+
+Emitted when a client certificate is requested.
+
+The `url` corresponds to the navigation entry requesting the client certificate
+and `callback` needs to be called with an entry filtered from the list. Using
+`event.preventDefault()` prevents the application from using the first
+certificate from the store.
 
 ```javascript
 app.on('select-certificate', function(event, host, url, list, callback) {
@@ -152,10 +157,36 @@ app.on('select-certificate', function(event, host, url, list, callback) {
 })
 ```
 
-The `url` corresponds to the navigation entry requesting the client certificate
-and `callback` needs to be called with an entry filtered from the list. Using
-`event.preventDefault()` prevents the application from using the first
-certificate from the store.
+### Event: 'login'
+
+Returns:
+
+* `event` Event
+* `webContents` [WebContents](web-contents.md)
+* `request` Object
+  * `method` String
+  * `url` URL
+  * `referrer` URL
+* `authInfo` Object
+  * `isProxy` Boolean
+  * `scheme` String
+  * `host` String
+  * `port` Integer
+  * `realm` String
+* `callback` Function
+
+Emitted when `webContents` wants to do basic auth.
+
+The default behavior is to cancel all authentications, to override this you
+should prevent the default behavior with  `event.preventDefault()` and call
+`callback(username, password)` with the credentials.
+
+```javascript
+app.on('login', function(event, webContents, request, authInfo, callback) {
+  event.preventDefault();
+  callback('username', 'secret');
+})
+```
 
 ### Event: 'gpu-process-crashed'
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -167,6 +167,27 @@ Emitted when DevTools is closed.
 
 Emitted when DevTools is focused / opened.
 
+### Event: 'login'
+
+Returns:
+
+* `event` Event
+* `request` Object
+  * `method` String
+  * `url` URL
+  * `referrer` URL
+* `authInfo` Object
+  * `isProxy` Boolean
+  * `scheme` String
+  * `host` String
+  * `port` Integer
+  * `realm` String
+* `callback` Function
+
+Emitted when `webContents` wants to do basic auth.
+
+The usage is the same with [the `login` event of `app`](app.md#event-login).
+
 ## Instance Methods
 
 The `webContents` object has the following instance methods:

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -306,6 +306,8 @@
       'atom/common/native_mate_converters/blink_converter.h',
       'atom/common/native_mate_converters/callback.cc',
       'atom/common/native_mate_converters/callback.h',
+      'atom/common/native_mate_converters/content_converter.cc',
+      'atom/common/native_mate_converters/content_converter.h',
       'atom/common/native_mate_converters/file_path_converter.h',
       'atom/common/native_mate_converters/gfx_converter.cc',
       'atom/common/native_mate_converters/gfx_converter.h',

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -304,6 +304,7 @@
       'atom/common/native_mate_converters/accelerator_converter.h',
       'atom/common/native_mate_converters/blink_converter.cc',
       'atom/common/native_mate_converters/blink_converter.h',
+      'atom/common/native_mate_converters/callback.cc',
       'atom/common/native_mate_converters/callback.h',
       'atom/common/native_mate_converters/file_path_converter.h',
       'atom/common/native_mate_converters/gfx_converter.cc',

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -150,6 +150,8 @@
       'atom/browser/common_web_contents_delegate.h',
       'atom/browser/javascript_environment.cc',
       'atom/browser/javascript_environment.h',
+      'atom/browser/login_handler.cc',
+      'atom/browser/login_handler.h',
       'atom/browser/mac/atom_application.h',
       'atom/browser/mac/atom_application.mm',
       'atom/browser/mac/atom_application_delegate.h',

--- a/spec/api-protocol-spec.coffee
+++ b/spec/api-protocol-spec.coffee
@@ -23,8 +23,10 @@ describe 'protocol module', ->
 
     it 'does not crash when handler is called twice', (done) ->
       doubleHandler = (request, callback) ->
-        callback(text)
-        callback()
+        try
+          callback(text)
+          callback()
+        catch
       protocol.registerStringProtocol protocolName, doubleHandler, (error) ->
         return done(error) if error
         $.ajax
@@ -302,8 +304,10 @@ describe 'protocol module', ->
 
     it 'does not crash when handler is called twice', (done) ->
       doubleHandler = (request, callback) ->
-        callback(text)
-        callback()
+        try
+          callback(text)
+          callback()
+        catch
       protocol.interceptStringProtocol 'http', doubleHandler, (error) ->
         return done(error) if error
         $.ajax

--- a/spec/api-protocol-spec.coffee
+++ b/spec/api-protocol-spec.coffee
@@ -26,6 +26,7 @@ describe 'protocol module', ->
         callback(text)
         callback()
       protocol.registerStringProtocol protocolName, doubleHandler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data) ->
@@ -36,6 +37,7 @@ describe 'protocol module', ->
 
     it 'sends error when callback is called with nothing', (done) ->
       protocol.registerBufferProtocol protocolName, emptyHandler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data) ->
@@ -48,6 +50,7 @@ describe 'protocol module', ->
       handler = (request, callback) ->
         setImmediate -> callback(text)
       protocol.registerStringProtocol protocolName, handler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data) ->
@@ -66,6 +69,7 @@ describe 'protocol module', ->
     it 'sends string as response', (done) ->
       handler = (request, callback) -> callback(text)
       protocol.registerStringProtocol protocolName, handler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data) ->
@@ -77,6 +81,7 @@ describe 'protocol module', ->
     it 'sends object as response', (done) ->
       handler = (request, callback) -> callback(data: text, mimeType: 'text/html')
       protocol.registerStringProtocol protocolName, handler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data, statux, request) ->
@@ -88,6 +93,7 @@ describe 'protocol module', ->
     it 'fails when sending object other than string', (done) ->
       handler = (request, callback) -> callback(new Date)
       protocol.registerBufferProtocol protocolName, handler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data) ->
@@ -102,6 +108,7 @@ describe 'protocol module', ->
     it 'sends Buffer as response', (done) ->
       handler = (request, callback) -> callback(buffer)
       protocol.registerBufferProtocol protocolName, handler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data) ->
@@ -113,6 +120,7 @@ describe 'protocol module', ->
     it 'sends object as response', (done) ->
       handler = (request, callback) -> callback(data: buffer, mimeType: 'text/html')
       protocol.registerBufferProtocol protocolName, handler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data, statux, request) ->
@@ -124,6 +132,7 @@ describe 'protocol module', ->
     it 'fails when sending string', (done) ->
       handler = (request, callback) -> callback(text)
       protocol.registerBufferProtocol protocolName, handler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data) ->
@@ -142,6 +151,7 @@ describe 'protocol module', ->
     it 'sends file path as response', (done) ->
       handler = (request, callback) -> callback(filePath)
       protocol.registerFileProtocol protocolName, handler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data) ->
@@ -153,6 +163,7 @@ describe 'protocol module', ->
     it 'sends object as response', (done) ->
       handler = (request, callback) -> callback(path: filePath)
       protocol.registerFileProtocol protocolName, handler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data, statux, request) ->
@@ -164,6 +175,7 @@ describe 'protocol module', ->
     it 'can send normal file', (done) ->
       handler = (request, callback) -> callback(normalPath)
       protocol.registerFileProtocol protocolName, handler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data) ->
@@ -176,6 +188,7 @@ describe 'protocol module', ->
       fakeFilePath = path.join __dirname, 'fixtures', 'asar', 'a.asar', 'not-exist'
       handler = (request, callback) -> callback(fakeFilePath)
       protocol.registerBufferProtocol protocolName, handler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data) ->
@@ -187,6 +200,7 @@ describe 'protocol module', ->
     it 'fails when sending unsupported content', (done) ->
       handler = (request, callback) -> callback(new Date)
       protocol.registerBufferProtocol protocolName, handler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data) ->
@@ -206,6 +220,7 @@ describe 'protocol module', ->
         url = "http://127.0.0.1:#{port}"
         handler = (request, callback) -> callback({url})
         protocol.registerHttpProtocol protocolName, handler, (error) ->
+          return done(error) if error
           $.ajax
             url: "#{protocolName}://fake-host"
             success: (data) ->
@@ -217,6 +232,7 @@ describe 'protocol module', ->
     it 'fails when sending invalid url', (done) ->
       handler = (request, callback) -> callback({url: 'url'})
       protocol.registerHttpProtocol protocolName, handler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data) ->
@@ -228,6 +244,7 @@ describe 'protocol module', ->
     it 'fails when sending unsupported content', (done) ->
       handler = (request, callback) -> callback(new Date)
       protocol.registerHttpProtocol protocolName, handler, (error) ->
+        return done(error) if error
         $.ajax
           url: "#{protocolName}://fake-host"
           success: (data) ->
@@ -288,6 +305,7 @@ describe 'protocol module', ->
         callback(text)
         callback()
       protocol.interceptStringProtocol 'http', doubleHandler, (error) ->
+        return done(error) if error
         $.ajax
           url: 'http://fake-host'
           success: (data) ->
@@ -298,6 +316,7 @@ describe 'protocol module', ->
 
     it 'sends error when callback is called with nothing', (done) ->
       protocol.interceptBufferProtocol 'http', emptyHandler, (error) ->
+        return done(error) if error
         $.ajax
           url: 'http://fake-host'
           success: (data) ->
@@ -310,6 +329,7 @@ describe 'protocol module', ->
     it 'can intercept http protocol', (done) ->
       handler = (request, callback) -> callback(text)
       protocol.interceptStringProtocol 'http', handler, (error) ->
+        return done(error) if error
         $.ajax
           url: 'http://fake-host'
           success: (data) ->
@@ -322,6 +342,7 @@ describe 'protocol module', ->
       handler = (request, callback) ->
         callback({mimeType: 'application/json', data: '{"value": 1}'})
       protocol.interceptStringProtocol 'http', handler, (error) ->
+        return done(error) if error
         $.ajax
           url: 'http://fake-host'
           success: (data) ->
@@ -335,6 +356,7 @@ describe 'protocol module', ->
     it 'can intercept http protocol', (done) ->
       handler = (request, callback) -> callback(new Buffer(text))
       protocol.interceptBufferProtocol 'http', handler, (error) ->
+        return done(error) if error
         $.ajax
           url: 'http://fake-host'
           success: (data) ->


### PR DESCRIPTION
Close #1362
Close #625

### Event: 'login'

Returns:

* `event` Event
* `webContents` [WebContents](web-contents.md)
* `request` Object
  * `method` String
  * `url` URL
  * `referrer` URL
* `authInfo` Object
  * `isProxy` Boolean
  * `scheme` String
  * `host` String
  * `port` Integer
  * `realm` String
* `callback` Function

Emitted when `webContents` wants to do basic auth.

The default behavior is to cancel all authentications, to override this you
should prevent the default behavior with  `event.preventDefault()` and call
`callback(username, password)` with the credentials.

```javascript
app.on('login', function(event, webContents, request, authInfo, callback) {
  event.preventDefault();
  callback('username', 'secret');
})
```