### PR TITLE
fix capital I -> i in isDocumentEdited

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -594,7 +594,7 @@ Returns the pathname of the file the window represents.
 Specifies whether the window’s document has been edited, and the icon in title
 bar will become grey when set to `true`.
 
-### `win.IsDocumentEdited()` _OS X_
+### `win.isDocumentEdited()` _OS X_
 
 Whether the window's document has been edited.
 


### PR DESCRIPTION
Typo in the function name
IsDocumentEdited -> isDocumentEdited

Uncaught Exception:
TypeError: mainWindow.IsDocumentEdited is not a function