### PR TITLE
Allow v8 to optimize fs.readFileSync

### DIFF
--- a/atom/common/lib/asar.coffee
+++ b/atom/common/lib/asar.coffee
@@ -254,7 +254,8 @@ exports.wrapFsWithAsar = (fs) ->
 
   openSync = fs.openSync
   readFileSync = fs.readFileSync
-  fs.readFileSync = (p, options) ->
+  fs.readFileSync = (p, opts) ->
+    options = opts # this allows v8 to optimize this function
     [isAsar, asarPath, filePath] = splitPath p
     return readFileSync.apply this, arguments unless isAsar
 


### PR DESCRIPTION
While evaluating startup times, I've noticed that `fs.readFileSync` was not being optimized by V8:

![screen shot 2015-10-30 at 10 29 25](https://cloud.githubusercontent.com/assets/482957/10842367/56119b28-7ef1-11e5-8868-b2aed310635f.png)

This won't probably make a huge difference, but this function is basically used everywhere and the tradeoff for allowing the optimization seems super reasonable.

/cc: @zcbenz 