### PR TITLE
Update autoUpdater api docs

### DIFF
--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -82,7 +82,7 @@ once it is set.
 Asks the server whether there is an update. You must call `setFeedUrl` before
 using this API.
 
-### `autoUpdater.quitAndUpdate()`
+### `autoUpdater.quitAndInstall()`
 
 Restarts the app and install the update after it has been downloaded. It should
 only be called after `update-downloaded` has been emitted.


### PR DESCRIPTION
Seems like somebody changed the code but forgot to update the docs. The `autoUpdater`-Module doesn't support anymore the `quitAndUpdate` function, instead it was renamed to `quitAndInstall`.

