### PR TITLE
Improve error handling from remote

### DIFF
--- a/atom/browser/lib/rpc-server.coffee
+++ b/atom/browser/lib/rpc-server.coffee
@@ -40,7 +40,7 @@ valueToMeta = (sender, value, optimizeSimpleObject=false) ->
   else if meta.type is 'promise'
     meta.then = valueToMeta(sender, value.then.bind(value))
   else if meta.type is 'error'
-    meta.message = value.message
+    meta = errorValueToMeta(value, meta)
   else if meta.type is 'date'
     meta.value = value.getTime()
   else
@@ -48,6 +48,13 @@ valueToMeta = (sender, value, optimizeSimpleObject=false) ->
     meta.value = value
 
   meta
+
+# Convert Error into meta data.
+errorValueToMeta = (err, meta) ->
+  Object.getOwnPropertyNames(err).reduce((obj, key) ->
+    obj[key] = err[key]
+    obj
+  , meta)
 
 # Convert Error into meta data.
 exceptionToMeta = (error) ->

--- a/atom/renderer/api/lib/remote.coffee
+++ b/atom/renderer/api/lib/remote.coffee
@@ -46,7 +46,7 @@ metaToValue = (meta) ->
     when 'array' then (metaToValue(el) for el in meta.members)
     when 'buffer' then new Buffer(meta.value)
     when 'promise' then Promise.resolve(then: metaToValue(meta.then))
-    when 'error' then new Error(meta.message)
+    when 'error' then metaToError(meta)
     when 'date' then new Date(meta.value)
     when 'exception'
       throw new Error("#{meta.message}\n#{meta.stack}")
@@ -109,6 +109,17 @@ metaToValue = (meta) ->
       v8Util.setHiddenValue ret, 'atomId', meta.id
 
       ret
+
+# Convert meta data from browser into Error.
+metaToError = (meta) ->
+  Object.getOwnPropertyNames(meta).reduce((error, prop) ->
+    Object.defineProperty(error, prop, {
+      get: -> meta[prop],
+      enumerable: false,
+      configurable: false
+    })
+    error
+  , new Error())
 
 # Browser calls a callback in renderer.
 ipc.on 'ATOM_RENDERER_CALLBACK', (id, args) ->


### PR DESCRIPTION
This way copy all properties available in the error object and keep the real stack trace

Fix the problem described here #3089

Before my changes:
![before](https://cloud.githubusercontent.com/assets/680356/10866438/c756b438-8015-11e5-95ad-fd651af4a232.png)

After my changes:
![after](https://cloud.githubusercontent.com/assets/680356/10866437/c7531fee-8015-11e5-9e15-f8f6b3ac5354.png)
 
If you prefer I can try apply the same approach used for `object` type. Also I think this approach should be applied for the `exception` type.