### PR TITLE
Enable Windows keyboard accessibility

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -102,13 +102,6 @@ void AtomMainDelegate::PreSandboxStartup() {
   if (!IsBrowserProcess(command_line))
     return;
 
-#if defined(OS_WIN)
-  // Disable the LegacyRenderWidgetHostHWND, it made frameless windows unable
-  // to move and resize. We may consider enabling it again after upgraded to
-  // Chrome 38, which should have fixed the problem.
-  command_line->AppendSwitch(switches::kDisableLegacyIntermediateWindow);
-#endif
-
   // Disable renderer sandbox for most of node's functions.
   command_line->AppendSwitch(switches::kNoSandbox);
 


### PR DESCRIPTION
When using `--force-renderer-accessibility`, one can enable some accessibility in Electron in Windows. Keyboard accessibility is not there, unfortunately.

The `kDisableLegacyIntermediateWindow` Chromium switch seems to be the one disabling it.

I found that this switch is being set in Electron due to an issue in moving and resizing frameless windows. The comment also mentions that the issue could have been been fixed in Chrome 38, which is rather old. The issue seems fixed since after removing the flag I can move and resize frameless windows.

Here's Inspect.exe happy to have found some keyboard accessible HTML elements within Electron:

![image](https://cloud.githubusercontent.com/assets/22350/10925818/64bced28-8246-11e5-85c7-116e3a85d42d.png)
