### PR TITLE
Clean up native resources on exit

### DIFF
--- a/atom/browser/api/atom_api_global_shortcut.cc
+++ b/atom/browser/api/atom_api_global_shortcut.cc
@@ -23,6 +23,9 @@ GlobalShortcut::GlobalShortcut() {
 }
 
 GlobalShortcut::~GlobalShortcut() {
+}
+
+void GlobalShortcut::Destroy() {
   UnregisterAll();
 }
 

--- a/atom/browser/api/atom_api_global_shortcut.h
+++ b/atom/browser/api/atom_api_global_shortcut.h
@@ -8,9 +8,9 @@
 #include <map>
 #include <string>
 
+#include "atom/browser/api/trackable_object.h"
 #include "base/callback.h"
 #include "chrome/browser/extensions/global_shortcut_listener.h"
-#include "native_mate/wrappable.h"
 #include "native_mate/handle.h"
 #include "ui/base/accelerators/accelerator.h"
 
@@ -19,13 +19,16 @@ namespace atom {
 namespace api {
 
 class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
-                       public mate::Wrappable {
+                       public mate::TrackableObject<GlobalShortcut> {
  public:
   static mate::Handle<GlobalShortcut> Create(v8::Isolate* isolate);
 
  protected:
   GlobalShortcut();
-  virtual ~GlobalShortcut();
+  ~GlobalShortcut() override;
+
+  // mate::TrackableObject:
+  void Destroy() override;
 
   // mate::Wrappable implementations:
   mate::ObjectTemplateBuilder GetObjectTemplateBuilder(

--- a/atom/browser/api/atom_api_menu.cc
+++ b/atom/browser/api/atom_api_menu.cc
@@ -27,6 +27,14 @@ Menu::Menu()
 Menu::~Menu() {
 }
 
+void Menu::Destroy() {
+  model_.reset();
+}
+
+bool Menu::IsDestroyed() const {
+  return !model_;
+}
+
 void Menu::AfterInit(v8::Isolate* isolate) {
   mate::Dictionary wrappable(isolate, GetWrapper(isolate));
   mate::Dictionary delegate;

--- a/atom/browser/api/atom_api_menu.h
+++ b/atom/browser/api/atom_api_menu.h
@@ -8,16 +8,16 @@
 #include <string>
 
 #include "atom/browser/api/atom_api_window.h"
+#include "atom/browser/api/trackable_object.h"
 #include "atom/browser/ui/atom_menu_model.h"
 #include "base/callback.h"
 #include "base/memory/scoped_ptr.h"
-#include "native_mate/wrappable.h"
 
 namespace atom {
 
 namespace api {
 
-class Menu : public mate::Wrappable,
+class Menu : public mate::TrackableObject<Menu>,
              public AtomMenuModel::Delegate {
  public:
   static mate::Wrappable* Create();
@@ -37,9 +37,13 @@ class Menu : public mate::Wrappable,
 
  protected:
   Menu();
-  virtual ~Menu();
+  ~Menu() override;
+
+  // mate::TrackableObject:
+  void Destroy() override;
 
   // mate::Wrappable:
+  bool IsDestroyed() const override;
   void AfterInit(v8::Isolate* isolate) override;
 
   // ui::SimpleMenuModel::Delegate:

--- a/atom/browser/api/atom_api_menu_mac.h
+++ b/atom/browser/api/atom_api_menu_mac.h
@@ -19,6 +19,7 @@ class MenuMac : public Menu {
  protected:
   MenuMac();
 
+  void Destroy() override;
   void Popup(Window* window) override;
   void PopupAt(Window* window, int x, int y) override;
 

--- a/atom/browser/api/atom_api_menu_mac.mm
+++ b/atom/browser/api/atom_api_menu_mac.mm
@@ -18,6 +18,11 @@ namespace api {
 MenuMac::MenuMac() {
 }
 
+void MenuMac::Destroy() {
+  menu_controller_.reset();
+  Menu::Destroy();
+}
+
 void MenuMac::Popup(Window* window) {
   NativeWindow* native_window = window->window();
   if (!native_window)

--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -19,6 +19,9 @@ PowerMonitor::PowerMonitor() {
 }
 
 PowerMonitor::~PowerMonitor() {
+}
+
+void PowerMonitor::Destroy() {
   base::PowerMonitor::Get()->RemoveObserver(this);
 }
 

--- a/atom/browser/api/atom_api_power_monitor.h
+++ b/atom/browser/api/atom_api_power_monitor.h
@@ -5,7 +5,7 @@
 #ifndef ATOM_BROWSER_API_ATOM_API_POWER_MONITOR_H_
 #define ATOM_BROWSER_API_ATOM_API_POWER_MONITOR_H_
 
-#include "atom/browser/api/event_emitter.h"
+#include "atom/browser/api/trackable_object.h"
 #include "base/compiler_specific.h"
 #include "base/power_monitor/power_observer.h"
 #include "native_mate/handle.h"
@@ -14,14 +14,17 @@ namespace atom {
 
 namespace api {
 
-class PowerMonitor : public mate::EventEmitter,
+class PowerMonitor : public mate::TrackableObject<PowerMonitor>,
                      public base::PowerObserver {
  public:
   static v8::Local<v8::Value> Create(v8::Isolate* isolate);
 
  protected:
   PowerMonitor();
-  virtual ~PowerMonitor();
+  ~PowerMonitor() override;
+
+  // mate::TrackableObject:
+  void Destroy() override;
 
   // base::PowerObserver implementations:
   void OnPowerStateChange(bool on_battery_power) override;

--- a/atom/browser/api/atom_api_power_save_blocker.cc
+++ b/atom/browser/api/atom_api_power_save_blocker.cc
@@ -45,6 +45,11 @@ PowerSaveBlocker::PowerSaveBlocker()
 PowerSaveBlocker::~PowerSaveBlocker() {
 }
 
+void PowerSaveBlocker::Destroy() {
+  power_save_blocker_types_.clear();
+  power_save_blocker_.reset();
+}
+
 void PowerSaveBlocker::UpdatePowerSaveBlocker() {
   if (power_save_blocker_types_.empty()) {
     power_save_blocker_.reset();

--- a/atom/browser/api/atom_api_power_save_blocker.h
+++ b/atom/browser/api/atom_api_power_save_blocker.h
@@ -7,10 +7,10 @@
 
 #include <map>
 
+#include "atom/browser/api/trackable_object.h"
 #include "base/memory/scoped_ptr.h"
 #include "content/public/browser/power_save_blocker.h"
 #include "native_mate/handle.h"
-#include "native_mate/wrappable.h"
 
 namespace mate {
 class Dictionary;
@@ -20,13 +20,16 @@ namespace atom {
 
 namespace api {
 
-class PowerSaveBlocker : public mate::Wrappable {
+class PowerSaveBlocker : public mate::TrackableObject<PowerSaveBlocker> {
  public:
   static mate::Handle<PowerSaveBlocker> Create(v8::Isolate* isolate);
 
  protected:
   PowerSaveBlocker();
-  virtual ~PowerSaveBlocker();
+  ~PowerSaveBlocker() override;
+
+  // mate::TrackableObject:
+  void Destroy() override;
 
   // mate::Wrappable implementations:
   mate::ObjectTemplateBuilder GetObjectTemplateBuilder(
@@ -47,7 +50,6 @@ class PowerSaveBlocker : public mate::Wrappable {
   using PowerSaveBlockerTypeMap =
       std::map<int, content::PowerSaveBlocker::PowerSaveBlockerType>;
   PowerSaveBlockerTypeMap power_save_blocker_types_;
-
 
   DISALLOW_COPY_AND_ASSIGN(PowerSaveBlocker);
 };

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -9,9 +9,10 @@
 
 #include "atom/browser/api/atom_api_cookies.h"
 #include "atom/browser/api/atom_api_download_item.h"
-#include "atom/browser/atom_browser_context.h"
 #include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/api/save_page_handler.h"
+#include "atom/browser/atom_browser_context.h"
+#include "atom/browser/atom_browser_main_parts.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
@@ -395,12 +396,16 @@ mate::Handle<Session> Session::FromPartition(
                     static_cast<AtomBrowserContext*>(browser_context.get()));
 }
 
-void SetWrapSession(const WrapSessionCallback& callback) {
-  g_wrap_session = callback;
-}
-
 void ClearWrapSession() {
   g_wrap_session.Reset();
+}
+
+void SetWrapSession(const WrapSessionCallback& callback) {
+  g_wrap_session = callback;
+
+  // Cleanup the wrapper on exit.
+  atom::AtomBrowserMainParts::Get()->RegisterDestructionCallback(
+      base::Bind(ClearWrapSession));
 }
 
 }  // namespace api
@@ -415,7 +420,6 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   mate::Dictionary dict(isolate, exports);
   dict.SetMethod("fromPartition", &atom::api::Session::FromPartition);
   dict.SetMethod("_setWrapSession", &atom::api::SetWrapSession);
-  dict.SetMethod("_clearWrapSession", &atom::api::ClearWrapSession);
 }
 
 }  // namespace

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -8,7 +8,7 @@
 #include <string>
 #include <vector>
 
-#include "atom/browser/api/event_emitter.h"
+#include "atom/browser/api/trackable_object.h"
 #include "atom/browser/ui/tray_icon_observer.h"
 #include "base/memory/scoped_ptr.h"
 
@@ -29,7 +29,7 @@ namespace api {
 
 class Menu;
 
-class Tray : public mate::EventEmitter,
+class Tray : public mate::TrackableObject<Tray>,
              public TrayIconObserver {
  public:
   static mate::Wrappable* New(v8::Isolate* isolate, const gfx::Image& image);
@@ -39,7 +39,7 @@ class Tray : public mate::EventEmitter,
 
  protected:
   explicit Tray(const gfx::Image& image);
-  virtual ~Tray();
+  ~Tray() override;
 
   // TrayIconObserver:
   void OnClicked(const gfx::Rect& bounds, int modifiers) override;
@@ -53,7 +53,9 @@ class Tray : public mate::EventEmitter,
   // mate::Wrappable:
   bool IsDestroyed() const override;
 
-  void Destroy();
+  // mate::TrackableObject:
+  void Destroy() override;
+
   void SetImage(mate::Arguments* args, const gfx::Image& image);
   void SetPressedImage(mate::Arguments* args, const gfx::Image& image);
   void SetToolTip(mate::Arguments* args, const std::string& tool_tip);

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1124,12 +1124,16 @@ mate::Handle<WebContents> WebContents::Create(
   return handle;
 }
 
-void SetWrapWebContents(const WrapWebContentsCallback& callback) {
-  g_wrap_web_contents = callback;
-}
-
 void ClearWrapWebContents() {
   g_wrap_web_contents.Reset();
+}
+
+void SetWrapWebContents(const WrapWebContentsCallback& callback) {
+  g_wrap_web_contents = callback;
+
+  // Cleanup the wrapper on exit.
+  atom::AtomBrowserMainParts::Get()->RegisterDestructionCallback(
+      base::Bind(ClearWrapWebContents));
 }
 
 }  // namespace api
@@ -1145,7 +1149,6 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   mate::Dictionary dict(isolate, exports);
   dict.SetMethod("create", &atom::api::WebContents::Create);
   dict.SetMethod("_setWrapWebContents", &atom::api::SetWrapWebContents);
-  dict.SetMethod("_clearWrapWebContents", &atom::api::ClearWrapWebContents);
 }
 
 }  // namespace

--- a/atom/browser/api/lib/app.coffee
+++ b/atom/browser/api/lib/app.coffee
@@ -11,14 +11,14 @@ wrapSession = (session) ->
   # session is an Event Emitter.
   session.__proto__ = EventEmitter.prototype
 
-wrapDownloadItem = (download_item) ->
-  # download_item is an Event Emitter.
-  download_item.__proto__ = EventEmitter.prototype
+wrapDownloadItem = (downloadItem) ->
+  # downloadItem is an Event Emitter.
+  downloadItem.__proto__ = EventEmitter.prototype
   # Be compatible with old APIs.
-  download_item.url = download_item.getUrl()
-  download_item.filename = download_item.getFilename()
-  download_item.mimeType = download_item.getMimeType()
-  download_item.hasUserGesture = download_item.hasUserGesture()
+  downloadItem.url = downloadItem.getUrl()
+  downloadItem.filename = downloadItem.getFilename()
+  downloadItem.mimeType = downloadItem.getMimeType()
+  downloadItem.hasUserGesture = downloadItem.hasUserGesture()
 
 app.setApplicationMenu = (menu) ->
   require('menu').setApplicationMenu menu
@@ -57,7 +57,7 @@ app.setDataPath = (path) -> @setPath 'userData', path
 app.resolveProxy = -> @defaultSession.resolveProxy.apply @defaultSession, arguments
 app.on 'activate', (event, hasVisibleWindows) -> @emit 'activate-with-no-open-windows' if not hasVisibleWindows
 
-# Session wrapper.
+# Wrappers for native classes.
 sessionBindings._setWrapSession wrapSession
 process.once 'exit', sessionBindings._clearWrapSession
 

--- a/atom/browser/api/lib/app.coffee
+++ b/atom/browser/api/lib/app.coffee
@@ -59,10 +59,7 @@ app.on 'activate', (event, hasVisibleWindows) -> @emit 'activate-with-no-open-wi
 
 # Wrappers for native classes.
 sessionBindings._setWrapSession wrapSession
-process.once 'exit', sessionBindings._clearWrapSession
-
 downloadItemBindings._setWrapDownloadItem wrapDownloadItem
-process.once 'exit', downloadItemBindings._clearWrapDownloadItem
 
 # Only one App object pemitted.
 module.exports = app

--- a/atom/browser/api/lib/web-contents.coffee
+++ b/atom/browser/api/lib/web-contents.coffee
@@ -112,7 +112,6 @@ wrapWebContents = (webContents) ->
     @_printToPDF printingSetting, callback
 
 binding._setWrapWebContents wrapWebContents
-process.once 'exit', binding._clearWrapWebContents
 
 module.exports.create = (options={}) ->
   binding.create(options)

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -137,6 +137,14 @@ void AtomBrowserMainParts::PostMainMessageLoopRun() {
   // won't be freed.
   for (const auto& callback : destruction_callbacks_)
     callback.Run();
+
+  // Destroy JavaScript environment immediately after running destruction
+  // callbacks.
+  gc_timer_.Stop();
+  node_debugger_.reset();
+  atom_bindings_.reset();
+  node_bindings_.reset();
+  js_env_.reset();
 }
 
 }  // namespace atom

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -128,6 +128,10 @@ void AtomBrowserMainParts::PostMainMessageLoopStart() {
 void AtomBrowserMainParts::PostMainMessageLoopRun() {
   brightray::BrowserMainParts::PostMainMessageLoopRun();
 
+#if defined(OS_MACOSX)
+  FreeAppDelegate();
+#endif
+
   // Make sure destruction callbacks are called before message loop is
   // destroyed, otherwise some objects that need to be deleted on IO thread
   // won't be freed.

--- a/atom/browser/atom_browser_main_parts.h
+++ b/atom/browser/atom_browser_main_parts.h
@@ -46,7 +46,6 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
   void PostMainMessageLoopRun() override;
 #if defined(OS_MACOSX)
   void PreMainMessageLoopStart() override;
-  void PostDestroyThreads() override;
 #endif
 
  private:
@@ -54,6 +53,10 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
   // Set signal handlers.
   void HandleSIGCHLD();
   void HandleShutdownSignals();
+#endif
+
+#if defined(OS_MACOSX)
+  void FreeAppDelegate();
 #endif
 
   // A fake BrowserProcess object that used to feed the source code from chrome.

--- a/atom/browser/atom_browser_main_parts_mac.mm
+++ b/atom/browser/atom_browser_main_parts_mac.mm
@@ -34,7 +34,7 @@ void AtomBrowserMainParts::PreMainMessageLoopStart() {
       setObject:@"NO" forKey:@"NSTreatUnknownArgumentsAsOpen"];
 }
 
-void AtomBrowserMainParts::PostDestroyThreads() {
+void AtomBrowserMainParts::FreeAppDelegate() {
   [[NSApp delegate] release];
   [NSApp setDelegate:nil];
 }


### PR DESCRIPTION
When Electron is quitting some native resources are not cleared after destroying the JavaScript environment, so it may happen that some native events which are emitted during exiting would try to execute JavaScript code, resulting in crashes.

This PR makes sure all native resources get freed on exit to fix that.

Close #3208.
Close https://github.com/atom/atom/issues/9118.