### PR TITLE
Fix win accessibility

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -129,6 +129,7 @@
         ['OS=="win"', {
           'include_dirs': [
             '<(libchromiumcontent_dir)/gen/ui/resources',
+            '<(libchromiumcontent_src_dir)',
           ],
           'msvs_settings': {
             'VCManifestTool': {

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -84,15 +84,17 @@ bool NativeWindowViews::PreHandleMSG(
   NotifyWindowMessage(message, w_param, l_param);
 
   switch (message) {
-    // Screen readers send WM_GETOBJECT in order to get the accessibility object, so take this opportunity
-    // to push Chromium into accessible mode if it isn't already, always say we didn't handle the message
-    // because we still want Chromium to handle returning the actual accessibility object.
-    case WM_GETOBJECT:
-    {
+    // Screen readers send WM_GETOBJECT in order to get the accessibility
+    // object, so take this opportunity to push Chromium into accessible
+    // mode if it isn't already, always say we didn't handle the message
+    // because we still want Chromium to handle returning the actual
+    // accessibility object.
+    case WM_GETOBJECT: {
         const DWORD objId = static_cast<DWORD>(static_cast<DWORD_PTR>(l_param));
-        if (objId == OBJID_CLIENT)
-        {
-            const auto axState = content::BrowserAccessibilityState::GetInstance();
+        if (objId == OBJID_CLIENT) {
+            const auto axState =
+              content::BrowserAccessibilityState::GetInstance();
+
             if (axState && !axState->IsAccessibleBrowser())
                 axState->OnScreenReaderDetected();
         }

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "atom/browser/native_window_views.h"
+#include "content/public/browser/browser_accessibility_state.h"
 
 namespace atom {
 
@@ -83,6 +84,20 @@ bool NativeWindowViews::PreHandleMSG(
   NotifyWindowMessage(message, w_param, l_param);
 
   switch (message) {
+    // Screen readers send WM_GETOBJECT in order to get the accessibility object, so take this opportunity
+    // to push Chromium into accessible mode if it isn't already, always say we didn't handle the message
+    // because we still want Chromium to handle returning the actual accessibility object.
+    case WM_GETOBJECT:
+    {
+        const DWORD objId = static_cast<DWORD>(static_cast<DWORD_PTR>(l_param));
+        if (objId == OBJID_CLIENT)
+        {
+            const auto axState = content::BrowserAccessibilityState::GetInstance();
+            if (axState && !axState->IsAccessibleBrowser())
+                axState->OnScreenReaderDetected();
+        }
+        return false;
+    }
     case WM_COMMAND:
       // Handle thumbar button click message.
       if (HIWORD(w_param) == THBN_CLICKED)


### PR DESCRIPTION
(in conjunction with commit 7c41f0e)

Context: In order for full accessibility support on Windows we need to remove the disable-legacy-window flag (commit 7c41f0e) as well as calling OnScreenReaderDetected at the appropriate time.

The appropriate time is when our window gets a WM_GETOBJECT request with an id of OBJID_CLIENT. This is the same way Chromium detects a request for the accessibility object. When we see that we simply toggle Chromium into accessibility mode, if it isn't already.