### PR TITLE
Make process.exit() quit program gracefully 

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -339,6 +339,7 @@ mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(
   auto browser = base::Unretained(Browser::Get());
   return mate::ObjectTemplateBuilder(isolate)
       .SetMethod("quit", base::Bind(&Browser::Quit, browser))
+      .SetMethod("exit", base::Bind(&Browser::Exit, browser))
       .SetMethod("focus", base::Bind(&Browser::Focus, browser))
       .SetMethod("getVersion", base::Bind(&Browser::GetVersion, browser))
       .SetMethod("setVersion", base::Bind(&Browser::SetVersion, browser))

--- a/atom/browser/api/lib/app.coffee
+++ b/atom/browser/api/lib/app.coffee
@@ -50,7 +50,6 @@ app.getAppPath = ->
 # Be compatible with old API.
 app.once 'ready', -> @emit 'finish-launching'
 app.terminate = app.quit
-app.exit = process.exit
 app.getHomeDir = -> @getPath 'home'
 app.getDataPath = -> @getPath 'userData'
 app.setDataPath = (path) -> @setPath 'userData', path

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -30,6 +30,7 @@ AtomBrowserMainParts* AtomBrowserMainParts::self_ = NULL;
 
 AtomBrowserMainParts::AtomBrowserMainParts()
     : fake_browser_process_(new BrowserProcess),
+      exit_code_(nullptr),
       browser_(new Browser),
       node_bindings_(NodeBindings::Create(true)),
       atom_bindings_(new AtomBindings),
@@ -45,6 +46,14 @@ AtomBrowserMainParts::~AtomBrowserMainParts() {
 AtomBrowserMainParts* AtomBrowserMainParts::Get() {
   DCHECK(self_);
   return self_;
+}
+
+bool AtomBrowserMainParts::SetExitCode(int code) {
+  if (!exit_code_)
+    return false;
+
+  *exit_code_ = code;
+  return true;
 }
 
 void AtomBrowserMainParts::RegisterDestructionCallback(
@@ -116,6 +125,11 @@ void AtomBrowserMainParts::PreMainMessageLoopRun() {
   Browser::Get()->WillFinishLaunching();
   Browser::Get()->DidFinishLaunching();
 #endif
+}
+
+bool AtomBrowserMainParts::MainMessageLoopRun(int* result_code) {
+  exit_code_ = result_code;
+  return brightray::BrowserMainParts::MainMessageLoopRun(result_code);
 }
 
 void AtomBrowserMainParts::PostMainMessageLoopStart() {

--- a/atom/browser/atom_browser_main_parts.h
+++ b/atom/browser/atom_browser_main_parts.h
@@ -31,6 +31,9 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
 
   static AtomBrowserMainParts* Get();
 
+  // Sets the exit code, will fail if the the message loop is not ready.
+  bool SetExitCode(int code);
+
   // Register a callback that should be destroyed before JavaScript environment
   // gets destroyed.
   void RegisterDestructionCallback(const base::Closure& callback);
@@ -42,6 +45,7 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
   void PreEarlyInitialization() override;
   void PostEarlyInitialization() override;
   void PreMainMessageLoopRun() override;
+  bool MainMessageLoopRun(int* result_code) override;
   void PostMainMessageLoopStart() override;
   void PostMainMessageLoopRun() override;
 #if defined(OS_MACOSX)
@@ -65,6 +69,9 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
   // The gin::PerIsolateData requires a task runner to create, so we feed it
   // with a task runner that will post all work to main loop.
   scoped_refptr<BridgeTaskRunner> bridge_task_runner_;
+
+  // Pointer to exit code.
+  int* exit_code_;
 
   scoped_ptr<Browser> browser_;
   scoped_ptr<JavascriptEnvironment> js_env_;

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -42,6 +42,9 @@ class Browser : public WindowListObserver {
   // Try to close all windows and quit the application.
   void Quit();
 
+  // Exit the application immediately and set exit code.
+  void Exit(int code);
+
   // Cleanup everything and shutdown the application gracefully.
   void Shutdown();
 

--- a/atom/browser/lib/init.coffee
+++ b/atom/browser/lib/init.coffee
@@ -53,6 +53,9 @@ app = require 'app'
 app.on 'quit', ->
   process.emit 'exit'
 
+# Map process.exit to app.exit, which quits gracefully.
+process.exit = app.exit
+
 # Load the RPC server.
 require './rpc-server'
 

--- a/atom/common/native_mate_converters/callback.h
+++ b/atom/common/native_mate_converters/callback.h
@@ -10,6 +10,7 @@
 #include "atom/common/api/locker.h"
 #include "base/bind.h"
 #include "base/callback.h"
+#include "base/memory/weak_ptr.h"
 #include "native_mate/function_template.h"
 #include "native_mate/scoped_persistent.h"
 #include "third_party/WebKit/public/web/WebScopedMicrotaskSuppression.h"
@@ -18,7 +19,24 @@ namespace mate {
 
 namespace internal {
 
-typedef scoped_refptr<RefCountedPersistent<v8::Function> > SafeV8Function;
+// Manages the V8 function with RAII, and automatically cleans the handle when
+// JavaScript context is destroyed, even when the class is not destroyed.
+class SafeV8Function {
+ public:
+  SafeV8Function(v8::Isolate* isolate, v8::Local<v8::Value> value);
+  SafeV8Function(const SafeV8Function& other);
+
+  bool is_alive() const { return v8_function_.get(); }
+
+  v8::Local<v8::Function> NewHandle() const;
+
+ private:
+  void Init();
+  void FreeHandle();
+
+  scoped_refptr<RefCountedPersistent<v8::Function>> v8_function_;
+  base::WeakPtrFactory<SafeV8Function> weak_factory_;
+};
 
 // Helper to invoke a V8 function with C++ parameters.
 template <typename Sig>
@@ -26,14 +44,17 @@ struct V8FunctionInvoker {};
 
 template <typename... ArgTypes>
 struct V8FunctionInvoker<v8::Local<v8::Value>(ArgTypes...)> {
-  static v8::Local<v8::Value> Go(v8::Isolate* isolate, SafeV8Function function,
+  static v8::Local<v8::Value> Go(v8::Isolate* isolate,
+                                 const SafeV8Function& function,
                                  ArgTypes... raw) {
     Locker locker(isolate);
     v8::EscapableHandleScope handle_scope(isolate);
+    if (!function.is_alive())
+      return v8::Null(isolate);
     scoped_ptr<blink::WebScopedRunV8Script> script_scope(
         Locker::IsBrowserProcess() ?
         nullptr : new blink::WebScopedRunV8Script(isolate));
-    v8::Local<v8::Function> holder = function->NewHandle();
+    v8::Local<v8::Function> holder = function.NewHandle();
     v8::Local<v8::Context> context = holder->CreationContext();
     v8::Context::Scope context_scope(context);
     std::vector<v8::Local<v8::Value>> args = { ConvertToV8(isolate, raw)... };
@@ -44,14 +65,17 @@ struct V8FunctionInvoker<v8::Local<v8::Value>(ArgTypes...)> {
 
 template <typename... ArgTypes>
 struct V8FunctionInvoker<void(ArgTypes...)> {
-  static void Go(v8::Isolate* isolate, SafeV8Function function,
+  static void Go(v8::Isolate* isolate,
+                 const SafeV8Function& function,
                  ArgTypes... raw) {
     Locker locker(isolate);
     v8::HandleScope handle_scope(isolate);
+    if (!function.is_alive())
+      return;
     scoped_ptr<blink::WebScopedRunV8Script> script_scope(
         Locker::IsBrowserProcess() ?
         nullptr : new blink::WebScopedRunV8Script(isolate));
-    v8::Local<v8::Function> holder = function->NewHandle();
+    v8::Local<v8::Function> holder = function.NewHandle();
     v8::Local<v8::Context> context = holder->CreationContext();
     v8::Context::Scope context_scope(context);
     std::vector<v8::Local<v8::Value>> args = { ConvertToV8(isolate, raw)... };
@@ -61,17 +85,20 @@ struct V8FunctionInvoker<void(ArgTypes...)> {
 
 template <typename ReturnType, typename... ArgTypes>
 struct V8FunctionInvoker<ReturnType(ArgTypes...)> {
-  static ReturnType Go(v8::Isolate* isolate, SafeV8Function function,
+  static ReturnType Go(v8::Isolate* isolate,
+                       const SafeV8Function& function,
                        ArgTypes... raw) {
     Locker locker(isolate);
     v8::HandleScope handle_scope(isolate);
+    ReturnType ret = ReturnType();
+    if (!function.is_alive())
+      return ret;
     scoped_ptr<blink::WebScopedRunV8Script> script_scope(
         Locker::IsBrowserProcess() ?
         nullptr : new blink::WebScopedRunV8Script(isolate));
-    v8::Local<v8::Function> holder = function->NewHandle();
+    v8::Local<v8::Function> holder = function.NewHandle();
     v8::Local<v8::Context> context = holder->CreationContext();
     v8::Context::Scope context_scope(context);
-    ReturnType ret = ReturnType();
     std::vector<v8::Local<v8::Value>> args = { ConvertToV8(isolate, raw)... };
     v8::Local<v8::Value> result;
     auto maybe_result =
@@ -119,9 +146,8 @@ struct Converter<base::Callback<Sig>> {
     if (!val->IsFunction())
       return false;
 
-    internal::SafeV8Function function(
-        new RefCountedPersistent<v8::Function>(isolate, val));
-    *out = base::Bind(&internal::V8FunctionInvoker<Sig>::Go, isolate, function);
+    *out = base::Bind(&internal::V8FunctionInvoker<Sig>::Go,
+                      isolate, internal::SafeV8Function(isolate, val));
     return true;
   }
 };

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -14,6 +14,7 @@
 #include "atom/common/node_includes.h"
 #include "base/command_line.h"
 #include "base/base_paths.h"
+#include "base/environment.h"
 #include "base/files/file_path.h"
 #include "base/message_loop/message_loop.h"
 #include "base/path_service.h"
@@ -141,6 +142,14 @@ void NodeBindings::Initialize() {
   // Init node.
   // (we assume node::Init would not modify the parameters under embedded mode).
   node::Init(nullptr, nullptr, nullptr, nullptr);
+
+#if defined(OS_WIN)
+  // uv_init overrides error mode to suppress the default crash dialog, bring
+  // it back if user wants to show it.
+  scoped_ptr<base::Environment> env(base::Environment::Create());
+  if (env->HasVar("ELECTRON_DEFAULT_ERROR_MODE"))
+    SetErrorMode(0);
+#endif
 }
 
 node::Environment* NodeBindings::CreateEnvironment(

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -208,6 +208,15 @@ This method guarantees that all `beforeunload` and `unload` event handlers are
 correctly executed. It is possible that a window cancels the quitting by
 returning `false` in the `beforeunload` event handler.
 
+### `app.exit(exitCode)`
+
+* `exitCode` Integer
+
+Exits immediately with `exitCode`.
+
+All windows will be closed immediately without asking user and the `before-quit`
+and `will-quit` events will not be emitted.
+
 ### `app.getAppPath()`
 
 Returns the current application directory.

--- a/spec/api-crash-reporter-spec.coffee
+++ b/spec/api-crash-reporter-spec.coffee
@@ -53,5 +53,6 @@ describe 'crash-reporter module', ->
         protocol: 'file'
         pathname: path.join fixtures, 'api', 'crash.html'
         search: "?port=#{port}"
-      crashReporter.start {'submitUrl': 'http://127.0.0.1:' + port}
+      if process.platform is 'darwin'
+        crashReporter.start {'submitUrl': 'http://127.0.0.1:' + port}
       w.loadUrl url


### PR DESCRIPTION
Instead of abrupting the whole program immediately, we should close all
windows and release all native resources gracefully on exit. This avoids
possible crashes.

Fix #3350.