### PR TITLE
Add option to build local libchromiumcontent

### DIFF
--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -41,7 +41,8 @@ def main():
   elif (args.libcc_source_path != None or
         args.libcc_shared_library_path != None or
         args.libcc_static_library_path != None):
-    print "Error: All options of libchromiumcontent are required OR let electron choose it"
+    print "Error: All options of libchromiumcontent are required OR let " \
+          "electron choose it"
     sys.exit(0)
   if not args.yes and PLATFORM != 'win32':
     check_root()
@@ -90,11 +91,17 @@ def parse_args():
   parser.add_argument('--target_arch', default=get_target_arch(),
                       help='Manually specify the arch to build for')
   parser.add_argument('--libcc_source_path', required=False,
-                        help='The source path of libchromiumcontent. NOTE: All options of libchromiumcontent are required OR let electron choose it')
+                        help='The source path of libchromiumcontent. ' \
+                        'NOTE: All options of libchromiumcontent are '
+                        'required OR let electron choose it')
   parser.add_argument('--libcc_shared_library_path', required=False,
-                        help='The shared library path of libchromiumcontent. NOTE: All options of libchromiumcontent are required OR let electron choose it')
+                        help='The shared library path of libchromiumcontent. ' \
+                        'NOTE: All options of libchromiumcontent are ' \
+                        'required OR let electron choose it')
   parser.add_argument('--libcc_static_library_path', required=False,
-                        help='The static library path of libchromiumcontent. NOTE: All options of libchromiumcontent are required OR let electron choose it')
+                        help='The static library path of libchromiumcontent. ' \
+                        'NOTE: All options of libchromiumcontent are ' \
+                        'required OR let electron choose it')
   return parser.parse_args()
 
 

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -26,6 +26,23 @@ def main():
   os.chdir(SOURCE_ROOT)
 
   args = parse_args()
+  if (args.libcc_source_path != None and
+      args.libcc_shared_library_path != None and
+      args.libcc_static_library_path != None):
+    if (not os.path.isdir(args.libcc_source_path)):
+      print "Error: Directory does not exist:", args.libcc_source_path
+      sys.exit(0)
+    elif (not os.path.isdir(args.libcc_shared_library_path)):
+      print "Error: Directory does not exist:", args.libcc_shared_library_path
+      sys.exit(0)
+    elif (not os.path.isdir(args.libcc_static_library_path)):
+      print "Error: Directory does not exist:", args.libcc_static_library_path
+      sys.exit(0)
+  elif (args.libcc_source_path != None or
+        args.libcc_shared_library_path != None or
+        args.libcc_static_library_path != None):
+    print "Error: All options of libchromiumcontent are required OR let electron choose it"
+    sys.exit(0)
   if not args.yes and PLATFORM != 'win32':
     check_root()
   if args.verbose:
@@ -39,7 +56,10 @@ def main():
   update_submodules()
   setup_python_libs()
   update_node_modules('.')
-  bootstrap_brightray(args.dev, args.url, args.target_arch)
+  bootstrap_brightray(args.dev, args.url, args.target_arch,
+                      args.libcc_source_path,
+                      args.libcc_shared_library_path,
+                      args.libcc_static_library_path)
 
   if args.target_arch in ['arm', 'ia32'] and PLATFORM == 'linux':
     download_sysroot(args.target_arch)
@@ -69,6 +89,12 @@ def parse_args():
                            'prompts.')
   parser.add_argument('--target_arch', default=get_target_arch(),
                       help='Manually specify the arch to build for')
+  parser.add_argument('--libcc_source_path', required=False,
+                        help='The source path of libchromiumcontent. NOTE: All options of libchromiumcontent are required OR let electron choose it')
+  parser.add_argument('--libcc_shared_library_path', required=False,
+                        help='The shared library path of libchromiumcontent. NOTE: All options of libchromiumcontent are required OR let electron choose it')
+  parser.add_argument('--libcc_static_library_path', required=False,
+                        help='The static library path of libchromiumcontent. NOTE: All options of libchromiumcontent are required OR let electron choose it')
   return parser.parse_args()
 
 
@@ -91,15 +117,23 @@ def setup_python_libs():
       execute_stdout([sys.executable, 'setup.py', 'build'])
 
 
-def bootstrap_brightray(is_dev, url, target_arch):
+def bootstrap_brightray(is_dev, url, target_arch, libcc_source_path,
+                        libcc_shared_library_path,
+                        libcc_static_library_path):
   bootstrap = os.path.join(VENDOR_DIR, 'brightray', 'script', 'bootstrap')
   args = [
     '--commit', LIBCHROMIUMCONTENT_COMMIT,
     '--target_arch', target_arch,
-    url,
+    url
   ]
   if is_dev:
     args = ['--dev'] + args
+  if (libcc_source_path != None and
+      libcc_shared_library_path != None and
+      libcc_static_library_path != None):
+    args = args + ['--libcc_source_path', libcc_source_path,
+                  '--libcc_shared_library_path', libcc_shared_library_path,
+                  '--libcc_static_library_path', libcc_static_library_path]
   execute_stdout([sys.executable, bootstrap] + args)
 
 


### PR DESCRIPTION
- Currently libchromiumcontent is downloaded by default.
- Now developer can choose to provide local libchromiumcontent src, shared and static path

Tries to solve similar issue noted in: [atom/electron#3310]