### PR TITLE
Add --js-flags support for main thread.

### DIFF
--- a/atom/browser/javascript_environment.cc
+++ b/atom/browser/javascript_environment.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <string>
+
 #include "atom/browser/javascript_environment.h"
 
 #include "base/command_line.h"
@@ -27,8 +29,18 @@ bool JavascriptEnvironment::Initialize() {
     const char expose_debug_as[] = "--expose_debug_as=v8debug";
     v8::V8::SetFlagsFromString(expose_debug_as, sizeof(expose_debug_as) - 1);
   }
+
+  const std::string js_flags_switch = "js-flags";
+
+  if (cmd->HasSwitch(js_flags_switch)) {
+    const char *js_flags_value =
+      cmd->GetSwitchValueASCII(js_flags_switch)).c_str();
+    v8::V8::SetFlagsFromString(js_flags_value, strlen(js_flags_value));
+  }
+
   gin::IsolateHolder::Initialize(gin::IsolateHolder::kNonStrictMode,
                                  gin::ArrayBufferAllocator::SharedInstance());
+
   return true;
 }
 


### PR DESCRIPTION
Allow use of flags that must be set before V8 is initialized, such as
"--harmony_proxies"

Example:
```
electron --js-flags="--harmony_proxies --harmony_collections" .
```