### PR TITLE
Separate options from switches

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -127,16 +127,16 @@ Window::Window(v8::Isolate* isolate, const mate::Dictionary& options) {
 
   // Use options.webPreferences to create WebContents.
   mate::Dictionary web_preferences = mate::Dictionary::CreateEmpty(isolate);
-  options.Get(switches::kWebPreferences, &web_preferences);
+  options.Get(options::kWebPreferences, &web_preferences);
 
   // Be compatible with old options which are now in web_preferences.
   v8::Local<v8::Value> value;
-  if (options.Get(switches::kNodeIntegration, &value))
-    web_preferences.Set(switches::kNodeIntegration, value);
-  if (options.Get(switches::kPreloadScript, &value))
-    web_preferences.Set(switches::kPreloadScript, value);
-  if (options.Get(switches::kZoomFactor, &value))
-    web_preferences.Set(switches::kZoomFactor, value);
+  if (options.Get(options::kNodeIntegration, &value))
+    web_preferences.Set(options::kNodeIntegration, value);
+  if (options.Get(options::kPreloadScript, &value))
+    web_preferences.Set(options::kPreloadScript, value);
+  if (options.Get(options::kZoomFactor, &value))
+    web_preferences.Set(options::kZoomFactor, value);
 
   // Creates the WebContents used by BrowserWindow.
   auto web_contents = WebContents::Create(isolate, web_preferences);

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -56,16 +56,16 @@ NativeWindow::NativeWindow(
       aspect_ratio_(0.0),
       inspectable_web_contents_(inspectable_web_contents),
       weak_factory_(this) {
-  options.Get(switches::kFrame, &has_frame_);
-  options.Get(switches::kTransparent, &transparent_);
-  options.Get(switches::kEnableLargerThanScreen, &enable_larger_than_screen_);
+  options.Get(options::kFrame, &has_frame_);
+  options.Get(options::kTransparent, &transparent_);
+  options.Get(options::kEnableLargerThanScreen, &enable_larger_than_screen_);
 
   // Tell the content module to initialize renderer widget with transparent
   // mode.
   ui::GpuSwitchingManager::SetTransparent(transparent_);
 
   // Read icon before window is created.
-  options.Get(switches::kIcon, &icon_);
+  options.Get(options::kIcon, &icon_);
 
   WindowList::AddWindow(this);
 }
@@ -91,25 +91,25 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   // Setup window from options.
   int x = -1, y = -1;
   bool center;
-  if (options.Get(switches::kX, &x) && options.Get(switches::kY, &y)) {
+  if (options.Get(options::kX, &x) && options.Get(options::kY, &y)) {
     SetPosition(gfx::Point(x, y));
-  } else if (options.Get(switches::kCenter, &center) && center) {
+  } else if (options.Get(options::kCenter, &center) && center) {
     Center();
   }
   // On Linux and Window we may already have maximum size defined.
   extensions::SizeConstraints size_constraints(GetContentSizeConstraints());
   int min_height = 0, min_width = 0;
-  if (options.Get(switches::kMinHeight, &min_height) |
-      options.Get(switches::kMinWidth, &min_width)) {
+  if (options.Get(options::kMinHeight, &min_height) |
+      options.Get(options::kMinWidth, &min_width)) {
     size_constraints.set_minimum_size(gfx::Size(min_width, min_height));
   }
   int max_height = INT_MAX, max_width = INT_MAX;
-  if (options.Get(switches::kMaxHeight, &max_height) |
-      options.Get(switches::kMaxWidth, &max_width)) {
+  if (options.Get(options::kMaxHeight, &max_height) |
+      options.Get(options::kMaxWidth, &max_width)) {
     size_constraints.set_maximum_size(gfx::Size(max_width, max_height));
   }
   bool use_content_size = false;
-  options.Get(switches::kUseContentSize, &use_content_size);
+  options.Get(options::kUseContentSize, &use_content_size);
   if (use_content_size) {
     SetContentSizeConstraints(size_constraints);
   } else {
@@ -117,39 +117,39 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   }
 #if defined(OS_WIN) || defined(USE_X11)
   bool resizable;
-  if (options.Get(switches::kResizable, &resizable)) {
+  if (options.Get(options::kResizable, &resizable)) {
     SetResizable(resizable);
   }
 #endif
   bool top;
-  if (options.Get(switches::kAlwaysOnTop, &top) && top) {
+  if (options.Get(options::kAlwaysOnTop, &top) && top) {
     SetAlwaysOnTop(true);
   }
 #if defined(OS_MACOSX) || defined(OS_WIN)
   bool fullscreen;
-  if (options.Get(switches::kFullscreen, &fullscreen) && fullscreen) {
+  if (options.Get(options::kFullscreen, &fullscreen) && fullscreen) {
     SetFullScreen(true);
   }
 #endif
   bool skip;
-  if (options.Get(switches::kSkipTaskbar, &skip) && skip) {
+  if (options.Get(options::kSkipTaskbar, &skip) && skip) {
     SetSkipTaskbar(skip);
   }
   bool kiosk;
-  if (options.Get(switches::kKiosk, &kiosk) && kiosk) {
+  if (options.Get(options::kKiosk, &kiosk) && kiosk) {
     SetKiosk(kiosk);
   }
   std::string color;
-  if (options.Get(switches::kBackgroundColor, &color)) {
+  if (options.Get(options::kBackgroundColor, &color)) {
     SetBackgroundColor(color);
   }
   std::string title("Electron");
-  options.Get(switches::kTitle, &title);
+  options.Get(options::kTitle, &title);
   SetTitle(title);
 
   // Then show it.
   bool show = true;
-  options.Get(switches::kShow, &show);
+  options.Get(options::kShow, &show);
   if (show)
     Show();
 }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -320,8 +320,8 @@ NativeWindowMac::NativeWindowMac(
       is_kiosk_(false),
       attention_request_id_(0) {
   int width = 800, height = 600;
-  options.Get(switches::kWidth, &width);
-  options.Get(switches::kHeight, &height);
+  options.Get(options::kWidth, &width);
+  options.Get(options::kHeight, &height);
 
   NSRect main_screen_rect = [[[NSScreen screens] objectAtIndex:0] frame];
   NSRect cocoa_bounds = NSMakeRect(
@@ -331,14 +331,14 @@ NativeWindowMac::NativeWindowMac(
       height);
 
   bool useStandardWindow = true;
-  options.Get(switches::kStandardWindow, &useStandardWindow);
+  options.Get(options::kStandardWindow, &useStandardWindow);
   bool resizable = true;
-  options.Get(switches::kResizable, &resizable);
+  options.Get(options::kResizable, &resizable);
 
   // New title bar styles are available in Yosemite or newer
   std::string titleBarStyle;
   if (base::mac::IsOSYosemiteOrLater())
-    options.Get(switches::kTitleBarStyle, &titleBarStyle);
+    options.Get(options::kTitleBarStyle, &titleBarStyle);
 
   NSUInteger styleMask = NSTitledWindowMask | NSClosableWindowMask |
                          NSMiniaturizableWindowMask;
@@ -394,23 +394,23 @@ NativeWindowMac::NativeWindowMac(
 
   // On OS X the initial window size doesn't include window frame.
   bool use_content_size = false;
-  options.Get(switches::kUseContentSize, &use_content_size);
+  options.Get(options::kUseContentSize, &use_content_size);
   if (!has_frame() || !use_content_size)
     SetSize(gfx::Size(width, height));
 
   // Enable the NSView to accept first mouse event.
   bool acceptsFirstMouse = false;
-  options.Get(switches::kAcceptFirstMouse, &acceptsFirstMouse);
+  options.Get(options::kAcceptFirstMouse, &acceptsFirstMouse);
   [window_ setAcceptsFirstMouse:acceptsFirstMouse];
 
   // Disable auto-hiding cursor.
   bool disableAutoHideCursor = false;
-  options.Get(switches::kDisableAutoHideCursor, &disableAutoHideCursor);
+  options.Get(options::kDisableAutoHideCursor, &disableAutoHideCursor);
   [window_ setDisableAutoHideCursor:disableAutoHideCursor];
 
   // Disable fullscreen button when 'fullscreen' is specified to false.
   bool fullscreen;
-  if (!(options.Get(switches::kFullscreen, &fullscreen) &&
+  if (!(options.Get(options::kFullscreen, &fullscreen) &&
         !fullscreen)) {
     NSUInteger collectionBehavior = [window_ collectionBehavior];
     collectionBehavior |= NSWindowCollectionBehaviorFullScreenPrimary;

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -132,13 +132,13 @@ NativeWindowViews::NativeWindowViews(
       keyboard_event_handler_(new views::UnhandledKeyboardEventHandler),
       use_content_size_(false),
       resizable_(true) {
-  options.Get(switches::kTitle, &title_);
-  options.Get(switches::kAutoHideMenuBar, &menu_bar_autohide_);
+  options.Get(options::kTitle, &title_);
+  options.Get(options::kAutoHideMenuBar, &menu_bar_autohide_);
 
 #if defined(OS_WIN)
   // On Windows we rely on the CanResize() to indicate whether window can be
   // resized, and it should be set before window is created.
-  options.Get(switches::kResizable, &resizable_);
+  options.Get(options::kResizable, &resizable_);
 #endif
 
   if (enable_larger_than_screen())
@@ -150,8 +150,8 @@ NativeWindowViews::NativeWindowViews(
         gfx::Size(), gfx::Size(INT_MAX / 10, INT_MAX / 10)));
 
   int width = 800, height = 600;
-  options.Get(switches::kWidth, &width);
-  options.Get(switches::kHeight, &height);
+  options.Get(options::kWidth, &width);
+  options.Get(options::kHeight, &height);
   gfx::Rect bounds(0, 0, width, height);
   widget_size_ = bounds.size();
 
@@ -187,7 +187,7 @@ NativeWindowViews::NativeWindowViews(
   window_->Init(params);
 
   bool fullscreen = false;
-  options.Get(switches::kFullscreen, &fullscreen);
+  options.Get(options::kFullscreen, &fullscreen);
 
 #if defined(USE_X11)
   // Start monitoring window states.
@@ -195,7 +195,7 @@ NativeWindowViews::NativeWindowViews(
 
   // Set _GTK_THEME_VARIANT to dark if we have "dark-theme" option set.
   bool use_dark_theme = false;
-  if (options.Get(switches::kDarkTheme, &use_dark_theme) && use_dark_theme) {
+  if (options.Get(options::kDarkTheme, &use_dark_theme) && use_dark_theme) {
     XDisplay* xdisplay = gfx::GetXDisplay();
     XChangeProperty(xdisplay, GetAcceleratedWidget(),
                     XInternAtom(xdisplay, "_GTK_THEME_VARIANT", False),
@@ -209,7 +209,7 @@ NativeWindowViews::NativeWindowViews(
   // to manually set the _NET_WM_STATE.
   std::vector<::Atom> state_atom_list;
   bool skip_taskbar = false;
-  if (options.Get(switches::kSkipTaskbar, &skip_taskbar) && skip_taskbar) {
+  if (options.Get(options::kSkipTaskbar, &skip_taskbar) && skip_taskbar) {
     state_atom_list.push_back(GetAtom("_NET_WM_STATE_SKIP_TASKBAR"));
   }
 
@@ -223,7 +223,7 @@ NativeWindowViews::NativeWindowViews(
 
   // Set the _NET_WM_WINDOW_TYPE.
   std::string window_type;
-  if (options.Get(switches::kType, &window_type))
+  if (options.Get(options::kType, &window_type))
     SetWindowType(GetAcceleratedWidget(), window_type);
 #endif
 
@@ -274,7 +274,7 @@ NativeWindowViews::NativeWindowViews(
 
   gfx::Size size = bounds.size();
   if (has_frame() &&
-      options.Get(switches::kUseContentSize, &use_content_size_) &&
+      options.Get(options::kUseContentSize, &use_content_size_) &&
       use_content_size_)
     size = ContentSizeToWindowSize(size);
 

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -25,13 +25,23 @@ namespace atom {
 namespace {
 
 // Array of available web runtime features.
-const char* kWebRuntimeFeatures[] = {
-  switches::kExperimentalFeatures,
-  switches::kExperimentalCanvasFeatures,
-  switches::kOverlayScrollbars,
-  switches::kOverlayFullscreenVideo,
-  switches::kSharedWorker,
-  switches::kPageVisibility,
+struct FeaturePair {
+  const char* name;
+  const char* cmd;
+};
+FeaturePair kWebRuntimeFeatures[] = {
+  { options::kExperimentalFeatures,
+    switches::kExperimentalFeatures },
+  { options::kExperimentalCanvasFeatures,
+    switches::kExperimentalCanvasFeatures },
+  { options::kOverlayScrollbars,
+    switches::kOverlayScrollbars },
+  { options::kOverlayFullscreenVideo,
+    switches::kOverlayFullscreenVideo },
+  { options::kSharedWorker,
+    switches::kSharedWorker },
+  { options::kPageVisibility,
+    switches::kPageVisibility },
 };
 
 }  // namespace
@@ -69,7 +79,7 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
   bool b;
 #if defined(OS_WIN)
   // Check if DirectWrite is disabled.
-  if (web_preferences.GetBoolean(switches::kDirectWrite, &b) && !b)
+  if (web_preferences.GetBoolean(options::kDirectWrite, &b) && !b)
     command_line->AppendSwitch(::switches::kDisableDirectWrite);
 #endif
 
@@ -80,17 +90,17 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
   // This set of options are not availabe in WebPreferences, so we have to pass
   // them via command line and enable them in renderer procss.
   for (size_t i = 0; i < arraysize(kWebRuntimeFeatures); ++i) {
-    const char* feature = kWebRuntimeFeatures[i];
-    if (web_preferences.GetBoolean(feature, &b))
-      command_line->AppendSwitchASCII(feature, b ? "true" : "false");
+    const auto& feature = kWebRuntimeFeatures[i];
+    if (web_preferences.GetBoolean(feature.name, &b))
+      command_line->AppendSwitchASCII(feature.cmd, b ? "true" : "false");
   }
 
   // Check if we have node integration specified.
   bool node_integration = true;
-  web_preferences.GetBoolean(switches::kNodeIntegration, &node_integration);
+  web_preferences.GetBoolean(options::kNodeIntegration, &node_integration);
   // Be compatible with old API of "node-integration" option.
   std::string old_token;
-  if (web_preferences.GetString(switches::kNodeIntegration, &old_token) &&
+  if (web_preferences.GetString(options::kNodeIntegration, &old_token) &&
       old_token != "disable")
     node_integration = true;
   command_line->AppendSwitchASCII(switches::kNodeIntegration,
@@ -98,12 +108,12 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
 
   // The preload script.
   base::FilePath::StringType preload;
-  if (web_preferences.GetString(switches::kPreloadScript, &preload)) {
+  if (web_preferences.GetString(options::kPreloadScript, &preload)) {
     if (base::FilePath(preload).IsAbsolute())
       command_line->AppendSwitchNative(switches::kPreloadScript, preload);
     else
       LOG(ERROR) << "preload script must have absolute path.";
-  } else if (web_preferences.GetString(switches::kPreloadUrl, &preload)) {
+  } else if (web_preferences.GetString(options::kPreloadUrl, &preload)) {
     // Translate to file path if there is "preload-url" option.
     base::FilePath preload_path;
     if (net::FileURLToFilePath(GURL(preload), &preload_path))
@@ -114,15 +124,14 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
 
   // The zoom factor.
   double zoom_factor = 1.0;
-  if (web_preferences.GetDouble(switches::kZoomFactor, &zoom_factor) &&
+  if (web_preferences.GetDouble(options::kZoomFactor, &zoom_factor) &&
       zoom_factor != 1.0)
     command_line->AppendSwitchASCII(switches::kZoomFactor,
                                     base::DoubleToString(zoom_factor));
 
   // --guest-instance-id, which is used to identify guest WebContents.
   int guest_instance_id;
-  if (web_preferences.GetInteger(switches::kGuestInstanceID,
-                                 &guest_instance_id))
+  if (web_preferences.GetInteger(options::kGuestInstanceID, &guest_instance_id))
       command_line->AppendSwitchASCII(switches::kGuestInstanceID,
                                       base::IntToString(guest_instance_id));
 }
@@ -152,8 +161,7 @@ void WebContentsPreferences::OverrideWebkitPrefs(
     prefs->allow_displaying_insecure_content = !b;
     prefs->allow_running_insecure_content = !b;
   }
-  if (self->web_preferences_.GetBoolean("allowDisplayingInsecureContent",
-                                        &b))
+  if (self->web_preferences_.GetBoolean("allowDisplayingInsecureContent", &b))
     prefs->allow_displaying_insecure_content = b;
   if (self->web_preferences_.GetBoolean("allowRunningInsecureContent", &b))
     prefs->allow_running_insecure_content = b;

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -6,7 +6,7 @@
 
 namespace atom {
 
-namespace switches {
+namespace options {
 
 const char kTitle[]      = "title";
 const char kIcon[]       = "icon";
@@ -85,12 +85,22 @@ const char kNodeIntegration[] = "nodeIntegration";
 // Instancd ID of guest WebContents.
 const char kGuestInstanceID[] = "guestInstanceId";
 
+// Set page visiblity to always visible.
+const char kPageVisibility[] = "pageVisibility";
+
+// Enable DirectWrite on Windows.
+const char kDirectWrite[] = "directWrite";
+
 // Web runtime features.
 const char kExperimentalFeatures[]       = "experimentalFeatures";
 const char kExperimentalCanvasFeatures[] = "experimentalCanvasFeatures";
 const char kOverlayScrollbars[]          = "overlayScrollbars";
 const char kOverlayFullscreenVideo[]     = "overlayFullscreenVideo";
 const char kSharedWorker[]               = "sharedWorker";
+
+}  // namespace options
+
+namespace switches {
 
 // Enable plugins.
 const char kEnablePlugins[] = "enable-plugins";
@@ -100,12 +110,6 @@ const char kPpapiFlashPath[] = "ppapi-flash-path";
 
 // Ppapi Flash version.
 const char kPpapiFlashVersion[] = "ppapi-flash-version";
-
-// Set page visiblity to always visible.
-const char kPageVisibility[] = "page-visibility";
-
-// Enable DirectWrite on Windows.
-const char kDirectWrite[] = "direct-write";
 
 // Path to client certificate.
 const char kClientCertificate[] = "client-certificate";
@@ -125,6 +129,19 @@ const char kCipherSuiteBlacklist[] = "cipher-suite-blacklist";
 
 // The browser process app model ID
 const char kAppUserModelId[] = "app-user-model-id";
+
+// The command line switch versions of the options.
+const char kZoomFactor[]                 = "zoom-factor";
+const char kPreloadScript[]              = "preload";
+const char kPreloadUrl[]                 = "preload-url";
+const char kNodeIntegration[]            = "node-integration";
+const char kGuestInstanceID[]            = "guest-instance-id";
+const char kExperimentalFeatures[]       = "experimental-features";
+const char kExperimentalCanvasFeatures[] = "experimental-canvas-features";
+const char kOverlayScrollbars[]          = "overlay-scrollbars";
+const char kOverlayFullscreenVideo[]     = "overlay-fullscreen-video";
+const char kSharedWorker[]               = "shared-worker";
+const char kPageVisibility[]             = "page-visiblity";
 
 }  // namespace switches
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -7,7 +7,7 @@
 
 namespace atom {
 
-namespace switches {
+namespace options {
 
 extern const char kTitle[];
 extern const char kIcon[];
@@ -41,6 +41,7 @@ extern const char kBackgroundColor[];
 extern const char kWebPreferences[];
 
 // WebPreferences.
+extern const char kDirectWrite[];
 extern const char kZoomFactor[];
 extern const char kPreloadScript[];
 extern const char kPreloadUrl[];
@@ -52,9 +53,14 @@ extern const char kOverlayScrollbars[];
 extern const char kOverlayFullscreenVideo[];
 extern const char kSharedWorker[];
 extern const char kPageVisibility[];
-extern const char kDirectWrite[];
+
+}   // namespace options
+
 
 // Following are actually command line switches, should be moved to other files.
+
+namespace switches {
+
 extern const char kEnablePlugins[];
 extern const char kPpapiFlashPath[];
 extern const char kPpapiFlashVersion[];
@@ -64,6 +70,18 @@ extern const char kRegisterStandardSchemes[];
 extern const char kSSLVersionFallbackMin[];
 extern const char kCipherSuiteBlacklist[];
 extern const char kAppUserModelId[];
+
+extern const char kZoomFactor[];
+extern const char kPreloadScript[];
+extern const char kPreloadUrl[];
+extern const char kNodeIntegration[];
+extern const char kGuestInstanceID[];
+extern const char kExperimentalFeatures[];
+extern const char kExperimentalCanvasFeatures[];
+extern const char kOverlayScrollbars[];
+extern const char kOverlayFullscreenVideo[];
+extern const char kSharedWorker[];
+extern const char kPageVisibility[];
 
 }  // namespace switches
 

--- a/atom/renderer/lib/init.coffee
+++ b/atom/renderer/lib/init.coffee
@@ -27,10 +27,10 @@ v8Util.setHiddenValue global, 'ipc', new events.EventEmitter
 # Process command line arguments.
 nodeIntegration = 'false'
 for arg in process.argv
-  if arg.indexOf('--guestInstanceId=') == 0
+  if arg.indexOf('--guest-instance-id=') == 0
     # This is a guest web view.
     process.guestInstanceId = parseInt arg.substr(arg.indexOf('=') + 1)
-  else if arg.indexOf('--nodeIntegration=') == 0
+  else if arg.indexOf('--node-integration=') == 0
     nodeIntegration = arg.substr arg.indexOf('=') + 1
   else if arg.indexOf('--preload=') == 0
     preloadScript = arg.substr arg.indexOf('=') + 1


### PR DESCRIPTION
On Windows the case sensitivity of command line switches are ignored, so `--nodeIntegraion` will become `--nodeintegration`.

We should separate options from switches so we use `nodeIntegraion` in options, while passing `--node-integration` in command line.