### PR TITLE
Rename the "clicked" event to "click" in Tray

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -44,21 +44,21 @@ mate::Wrappable* Tray::New(v8::Isolate* isolate, const gfx::Image& image) {
 void Tray::OnClicked(const gfx::Rect& bounds, int modifiers) {
   v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
-  EmitCustomEvent("clicked",
+  EmitCustomEvent("click",
                   ModifiersToObject(isolate(), modifiers), bounds);
 }
 
 void Tray::OnDoubleClicked(const gfx::Rect& bounds, int modifiers) {
   v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
-  EmitCustomEvent("double-clicked",
+  EmitCustomEvent("double-click",
                   ModifiersToObject(isolate(), modifiers), bounds);
 }
 
 void Tray::OnRightClicked(const gfx::Rect& bounds, int modifiers) {
   v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
-  EmitCustomEvent("right-clicked",
+  EmitCustomEvent("right-click",
                   ModifiersToObject(isolate(), modifiers), bounds);
 }
 
@@ -67,7 +67,7 @@ void Tray::OnBalloonShow() {
 }
 
 void Tray::OnBalloonClicked() {
-  Emit("balloon-clicked");
+  Emit("balloon-click");
 }
 
 void Tray::OnBalloonClosed() {

--- a/atom/browser/api/lib/browser-window.coffee
+++ b/atom/browser/api/lib/browser-window.coffee
@@ -1,7 +1,7 @@
 {app, ipcMain, deprecate} = require 'electron'
 {EventEmitter} = require 'events'
 
-BrowserWindow = process.atomBinding('window').BrowserWindow
+{BrowserWindow} = process.atomBinding 'window'
 BrowserWindow::__proto__ = EventEmitter.prototype
 
 BrowserWindow::_init = ->

--- a/atom/browser/api/lib/tray.coffee
+++ b/atom/browser/api/lib/tray.coffee
@@ -1,13 +1,19 @@
+{deprecate} = require 'electron'
 {EventEmitter} = require 'events'
-{Tray} = process.atomBinding 'tray'
 
+{Tray} = process.atomBinding 'tray'
 Tray::__proto__ = EventEmitter.prototype
+
+Tray::_init = ->
+  # Deprecated.
+  deprecate.rename this, 'popContextMenu', 'popUpContextMenu'
+  deprecate.event this, 'clicked', 'click'
+  deprecate.event this, 'double-clicked', 'double-click'
+  deprecate.event this, 'right-clicked', 'right-click'
+  deprecate.event this, 'balloon-clicked', 'balloon-click'
 
 Tray::setContextMenu = (menu) ->
   @_setContextMenu menu
   @menu = menu  # Keep a strong reference of menu.
-
-# Keep compatibility with old APIs.
-Tray::popContextMenu = Tray::popUpContextMenu
 
 module.exports = Tray

--- a/atom/common/api/lib/deprecate.coffee
+++ b/atom/common/api/lib/deprecate.coffee
@@ -42,12 +42,15 @@ deprecate.property = (object, property, method) ->
 # Deprecate an event.
 deprecate.event = (emitter, oldName, newName, fn) ->
   warned = false
-  emitter.on newName, ->
+  emitter.on newName, (args...) ->
     if @listenerCount(oldName) > 0  # there is listeners for old API.
       unless warned or process.noDeprecation
         warned = true
         deprecate.warn "'#{oldName}' event", "'#{newName}' event"
-      fn.apply this, arguments
+      if fn?
+        fn.apply this, arguments
+      else
+        @emit oldName, args...
 
 # Print deprecate warning.
 deprecate.warn = (oldName, newName) ->

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -31,10 +31,10 @@ __Platform limitations:__
 * On Linux distributions that only have app indicator support, you have to
   install `libappindicator1` to make the tray icon work.
 * App indicator will only be shown when it has a context menu.
-* When app indicator is used on Linux, the `clicked` event is ignored.
+* When app indicator is used on Linux, the `click` event is ignored.
 
 If you want to keep exact same behaviors on all platforms, you should not
-rely on the `clicked` event and always attach a context menu to the tray icon.
+rely on the `click` event and always attach a context menu to the tray icon.
 
 ## Class: Tray
 
@@ -53,7 +53,7 @@ The `Tray` module emits the following events:
 **Note:** Some events are only available on specific operating systems and are
 labeled as such.
 
-### Event: 'clicked'
+### Event: 'click'
 
 * `event` Event
   * `altKey` Boolean
@@ -70,7 +70,7 @@ Emitted when the tray icon is clicked.
 
 __Note:__ The `bounds` payload is only implemented on OS X and Windows.
 
-### Event: 'right-clicked' _OS X_ _Windows_
+### Event: 'right-click' _OS X_ _Windows_
 
 * `event` Event
   * `altKey` Boolean
@@ -85,7 +85,7 @@ __Note:__ The `bounds` payload is only implemented on OS X and Windows.
 
 Emitted when the tray icon is right clicked.
 
-### Event: 'double-clicked' _OS X_ _Windows_
+### Event: 'double-click' _OS X_ _Windows_
 
 * `event` Event
   * `altKey` Boolean
@@ -104,7 +104,7 @@ Emitted when the tray icon is double clicked.
 
 Emitted when the tray balloon shows.
 
-### Event: 'balloon-clicked' _Windows_
+### Event: 'balloon-click' _Windows_
 
 Emitted when the tray balloon is clicked.
 


### PR DESCRIPTION
Old events are still supported with deprecation warnings.

Refs #2544.