### PR TITLE
browser: fix reloadignoringcache api

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -658,10 +658,6 @@ void WebContents::Stop() {
   web_contents()->Stop();
 }
 
-void WebContents::ReloadIgnoringCache() {
-  web_contents()->GetController().ReloadIgnoringCache(false);
-}
-
 void WebContents::GoBack() {
   atom::AtomBrowserClient::SuppressRendererProcessRestartForOnce();
   web_contents()->GetController().GoBack();
@@ -1009,7 +1005,6 @@ mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
         .SetMethod("isLoading", &WebContents::IsLoading)
         .SetMethod("isWaitingForResponse", &WebContents::IsWaitingForResponse)
         .SetMethod("_stop", &WebContents::Stop)
-        .SetMethod("_reloadIgnoringCache", &WebContents::ReloadIgnoringCache)
         .SetMethod("_goBack", &WebContents::GoBack)
         .SetMethod("_goForward", &WebContents::GoForward)
         .SetMethod("_goToOffset", &WebContents::GoToOffset)

--- a/atom/browser/api/lib/navigation-controller.coffee
+++ b/atom/browser/api/lib/navigation-controller.coffee
@@ -62,8 +62,8 @@ class NavigationController
     @webContents._loadURL @getURL(), {}
 
   reloadIgnoringCache: ->
-    @webContents._reloadIgnoringCache()  # Rely on WebContents to clear cache.
-    @reload()
+    @pendingIndex = @currentIndex
+    @webContents._loadURL @getURL(), {extraHeaders: "pragma: no-cache\n"}
 
   canGoBack: ->
     @getActiveIndex() > 0

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -207,7 +207,13 @@ See [session documentation](session.md) for this object's methods.
   * `extraHeaders` String - Extra headers separated by "\n"
 
 Loads the `url` in the window, the `url` must contain the protocol prefix,
-e.g. the `http://` or `file://`.
+e.g. the `http://` or `file://`. If the load should bypass http cache then
+use the `pragma` header to achieve it.
+
+```javascript
+const options = {"extraHeaders" : "pragma: no-cache\n"}
+webContents.loadURL(url, options)
+```
 
 ### `webContents.getURL()`
 


### PR DESCRIPTION
A more reliable way to bypass cache.

Fixes #3393 
Ref #1360 