### PR TITLE
docs: Use absolute URLs

### DIFF
--- a/docs-translations/es/development/atom-shell-vs-node-webkit.md
+++ b/docs-translations/es/development/atom-shell-vs-node-webkit.md
@@ -22,7 +22,7 @@ Con el fin de evitar la complejidad de la construcción de todo Chromium, Electr
 
 In NW.js, the Node integration in web pages requires patching Chromium to work, while in Electron we chose a different way to integrate the libuv loop with each platform's message loop to avoid hacking Chromium. See the node_bindings code for how that was done.
 
-En NW.js, la integración de Node en las páginas web requiere parchear Chromium para que funcione, mientras que en Electron elegimos una manera diferente para integrar el cilco libuv con cada ciclo de mensaje de las plataformas para evitar el hacking en Chromium. Ver el código  `node_bindings` de cómo se hizo.
+En NW.js, la integración de Node en las páginas web requiere parchear Chromium para que funcione, mientras que en Electron elegimos una manera diferente para integrar el cilco libuv con cada ciclo de mensaje de las plataformas para evitar el hacking en Chromium. Ver el código [`node_bindings`][node-bindings] de cómo se hizo.
 
 
 **4. Multi-contexto**
@@ -31,4 +31,4 @@ Si usted es un usuario experimentado NW.js, usted debe estar familiarizado con e
 
 Mediante el uso de la característica [multi-contexto](http://strongloop.com/strongblog/whats-new-node-js-v0-12-multiple-context-execution/) de Node, Electron no introduce un nuevo contexto JavaScript en páginas web.Resultados de búsqueda
 
-    
+[node-bindings]: https://github.com/atom/electron/tree/master/atom/common

--- a/docs-translations/ko-KR/development/atom-shell-vs-node-webkit.md
+++ b/docs-translations/ko-KR/development/atom-shell-vs-node-webkit.md
@@ -26,10 +26,12 @@ Chromium의 Content API에 접근합니다. libchromiumcontent은 단일 공유 
 __3. Node 통합__
 
 NW.js는 웹 페이지에서 require를 사용할 수 있도록 Chromium을 패치했습니다. 한편 Electron은 Chromium의 해킹을 방지하기 위해 libuv loop와 각 플랫폼의 메시지 루프에 통합하는 등의 다른 방법을 채택하였습니다.
-[`node_bindings`](../../../atom/common/) 코드를 보면 이 부분이 어떻게 구현됬는지를 알 수 있습니다.
+[`node_bindings`][node-bindings] 코드를 보면 이 부분이 어떻게 구현됬는지를 알 수 있습니다.
 
 __4. 다중 컨텍스트__
 
 만약 NW.js를 사용해본적이 있다면 Node context와 Web context의 개념을 잘 알고 있을겁니다. 이 개념은 NW.js가 구현된 방식에 따라 만들어졌습니다.
 
 Node의 [다중 컨텍스트](http://strongloop.com/strongblog/whats-new-node-js-v0-12-multiple-context-execution/)를 사용할 경우 Electron은 웹 페이지에서 새로운 JavaScript 컨텍스트를 생성하지 않습니다.
+
+[node-bindings]: https://github.com/atom/electron/tree/master/atom/common

--- a/docs-translations/zh-CN/development/atom-shell-vs-node-webkit.md
+++ b/docs-translations/zh-CN/development/atom-shell-vs-node-webkit.md
@@ -20,10 +20,12 @@ __2. 构建系统__
 
 __3. Node 集成__
 
-在 NW.js，网页中的 Node 集成需要通过给 Chromium 打补丁来实现。但在 Electron 中，我们选择了另一种方式：通过各个平台的消息循环与 libuv 的循环集成，避免了直接在 Chromium 上做改动。你可以看 [`node_bindings`](../../atom/common/) 来了解这是如何完成的。
+在 NW.js，网页中的 Node 集成需要通过给 Chromium 打补丁来实现。但在 Electron 中，我们选择了另一种方式：通过各个平台的消息循环与 libuv 的循环集成，避免了直接在 Chromium 上做改动。你可以看 [`node_bindings`][node-bindings] 来了解这是如何完成的。
 
 __4. 多上下文__
 
 如果你是有经验的 NW.js 用户，你应该会熟悉 Node 上下文和 web 上下文的概念。这些概念的产生源于 NW.js 的实现方式。
 
 通过使用 Node 的[多上下文](http://strongloop.com/strongblog/whats-new-node-js-v0-12-multiple-context-execution/)特性，Electron不需要在网页中引入新的 JavaScript 上下文。
+
+[node-bindings]: https://github.com/atom/electron/tree/master/atom/common

--- a/docs/development/atom-shell-vs-node-webkit.md
+++ b/docs/development/atom-shell-vs-node-webkit.md
@@ -35,7 +35,7 @@ __3. Node Integration__
 In NW.js, the Node integration in web pages requires patching Chromium to
 work, while in Electron we chose a different way to integrate the libuv loop
 with each platform's message loop to avoid hacking Chromium. See the
-[`node_bindings`](../../../atom/common/) code for how that was done.
+[`node_bindings`][node-bindings] code for how that was done.
 
 __4. Multi-context__
 
@@ -46,3 +46,5 @@ of how NW.js was implemented.
 By using the [multi-context](http://strongloop.com/strongblog/whats-new-node-js-v0-12-multiple-context-execution/)
 feature of Node, Electron doesn't introduce a new JavaScript context in web
 pages.
+
+[node-bindings]: https://github.com/atom/electron/tree/master/atom/common


### PR DESCRIPTION
Relative paths in GitHub's repo do not work very well, and our docs site can not recognize them.