### PR TITLE
Fix sizing of Mac OS X tray icon after image change

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -158,7 +158,8 @@ Sets the title displayed aside of the tray icon in the status bar.
 
 * `highlight` Boolean
 
-Sets whether the tray icon is highlighted when it is clicked.
+Sets whether the tray icon's background becomes highlighted (in blue)
+when the tray icon is clicked. Defaults to true.
 
 ### `Tray.displayBalloon(options)` _Windows_
 


### PR DESCRIPTION
- Consolidate logic that applies view dimensions into a function
- Use `NSVariableStatusItemLength` instead of trying to sync status item width
- Use modern Obj-C syntax `@[], @{}` in a few places
- Recompute view bounds after updating image in `setImage:`

This fixes #3478