### PR TITLE
Rework of the certificate API

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -252,7 +252,7 @@ void App::AllowCertificateError(
   bool prevent_default = Emit("certificate-error",
                               WebContents::CreateFrom(isolate(), web_contents),
                               request_url,
-                              cert_error,
+                              net::ErrorToString(cert_error),
                               ssl_info.cert,
                               callback);
 

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -247,7 +247,7 @@ void App::SelectClientCertificate(
   std::shared_ptr<content::ClientCertificateDelegate>
       shared_delegate(delegate.release());
   bool prevent_default =
-      Emit("select-certificate",
+      Emit("select-client-certificate",
            api::WebContents::CreateFrom(isolate(), web_contents),
            cert_request_info->host_and_port.ToString(),
            cert_request_info->client_certs,

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "atom/browser/api/event_emitter.h"
+#include "atom/browser/atom_browser_client.h"
 #include "atom/browser/browser_observer.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "chrome/browser/process_singleton.h"
@@ -26,7 +27,8 @@ namespace atom {
 
 namespace api {
 
-class App : public mate::EventEmitter,
+class App : public AtomBrowserClient::Delegate,
+            public mate::EventEmitter,
             public BrowserObserver,
             public content::GpuDataManagerObserver {
  public:
@@ -46,11 +48,13 @@ class App : public mate::EventEmitter,
   void OnActivate(bool has_visible_windows) override;
   void OnWillFinishLaunching() override;
   void OnFinishLaunching() override;
-  void OnSelectCertificate(
+  void OnLogin(LoginHandler* login_handler) override;
+
+  // content::ContentBrowserClient:
+  void SelectClientCertificate(
       content::WebContents* web_contents,
       net::SSLCertRequestInfo* cert_request_info,
       scoped_ptr<content::ClientCertificateDelegate> delegate) override;
-  void OnLogin(LoginHandler* login_handler) override;
 
   // content::GpuDataManagerObserver:
   void OnGpuProcessCrashed(base::TerminationStatus exit_code) override;

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -51,6 +51,18 @@ class App : public AtomBrowserClient::Delegate,
   void OnLogin(LoginHandler* login_handler) override;
 
   // content::ContentBrowserClient:
+  void AllowCertificateError(
+      int render_process_id,
+      int render_frame_id,
+      int cert_error,
+      const net::SSLInfo& ssl_info,
+      const GURL& request_url,
+      content::ResourceType resource_type,
+      bool overridable,
+      bool strict_enforcement,
+      bool expired_previous_decision,
+      const base::Callback<void(bool)>& callback,
+      content::CertificateRequestResultType* request) override;
   void SelectClientCertificate(
       content::WebContents* web_contents,
       net::SSLCertRequestInfo* cert_request_info,

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -357,10 +357,10 @@ void Session::DisableNetworkEmulation() {
                  base::Passed(&conditions)));
 }
 
-void Session::SetCertVerifyProc(v8::Local<v8::Value> val, mate::Arguments* args) {
+void Session::SetCertVerifyProc(v8::Local<v8::Value> val,
+                                mate::Arguments* args) {
   AtomCertVerifier::VerifyProc proc;
-  if (val.IsEmpty() ||
-      !(val->IsNull() || mate::ConvertFromV8(args->isolate(), val, &proc))) {
+  if (!(val->IsNull() || mate::ConvertFromV8(args->isolate(), val, &proc))) {
     args->ThrowError("Must pass null or function");
     return;
   }

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -13,6 +13,7 @@
 #include "atom/browser/api/save_page_handler.h"
 #include "atom/browser/atom_browser_context.h"
 #include "atom/browser/atom_browser_main_parts.h"
+#include "atom/browser/net/atom_cert_verifier.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
@@ -243,7 +244,6 @@ void SetProxyInIO(net::URLRequestContextGetter* getter,
 Session::Session(AtomBrowserContext* browser_context)
     : browser_context_(browser_context) {
   AttachAsUserData(browser_context);
-  browser_context->cert_verifier()->SetDelegate(this);
 
   // Observe DownloadManger to get download notifications.
   content::BrowserContext::GetDownloadManager(browser_context)->
@@ -276,7 +276,6 @@ bool Session::IsDestroyed() const {
 }
 
 void Session::Destroy() {
-  browser_context_->cert_verifier()->SetDelegate(nullptr);
   browser_context_ = nullptr;
 }
 
@@ -358,6 +357,17 @@ void Session::DisableNetworkEmulation() {
                  base::Passed(&conditions)));
 }
 
+void Session::SetCertVerifyProc(v8::Local<v8::Value> val, mate::Arguments* args) {
+  AtomCertVerifier::VerifyProc proc;
+  if (val.IsEmpty() ||
+      !(val->IsNull() || mate::ConvertFromV8(args->isolate(), val, &proc))) {
+    args->ThrowError("Must pass null or function");
+    return;
+  }
+
+  browser_context_->cert_verifier()->SetVerifyProc(proc);
+}
+
 v8::Local<v8::Value> Session::Cookies(v8::Isolate* isolate) {
   if (cookies_.IsEmpty()) {
     auto handle = atom::api::Cookies::Create(isolate, browser_context());
@@ -376,6 +386,7 @@ mate::ObjectTemplateBuilder Session::GetObjectTemplateBuilder(
       .SetMethod("setDownloadPath", &Session::SetDownloadPath)
       .SetMethod("enableNetworkEmulation", &Session::EnableNetworkEmulation)
       .SetMethod("disableNetworkEmulation", &Session::DisableNetworkEmulation)
+      .SetMethod("setCertificateVerifyProc", &Session::SetCertVerifyProc)
       .SetProperty("cookies", &Session::Cookies);
 }
 

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -238,12 +238,6 @@ void SetProxyInIO(net::URLRequestContextGetter* getter,
   RunCallbackInUI(callback);
 }
 
-void PassVerificationResult(
-    scoped_refptr<AtomCertVerifier::CertVerifyRequest> request,
-    bool success) {
-  request->ContinueWithResult(success ? net::OK : net::ERR_FAILED);
-}
-
 }  // namespace
 
 Session::Session(AtomBrowserContext* browser_context)
@@ -260,19 +254,6 @@ Session::~Session() {
   content::BrowserContext::GetDownloadManager(browser_context())->
       RemoveObserver(this);
   Destroy();
-}
-
-void Session::RequestCertVerification(
-    const scoped_refptr<AtomCertVerifier::CertVerifyRequest>& request) {
-  bool prevent_default = Emit(
-      "untrusted-certificate",
-      request->args().hostname,
-      request->args().cert,
-      base::Bind(&PassVerificationResult, request));
-
-  if (!prevent_default)
-    // Tell the request to use the result of default verifier.
-    request->ContinueWithResult(net::ERR_IO_PENDING);
 }
 
 void Session::OnDownloadCreated(content::DownloadManager* manager,

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "atom/browser/api/trackable_object.h"
-#include "atom/browser/net/atom_cert_verifier.h"
 #include "content/public/browser/download_manager.h"
 #include "native_mate/handle.h"
 #include "net/base/completion_callback.h"
@@ -35,7 +34,6 @@ class AtomBrowserContext;
 namespace api {
 
 class Session: public mate::TrackableObject<Session>,
-               public AtomCertVerifier::Delegate,
                public content::DownloadManager::Observer {
  public:
   using ResolveProxyCallback = base::Callback<void(std::string)>;
@@ -74,6 +72,7 @@ class Session: public mate::TrackableObject<Session>,
   void SetDownloadPath(const base::FilePath& path);
   void EnableNetworkEmulation(const mate::Dictionary& options);
   void DisableNetworkEmulation();
+  void SetCertVerifyProc(v8::Local<v8::Value> proc, mate::Arguments* args);
   v8::Local<v8::Value> Cookies(v8::Isolate* isolate);
 
   // Cached object for cookies API.

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -54,10 +54,6 @@ class Session: public mate::TrackableObject<Session>,
   explicit Session(AtomBrowserContext* browser_context);
   ~Session();
 
-  // AtomCertVerifier::Delegate:
-  void RequestCertVerification(
-      const scoped_refptr<AtomCertVerifier::CertVerifyRequest>&) override;
-
   // content::DownloadManager::Observer:
   void OnDownloadCreated(content::DownloadManager* manager,
                          content::DownloadItem* item) override;

--- a/atom/browser/api/lib/app.coffee
+++ b/atom/browser/api/lib/app.coffee
@@ -52,6 +52,7 @@ deprecate.event app, 'finish-launching', 'ready', ->
     @emit 'finish-launching'
 deprecate.event app, 'activate-with-no-open-windows', 'activate', (event, hasVisibleWindows) ->
   @emit 'activate-with-no-open-windows' if not hasVisibleWindows
+deprecate.event app, 'select-certificate', 'select-client-certificate'
 
 # Wrappers for native classes.
 wrapSession = (session) ->

--- a/atom/browser/api/lib/app.coffee
+++ b/atom/browser/api/lib/app.coffee
@@ -38,6 +38,12 @@ app.getAppPath = ->
 # Helpers.
 app.resolveProxy = (url, callback) -> @defaultSession.resolveProxy url, callback
 
+# Routes the events to webContents.
+for name in ['login', 'certificate-error', 'select-client-certificate']
+  do (name) ->
+    app.on name, (event, webContents, args...) ->
+      webContents.emit name, event, args...
+
 # Deprecated.
 {deprecate} = electron
 app.getHomeDir = deprecate 'app.getHomeDir', 'app.getPath', ->

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -14,7 +14,6 @@
 #include "atom/browser/atom_quota_permission_context.h"
 #include "atom/browser/atom_resource_dispatcher_host_delegate.h"
 #include "atom/browser/atom_speech_recognition_manager_delegate.h"
-#include "atom/browser/browser.h"
 #include "atom/browser/native_window.h"
 #include "atom/browser/web_contents_preferences.h"
 #include "atom/browser/window_list.h"
@@ -88,7 +87,7 @@ void AtomBrowserClient::SetCustomSchemes(
   g_custom_schemes = JoinString(schemes, ',');
 }
 
-AtomBrowserClient::AtomBrowserClient() {
+AtomBrowserClient::AtomBrowserClient() : delegate_(nullptr) {
 }
 
 AtomBrowserClient::~AtomBrowserClient() {
@@ -222,10 +221,10 @@ void AtomBrowserClient::SelectClientCertificate(
     return;
   }
 
-  if (!cert_request_info->client_certs.empty())
-    Browser::Get()->ClientCertificateSelector(web_contents,
-                                              cert_request_info,
-                                              delegate.Pass());
+  if (!cert_request_info->client_certs.empty() && delegate_) {
+    delegate_->SelectClientCertificate(
+        web_contents, cert_request_info, delegate.Pass());
+  }
 }
 
 void AtomBrowserClient::ResourceDispatcherHostCreated() {

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -207,6 +207,26 @@ content::QuotaPermissionContext*
   return new AtomQuotaPermissionContext;
 }
 
+void AtomBrowserClient::AllowCertificateError(
+    int render_process_id,
+    int render_frame_id,
+    int cert_error,
+    const net::SSLInfo& ssl_info,
+    const GURL& request_url,
+    content::ResourceType resource_type,
+    bool overridable,
+    bool strict_enforcement,
+    bool expired_previous_decision,
+    const base::Callback<void(bool)>& callback,
+    content::CertificateRequestResultType* request) {
+  if (delegate_) {
+    delegate_->AllowCertificateError(
+        render_process_id, render_frame_id, cert_error, ssl_info, request_url,
+        resource_type, overridable, strict_enforcement,
+        expired_previous_decision, callback, request);
+  }
+}
+
 void AtomBrowserClient::SelectClientCertificate(
     content::WebContents* web_contents,
     net::SSLCertRequestInfo* cert_request_info,

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -31,6 +31,9 @@ class AtomBrowserClient : public brightray::BrowserClient,
   AtomBrowserClient();
   virtual ~AtomBrowserClient();
 
+  using Delegate = content::ContentBrowserClient;
+  void set_delegate(Delegate* delegate) { delegate_ = delegate; }
+
   // Don't force renderer process to restart for once.
   static void SuppressRendererProcessRestartForOnce();
   // Custom schemes to be registered to standard.
@@ -73,6 +76,8 @@ class AtomBrowserClient : public brightray::BrowserClient,
 
   scoped_ptr<AtomResourceDispatcherHostDelegate>
       resource_dispatcher_host_delegate_;
+
+  Delegate* delegate_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomBrowserClient);
 };

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -57,6 +57,18 @@ class AtomBrowserClient : public brightray::BrowserClient,
                                       int child_process_id) override;
   void DidCreatePpapiPlugin(content::BrowserPpapiHost* browser_host) override;
   content::QuotaPermissionContext* CreateQuotaPermissionContext() override;
+  void AllowCertificateError(
+      int render_process_id,
+      int render_frame_id,
+      int cert_error,
+      const net::SSLInfo& ssl_info,
+      const GURL& request_url,
+      content::ResourceType resource_type,
+      bool overridable,
+      bool strict_enforcement,
+      bool expired_previous_decision,
+      const base::Callback<void(bool)>& callback,
+      content::CertificateRequestResultType* request) override;
   void SelectClientCertificate(
       content::WebContents* web_contents,
       net::SSLCertRequestInfo* cert_request_info,

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -10,8 +10,6 @@
 #include "atom/browser/native_window.h"
 #include "atom/browser/window_list.h"
 #include "base/message_loop/message_loop.h"
-#include "content/public/browser/client_certificate_delegate.h"
-#include "net/ssl/ssl_cert_request_info.h"
 
 namespace atom {
 
@@ -139,17 +137,6 @@ void Browser::WillFinishLaunching() {
 void Browser::DidFinishLaunching() {
   is_ready_ = true;
   FOR_EACH_OBSERVER(BrowserObserver, observers_, OnFinishLaunching());
-}
-
-void Browser::ClientCertificateSelector(
-    content::WebContents* web_contents,
-    net::SSLCertRequestInfo* cert_request_info,
-    scoped_ptr<content::ClientCertificateDelegate> delegate) {
-  FOR_EACH_OBSERVER(BrowserObserver,
-                    observers_,
-                    OnSelectCertificate(web_contents,
-                                        cert_request_info,
-                                        delegate.Pass()));
 }
 
 void Browser::RequestLogin(LoginHandler* login_handler) {

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -126,12 +126,6 @@ class Browser : public WindowListObserver {
   void WillFinishLaunching();
   void DidFinishLaunching();
 
-  // Called when client certificate is required.
-  void ClientCertificateSelector(
-      content::WebContents* web_contents,
-      net::SSLCertRequestInfo* cert_request_info,
-      scoped_ptr<content::ClientCertificateDelegate> delegate);
-
   // Request basic auth login.
   void RequestLogin(LoginHandler* login_handler);
 

--- a/atom/browser/browser_observer.h
+++ b/atom/browser/browser_observer.h
@@ -7,17 +7,6 @@
 
 #include <string>
 
-#include "base/memory/scoped_ptr.h"
-#include "content/public/browser/client_certificate_delegate.h"
-
-namespace content {
-class WebContents;
-}
-
-namespace net {
-class SSLCertRequestInfo;
-}
-
 namespace atom {
 
 class LoginHandler;
@@ -52,12 +41,6 @@ class BrowserObserver {
   // The browser has finished loading.
   virtual void OnWillFinishLaunching() {}
   virtual void OnFinishLaunching() {}
-
-  // The browser requires client certificate.
-  virtual void OnSelectCertificate(
-      content::WebContents* web_contents,
-      net::SSLCertRequestInfo* cert_request_info,
-      scoped_ptr<content::ClientCertificateDelegate> delegate) {}
 
   // The browser requests HTTP login.
   virtual void OnLogin(LoginHandler* login_handler) {}

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -131,7 +131,7 @@ Returns:
 
 Emitted when a new [browserWindow](browser-window.md) is created.
 
-### Event: 'select-certificate'
+### Event: 'select-client-certificate'
 
 Returns:
 
@@ -151,7 +151,7 @@ and `callback` needs to be called with an entry filtered from the list. Using
 certificate from the store.
 
 ```javascript
-app.on('select-certificate', function(event, host, url, list, callback) {
+app.on('select-client-certificate', function(event, webContents, url, list, callback) {
   event.preventDefault();
   callback(list[0]);
 })

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -131,6 +131,35 @@ Returns:
 
 Emitted when a new [browserWindow](browser-window.md) is created.
 
+### Event: 'certificate-error'
+
+Returns:
+
+* `event` Event
+* `webContents` [WebContents](web-contents.md)
+* `url` URL
+* `error` String - The error code
+* `certificate` Object
+  * `data` Buffer - PEM encoded data
+  * `issuerName` String
+* `callback` Function
+
+Emitted when failed to verify the `certificate` for `url`, to trust the
+certificate you should prevent the default behavior with
+`event.preventDefault()` and call `callback(true)`.
+
+```javascript
+session.on('certificate-error', function(event, webContents, url, error, certificate, callback) {
+  if (url == "https://github.com") {
+    // Verification logic.
+    event.preventDefault();
+    callback(true);
+  } else {
+    callback(false);
+  }
+});
+```
+
 ### Event: 'select-client-certificate'
 
 Returns:

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -34,31 +34,6 @@ session.on('will-download', function(event, item, webContents) {
 });
 ```
 
-### Event: 'untrusted-certificate'
-
-* `event` Event
-* `hostname` String
-* `certificate` Object
-  * `data` Buffer - PEM encoded data
-  * `issuerName` String
-* `callback` Function
-
-Emitted when failed to verify the `certificate` for `hostname`, to trust the
-certificate you should prevent the default behavior with
-`event.preventDefault()` and call `callback(true)`.
-
-```js
-session.on('verify-certificate', function(event, hostname, certificate, callback) {
-  if (hostname == "github.com") {
-    // Verification logic.
-    event.preventDefault();
-    callback(true);
-  } else {
-    callback(false);
-  }
-});
-```
-
 ## Methods
 
 The `session` object has the following methods:
@@ -245,3 +220,24 @@ window.webContents.session.enableNetworkEmulation({offline: true});
 
 Disables any network emulation already active for the `session`. Resets to
 the original network configuration.
+
+### `session.setCertificateVerifyProc(proc)`
+
+* `proc` Function
+
+Sets the certificate verify proc for `session`, the `proc` will be called with
+`proc(hostname, certificate, callback)` whenever a server certificate
+verification is requested. Calling `callback(true)` accepts the certificate,
+calling `callback(false)` rejects it.
+
+Calling `setCertificateVerifyProc(null)` will revert back to default certificate
+verify proc.
+
+```javascript
+myWindow.webContents.session.setCertificateVerifyProc(function(hostname, cert, callback) {
+  if (hostname == 'github.com')
+    callback(true);
+  else
+    callback(false);
+});
+```

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -167,6 +167,39 @@ Emitted when DevTools is closed.
 
 Emitted when DevTools is focused / opened.
 
+### Event: 'certificate-error'
+
+Returns:
+
+* `event` Event
+* `url` URL
+* `error` String - The error code
+* `certificate` Object
+  * `data` Buffer - PEM encoded data
+  * `issuerName` String
+* `callback` Function
+
+Emitted when failed to verify the `certificate` for `url`.
+
+The usage is the same with [the `certificate-error` event of
+`app`](app.md#event-certificate-error).
+
+### Event: 'select-client-certificate'
+
+Returns:
+
+* `event` Event
+* `url` URL
+* `certificateList` [Objects]
+  * `data` Buffer - PEM encoded data
+  * `issuerName` String - Issuer's Common Name
+* `callback` Function
+
+Emitted when a client certificate is requested.
+
+The usage is the same with [the `select-client-certificate` event of
+`app`](app.md#event-select-client-certificate).
+
 ### Event: 'login'
 
 Returns:


### PR DESCRIPTION
```markdown
# app

### Event: 'certificate-error'

Returns:

* `event` Event
* `webContents` [WebContents](web-contents.md)
* `url` URL
* `error` String - The error code
* `certificate` Object
  * `data` Buffer - PEM encoded data
  * `issuerName` String
* `callback` Function

Emitted when failed to verify the `certificate` for `url`, to trust the
certificate you should prevent the default behavior with
`event.preventDefault()` and call `callback(true)`.
```

```markdown
# session

### `session.setCertificateVerifyProc(proc)`

* `proc` Function

Sets the certificate verify proc for `session`, the `proc` will be called with
`proc(hostname, certificate, callback)` whenever a server certificate
verification is requested. Calling `callback(true)` accepts the certificate,
calling `callback(false)` rejects it.

Calling `setCertificateVerifyProc(null)` will revert back to default certificate
verify proc.
````

Close #3330.