### PR TITLE
Upload the dSYM symbols

### DIFF
--- a/script/upload.py
+++ b/script/upload.py
@@ -31,6 +31,10 @@ SYMBOLS_NAME = '{0}-{1}-{2}-{3}-symbols.zip'.format(PROJECT_NAME,
                                                     ATOM_SHELL_VERSION,
                                                     get_platform_key(),
                                                     get_target_arch())
+DSYM_NAME = '{0}-{1}-{2}-{3}-dsym.zip'.format(PROJECT_NAME,
+                                              ATOM_SHELL_VERSION,
+                                              get_platform_key(),
+                                              get_target_arch())
 MKSNAPSHOT_NAME = 'mksnapshot-{0}-{1}-{2}.zip'.format(ATOM_SHELL_VERSION,
                                                       get_platform_key(),
                                                       get_target_arch())
@@ -82,6 +86,8 @@ def main():
   # Upload atom-shell with GitHub Releases API.
   upload_atom_shell(github, release, os.path.join(DIST_DIR, DIST_NAME))
   upload_atom_shell(github, release, os.path.join(DIST_DIR, SYMBOLS_NAME))
+  if PLATFORM == 'darwin':
+    upload_atom_shell(github, release, os.path.join(DIST_DIR, DSYM_NAME))
 
   # Upload chromedriver and mksnapshot for minor version update.
   if parse_version(args.version)[2] == '0':


### PR DESCRIPTION
Apart from the breakpad symbols, this PR also uploads the dSYM symbols on OS X, so tools like Instruments can read the symbols.

Fix #3502.