### PR TITLE
Support the "desktop" window type on Mac OS X

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -211,6 +211,8 @@ bool ScopedDisableResize::disable_resize_ = false;
 }
 @property BOOL acceptsFirstMouse;
 @property BOOL disableAutoHideCursor;
+@property BOOL disableKeyOrMainWindow;
+
 - (void)setShell:(atom::NativeWindowMac*)shell;
 - (void)setEnableLargerThanScreen:(bool)enable;
 @end
@@ -255,6 +257,16 @@ bool ScopedDisableResize::disable_resize_ = false;
 
   NSArray *children = [super accessibilityAttributeValue:attribute];
   return [children filteredArrayUsingPredicate:predicate];
+}
+
+- (BOOL)canBecomeMainWindow
+{
+    return !self.disableKeyOrMainWindow;
+}
+
+- (BOOL)canBecomeKeyWindow
+{
+    return !self.disableKeyOrMainWindow;
 }
 
 @end
@@ -330,8 +342,6 @@ NativeWindowMac::NativeWindowMac(
       width,
       height);
 
-  bool useStandardWindow = true;
-  options.Get(options::kStandardWindow, &useStandardWindow);
   bool resizable = true;
   options.Get(options::kResizable, &resizable);
 
@@ -339,6 +349,17 @@ NativeWindowMac::NativeWindowMac(
   std::string titleBarStyle;
   if (base::mac::IsOSYosemiteOrLater())
     options.Get(options::kTitleBarStyle, &titleBarStyle);
+
+  std::string windowType;
+  options.Get(options::kType, &windowType);
+
+  bool useStandardWindow = true;
+  // eventually deprecate separate "standardWindow" option in favor of
+  // standard / textured window types
+  options.Get(options::kStandardWindow, &useStandardWindow);
+  if (windowType == "textured") {
+    useStandardWindow = false;
+  }
 
   NSUInteger styleMask = NSTitledWindowMask | NSClosableWindowMask |
                          NSMiniaturizableWindowMask;
@@ -369,6 +390,15 @@ NativeWindowMac::NativeWindowMac(
     [window_ setOpaque:NO];
     [window_ setHasShadow:NO];
     [window_ setBackgroundColor:[NSColor clearColor]];
+  }
+
+  if (windowType == "desktop") {
+    [window_ setLevel:kCGDesktopWindowLevel - 1];
+    [window_ setDisableKeyOrMainWindow: YES];
+    [window_ setCollectionBehavior:
+        (NSWindowCollectionBehaviorCanJoinAllSpaces |
+         NSWindowCollectionBehaviorStationary |
+         NSWindowCollectionBehaviorIgnoresCycle)];
   }
 
   // Remove non-transparent corners, see http://git.io/vfonD.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -68,12 +68,14 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
 * `transparent` Boolean - Makes the window [transparent](frameless-window.md).
 * `type` String - Specifies the type of the window, which applies
   additional platform-specific properties.
-  - On Linux, possible types are `desktop`, `dock`, `toolbar`, `splash`, `notification`.
-  - On Mac OS X:
-    - `textured`: Adds metal gradient appearance (NSTexturedBackgroundWindowMask)
-    - `desktop`: Places the window at the desktop background window level (kCGDesktopWindowLevel - 1).
-      Note that the window will not receive focus, keyboard or mouse events, but
-      you can use `globalShortcut` to receive input sparingly.
+  * On Linux, possible types are `desktop`, `dock`, `toolbar`, `splash`,
+    `notification`.
+  * On OS X, possible types are `desktop`, `textured`. The `textured` type adds
+    metal gradient appearance (NSTexturedBackgroundWindowMask). The `desktop`
+    type places the window at the desktop background window level
+    (kCGDesktopWindowLevel - 1). Note that desktop window will not receive focus,
+    keyboard or mouse events, but you can use `globalShortcut` to receive input
+    sparingly.
 * `titleBarStyle` String, OS X - specifies the style of window title bar.
   This option is supported on OS X 10.10 Yosemite and newer. There are three
   possible values:

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -66,11 +66,14 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
 * `darkTheme` Boolean - Forces using dark theme for the window, only works on
   some GTK+3 desktop environments.
 * `transparent` Boolean - Makes the window [transparent](frameless-window.md).
-* `type` String - Specifies the type of the window, possible types are
-  `desktop`, `dock`, `toolbar`, `splash`, `notification`. This only works on
-  Linux.
-* `standardWindow` Boolean - Uses the OS X's standard window instead of the
-  textured window. Defaults to `true`.
+* `type` String - Specifies the type of the window, which applies
+  additional platform-specific properties.
+  - On Linux, possible types are `desktop`, `dock`, `toolbar`, `splash`, `notification`.
+  - On Mac OS X:
+    - `textured`: Adds metal gradient appearance (NSTexturedBackgroundWindowMask)
+    - `desktop`: Places the window at the desktop background window level (kCGDesktopWindowLevel - 1).
+      Note that the window will not receive focus, keyboard or mouse events, but
+      you can use `globalShortcut` to receive input sparingly.
 * `titleBarStyle` String, OS X - specifies the style of window title bar.
   This option is supported on OS X 10.10 Yosemite and newer. There are three
   possible values:
@@ -86,11 +89,11 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     is `true`.
   * `preload` String - Specifies a script that will be loaded before other
     scripts run in the page. This script will always have access to node APIs
-    no matter whether node integration is turned on or off. The value should 
+    no matter whether node integration is turned on or off. The value should
     be the absolute file path to the script.
 
-    When node integration is turned off, the preload script can reintroduce 
-    Node global symbols back to the global scope. See example 
+    When node integration is turned off, the preload script can reintroduce
+    Node global symbols back to the global scope. See example
     [here](process.md#event-loaded).
   * `partition` String - Sets the session used by the page. If `partition`
     starts with `persist:`, the page will use a persistent session available to


### PR DESCRIPTION
Adds the desktop window type referenced in https://github.com/atom/electron/issues/2899 for compatiblity with the linux version. Note that on Mac OS X, the desktop window cannot receive input events (seems to be a limitation of being behind the desktop).

In this diff I also removed the `standardWindow` option from the docs, in favor of an additional `textured` value for window `type` on Mac OS X. The old `standardWindow` option continues to work, but seemed more confusing. If this seems like a bad idea, I can revert that change.

Here's a sample app adapted to use the `desktop` window type. I also made it use the `globalShortcut` for interaction, since it can't receive input directly: https://dl.dropboxusercontent.com/u/4803975/Electron%20Examples/webgl-desktop.zip