### PR TITLE
Add "isDestroyed" method for objects with "destroy" method

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -161,6 +161,7 @@ void Tray::BuildPrototype(v8::Isolate* isolate,
                           v8::Local<v8::ObjectTemplate> prototype) {
   mate::ObjectTemplateBuilder(isolate, prototype)
       .SetMethod("destroy", &Tray::Destroy, true)
+      .SetMethod("isDestroyed", &Tray::IsDestroyed, true)
       .SetMethod("setImage", &Tray::SetImage)
       .SetMethod("setPressedImage", &Tray::SetPressedImage)
       .SetMethod("setToolTip", &Tray::SetToolTip)

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -604,10 +604,6 @@ void WebContents::Destroy() {
   }
 }
 
-bool WebContents::IsAlive() const {
-  return web_contents() != NULL;
-}
-
 int WebContents::GetID() const {
   return web_contents()->GetRenderProcessHost()->GetID();
 }
@@ -996,7 +992,7 @@ mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
   if (template_.IsEmpty())
     template_.Reset(isolate, mate::ObjectTemplateBuilder(isolate)
         .SetMethod("destroy", &WebContents::Destroy, true)
-        .SetMethod("isAlive", &WebContents::IsAlive, true)
+        .SetMethod("isDestroyed", &WebContents::IsDestroyed, true)
         .SetMethod("getId", &WebContents::GetID)
         .SetMethod("equal", &WebContents::Equal)
         .SetMethod("_loadURL", &WebContents::LoadURL)
@@ -1066,7 +1062,7 @@ mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
 }
 
 bool WebContents::IsDestroyed() const {
-  return !IsAlive();
+  return !web_contents();
 }
 
 AtomBrowserContext* WebContents::GetBrowserContext() const {

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -57,7 +57,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
   // mate::TrackableObject:
   void Destroy() override;
 
-  bool IsAlive() const;
   int GetID() const;
   bool Equal(const WebContents* web_contents) const;
   void LoadURL(const GURL& url, const mate::Dictionary& options);

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -284,10 +284,6 @@ void Window::Close() {
   window_->Close();
 }
 
-bool Window::IsClosed() {
-  return window_->IsClosed();
-}
-
 void Window::Focus() {
   window_->Focus(true);
 }
@@ -622,8 +618,8 @@ void Window::BuildPrototype(v8::Isolate* isolate,
                             v8::Local<v8::ObjectTemplate> prototype) {
   mate::ObjectTemplateBuilder(isolate, prototype)
       .SetMethod("destroy", &Window::Destroy, true)
+      .SetMethod("isDestroyed", &Window::IsDestroyed, true)
       .SetMethod("close", &Window::Close)
-      .SetMethod("isClosed", &Window::IsClosed)
       .SetMethod("focus", &Window::Focus)
       .SetMethod("isFocused", &Window::IsFocused)
       .SetMethod("show", &Window::Show)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -89,7 +89,6 @@ class Window : public mate::TrackableObject<Window>,
 
   // APIs for NativeWindow.
   void Close();
-  bool IsClosed();
   void Focus();
   bool IsFocused();
   void Show();


### PR DESCRIPTION
We had lots of different APIs for checking whether an object is destroyed, and none of them is public, this PR tries to add a `isDestroyed` API to balance the `destroy` API and makes styles more consistent.

The `isDestroyed` API will stay undocumented for a while in case there is better way to do this.