### PR TITLE
Remove trailing colons from default menu roles

### DIFF
--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -189,11 +189,11 @@ app.once('ready', function() {
         {
           label: 'Hide Others',
           accelerator: 'Command+Shift+H',
-          role: 'hideothers:'
+          role: 'hideothers'
         },
         {
           label: 'Show All',
-          role: 'unhide:'
+          role: 'unhide'
         },
         {
           type: 'separator'


### PR DESCRIPTION
`hideothers` and `unhide` had trailing colons which prevented them from being enabled / working in the default app. #3543