### PR TITLE
Enable all origins via CORS header for custom schemes

### DIFF
--- a/atom/browser/net/js_asker.cc
+++ b/atom/browser/net/js_asker.cc
@@ -11,6 +11,8 @@
 
 namespace atom {
 
+const std::string kCorsHeader("Access-Control-Allow-Origin: *");
+
 namespace internal {
 
 namespace {

--- a/atom/browser/net/js_asker.h
+++ b/atom/browser/net/js_asker.h
@@ -17,6 +17,7 @@
 #include "v8/include/v8.h"
 
 namespace atom {
+extern const std::string kCorsHeader;
 
 using JavaScriptHandler =
     base::Callback<void(const net::URLRequest*, v8::Local<v8::Value>)>;

--- a/atom/browser/net/js_asker.h
+++ b/atom/browser/net/js_asker.h
@@ -5,6 +5,8 @@
 #ifndef ATOM_BROWSER_NET_JS_ASKER_H_
 #define ATOM_BROWSER_NET_JS_ASKER_H_
 
+#include <string>
+
 #include "base/callback.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"

--- a/atom/browser/net/url_request_async_asar_job.cc
+++ b/atom/browser/net/url_request_async_asar_job.cc
@@ -34,4 +34,13 @@ void URLRequestAsyncAsarJob::StartAsync(scoped_ptr<base::Value> options) {
   }
 }
 
+
+void URLRequestAsyncAsarJob::GetResponseInfo(net::HttpResponseInfo* info) {
+  std::string status("HTTP/1.1 200 OK");
+  net::HttpResponseHeaders* headers = new net::HttpResponseHeaders(status);
+
+  headers->AddHeader(kCorsHeader);
+  info->headers = headers;
+}
+
 }  // namespace atom

--- a/atom/browser/net/url_request_async_asar_job.cc
+++ b/atom/browser/net/url_request_async_asar_job.cc
@@ -4,6 +4,8 @@
 
 #include "atom/browser/net/url_request_async_asar_job.h"
 
+#include <string>
+
 namespace atom {
 
 URLRequestAsyncAsarJob::URLRequestAsyncAsarJob(

--- a/atom/browser/net/url_request_async_asar_job.h
+++ b/atom/browser/net/url_request_async_asar_job.h
@@ -18,6 +18,9 @@ class URLRequestAsyncAsarJob : public JsAsker<asar::URLRequestAsarJob> {
   // JsAsker:
   void StartAsync(scoped_ptr<base::Value> options) override;
 
+  // URLRequestJob:
+  void GetResponseInfo(net::HttpResponseInfo* info) override;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(URLRequestAsyncAsarJob);
 };

--- a/atom/browser/net/url_request_buffer_job.cc
+++ b/atom/browser/net/url_request_buffer_job.cc
@@ -50,6 +50,9 @@ void URLRequestBufferJob::GetResponseInfo(net::HttpResponseInfo* info) {
   status.append("\0\0", 2);
   net::HttpResponseHeaders* headers = new net::HttpResponseHeaders(status);
 
+  std::string cors("Access-Control-Allow-Origin: *");
+  headers->AddHeader(cors);
+
   if (!mime_type_.empty()) {
     std::string content_type_header(net::HttpRequestHeaders::kContentType);
     content_type_header.append(": ");

--- a/atom/browser/net/url_request_buffer_job.cc
+++ b/atom/browser/net/url_request_buffer_job.cc
@@ -50,8 +50,7 @@ void URLRequestBufferJob::GetResponseInfo(net::HttpResponseInfo* info) {
   status.append("\0\0", 2);
   net::HttpResponseHeaders* headers = new net::HttpResponseHeaders(status);
 
-  std::string cors("Access-Control-Allow-Origin: *");
-  headers->AddHeader(cors);
+  headers->AddHeader(kCorsHeader);
 
   if (!mime_type_.empty()) {
     std::string content_type_header(net::HttpRequestHeaders::kContentType);

--- a/atom/browser/net/url_request_buffer_job.h
+++ b/atom/browser/net/url_request_buffer_job.h
@@ -12,6 +12,8 @@
 #include "net/http/http_status_code.h"
 #include "net/url_request/url_request_simple_job.h"
 
+const std::string kCorsHeader("Access-Control-Allow-Origin: *");
+
 namespace atom {
 
 class URLRequestBufferJob : public JsAsker<net::URLRequestSimpleJob> {

--- a/atom/browser/net/url_request_buffer_job.h
+++ b/atom/browser/net/url_request_buffer_job.h
@@ -12,8 +12,6 @@
 #include "net/http/http_status_code.h"
 #include "net/url_request/url_request_simple_job.h"
 
-const std::string kCorsHeader("Access-Control-Allow-Origin: *");
-
 namespace atom {
 
 class URLRequestBufferJob : public JsAsker<net::URLRequestSimpleJob> {

--- a/atom/browser/net/url_request_string_job.cc
+++ b/atom/browser/net/url_request_string_job.cc
@@ -32,6 +32,9 @@ void URLRequestStringJob::GetResponseInfo(net::HttpResponseInfo* info) {
   std::string status("HTTP/1.1 200 OK");
   net::HttpResponseHeaders* headers = new net::HttpResponseHeaders(status);
 
+  std::string cors("Access-Control-Allow-Origin: *");
+  headers->AddHeader(cors);
+
   if (!mime_type_.empty()) {
     std::string content_type_header(net::HttpRequestHeaders::kContentType);
     content_type_header.append(": ");

--- a/atom/browser/net/url_request_string_job.cc
+++ b/atom/browser/net/url_request_string_job.cc
@@ -32,8 +32,7 @@ void URLRequestStringJob::GetResponseInfo(net::HttpResponseInfo* info) {
   std::string status("HTTP/1.1 200 OK");
   net::HttpResponseHeaders* headers = new net::HttpResponseHeaders(status);
 
-  std::string cors("Access-Control-Allow-Origin: *");
-  headers->AddHeader(cors);
+  headers->AddHeader(kCorsHeader);
 
   if (!mime_type_.empty()) {
     std::string content_type_header(net::HttpRequestHeaders::kContentType);

--- a/spec/api-protocol-spec.coffee
+++ b/spec/api-protocol-spec.coffee
@@ -81,6 +81,21 @@ describe 'protocol module', ->
           error: (xhr, errorType, error) ->
             done(error)
 
+    it 'sets Access-Control-Allow-Origin', (done) ->
+      handler = (request, callback) -> callback(text)
+      protocol.registerStringProtocol protocolName, handler, (error) ->
+        return done(error) if error
+        $.ajax
+          url: "#{protocolName}://fake-host"
+          success: (data, status, request) ->
+            assert.equal data, text
+            assert.equal(
+              request.getResponseHeader('Access-Control-Allow-Origin'),
+              '*')
+            done()
+          error: (xhr, errorType, error) ->
+            done(error)
+
     it 'sends object as response', (done) ->
       handler = (request, callback) -> callback(data: text, mimeType: 'text/html')
       protocol.registerStringProtocol protocolName, handler, (error) ->
@@ -116,6 +131,21 @@ describe 'protocol module', ->
           url: "#{protocolName}://fake-host"
           success: (data) ->
             assert.equal data, text
+            done()
+          error: (xhr, errorType, error) ->
+            done(error)
+
+    it 'sets Access-Control-Allow-Origin', (done) ->
+      handler = (request, callback) -> callback(buffer)
+      protocol.registerBufferProtocol protocolName, handler, (error) ->
+        return done(error) if error
+        $.ajax
+          url: "#{protocolName}://fake-host"
+          success: (data, status, request) ->
+            assert.equal data, text
+            assert.equal(
+              request.getResponseHeader('Access-Control-Allow-Origin'),
+              '*')
             done()
           error: (xhr, errorType, error) ->
             done(error)
@@ -159,6 +189,21 @@ describe 'protocol module', ->
           url: "#{protocolName}://fake-host"
           success: (data) ->
             assert.equal data, String(fileContent)
+            done()
+          error: (xhr, errorType, error) ->
+            done(error)
+
+    it 'sets Access-Control-Allow-Origin', (done) ->
+      handler = (request, callback) -> callback(filePath)
+      protocol.registerFileProtocol protocolName, handler, (error) ->
+        return done(error) if error
+        $.ajax
+          url: "#{protocolName}://fake-host"
+          success: (data, status, request) ->
+            assert.equal data, String(fileContent)
+            assert.equal(
+              request.getResponseHeader('Access-Control-Allow-Origin'),
+              '*')
             done()
           error: (xhr, errorType, error) ->
             done(error)


### PR DESCRIPTION
This PR disables CORS for custom schemes, which allows you to serve Font resources from custom schemes after using registerCustomSchemeAsSecure (i.e. the hosting page is HTTPS but your font is at `myproto://`)

## TODO:

- [x] Figure out how to do this for ASAR jobs
- [x] Make sure this actually works
- [ ] Code Review