### PR TITLE
docs: s/loadUrl/loadURL/g in docs-translations/

### DIFF
--- a/docs-translations/es/api/synopsis.md
+++ b/docs-translations/es/api/synopsis.md
@@ -25,7 +25,7 @@ var window = null;
 
 app.on('ready', function() {
   window = new BrowserWindow({width: 800, height: 600});
-  window.loadUrl('https://github.com');
+  window.loadURL('https://github.com');
 });
 ```
 

--- a/docs-translations/es/tutorial/application-packaging.md
+++ b/docs-translations/es/tutorial/application-packaging.md
@@ -70,7 +70,7 @@ También puedes mostrar una página web contenida en un `asar` utilizando `Brows
 ```javascript
 var BrowserWindow = require('browser-window');
 var win = new BrowserWindow({width: 800, height: 600});
-win.loadUrl('file:///path/to/example.asar/static/index.html');
+win.loadURL('file:///path/to/example.asar/static/index.html');
 ```
 
 ### API Web

--- a/docs-translations/es/tutorial/online-offline-events.md
+++ b/docs-translations/es/tutorial/online-offline-events.md
@@ -12,7 +12,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadUrl('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
 });
 ```
 
@@ -50,7 +50,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadUrl('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
 });
 
 ipc.on('online-status-changed', function(event, status) {

--- a/docs-translations/es/tutorial/using-pepper-flash-plugin.md
+++ b/docs-translations/es/tutorial/using-pepper-flash-plugin.md
@@ -46,7 +46,7 @@ app.on('ready', function() {
       'plugins': true
     }
   });
-  mainWindow.loadUrl('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + __dirname + '/index.html');
   // Something else
 });
 ```

--- a/docs-translations/pt-BR/tutorial/application-packaging.md
+++ b/docs-translations/pt-BR/tutorial/application-packaging.md
@@ -71,7 +71,7 @@ Você também pode renderizar uma página web apartir de um arquivo `asar` utili
 ```javascript
 var BrowserWindow = require('browser-window');
 var win = new BrowserWindow({width: 800, height: 600});
-win.loadUrl('file:///path/to/example.asar/static/index.html');
+win.loadURL('file:///path/to/example.asar/static/index.html');
 ```
 
 ### API Web

--- a/docs-translations/pt-BR/tutorial/online-offline-events.md
+++ b/docs-translations/pt-BR/tutorial/online-offline-events.md
@@ -13,7 +13,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadUrl('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
 });
 ```
 
@@ -53,7 +53,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadUrl('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
 });
 
 ipc.on('online-status-changed', function(event, status) {

--- a/docs-translations/pt-BR/tutorial/using-pepper-flash-plugin.md
+++ b/docs-translations/pt-BR/tutorial/using-pepper-flash-plugin.md
@@ -54,7 +54,7 @@ app.on('ready', function() {
       'plugins': true
     }
   });
-  mainWindow.loadUrl('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + __dirname + '/index.html');
   // Algo mais
 });
 ```

--- a/docs-translations/zh-CN/tutorial/online-offline-events.md
+++ b/docs-translations/zh-CN/tutorial/online-offline-events.md
@@ -9,7 +9,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadUrl('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
 });
 ````
 
@@ -43,7 +43,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadUrl('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
 });
 
 ipc.on('online-status-changed', function(event, status) {

--- a/docs-translations/zh-TW/api/synopsis.md
+++ b/docs-translations/zh-TW/api/synopsis.md
@@ -20,7 +20,7 @@ var window = null;
 
 app.on('ready', function() {
   window = new BrowserWindow({width: 800, height: 600});
-  window.loadUrl('https://github.com');
+  window.loadURL('https://github.com');
 });
 ```
 

--- a/docs-translations/zh-TW/tutorial/online-offline-events.md
+++ b/docs-translations/zh-TW/tutorial/online-offline-events.md
@@ -12,7 +12,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadUrl('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
 });
 ```
 
@@ -50,7 +50,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadUrl('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
 });
 
 ipc.on('online-status-changed', function(event, status) {


### PR DESCRIPTION
Run `npm start`, and show warnings in my console:
```
(electron) loadUrl is deprecated. Use loadURL instead.
```
#3424 updates, fix it.
