### PR TITLE
Ensure calling webview.send will not block the renderer

### DIFF
--- a/atom/browser/lib/rpc-server.coffee
+++ b/atom/browser/lib/rpc-server.coffee
@@ -221,3 +221,11 @@ ipcMain.on 'ATOM_BROWSER_GUEST_WEB_CONTENTS', (event, guestInstanceId) ->
 
 ipcMain.on 'ATOM_BROWSER_LIST_MODULES', (event) ->
   event.returnValue = (name for name of electron)
+
+ipcMain.on 'ATOM_BROWSER_ASYNC_CALL_TO_GUEST_VIEW', (event, guestInstanceId, method, args...) ->
+  try
+    guestViewManager = require './guest-view-manager'
+    guest = guestViewManager.getGuest(guestInstanceId)
+    guest[method].apply(guest, args)
+  catch e
+    event.returnValue = exceptionToMeta e

--- a/atom/renderer/lib/web-view/web-view.coffee
+++ b/atom/renderer/lib/web-view/web-view.coffee
@@ -1,4 +1,4 @@
-{deprecate, webFrame, remote} = require 'electron'
+{deprecate, webFrame, remote, ipcRenderer} = require 'electron'
 v8Util = process.atomBinding 'v8_util'
 
 guestViewInternal = require './guest-view-internal'
@@ -270,8 +270,6 @@ registerWebViewElement = ->
     'isCrashed'
     'setUserAgent'
     'getUserAgent'
-    'executeJavaScript'
-    'insertCSS'
     'openDevTools'
     'closeDevTools'
     'isDevToolsOpened'
@@ -289,20 +287,32 @@ registerWebViewElement = ->
     'unselect'
     'replace'
     'replaceMisspelling'
-    'send'
     'getId'
     'inspectServiceWorker'
     'print'
     'printToPDF'
-    'sendInputEvent'
+  ]
+
+  nonblockMethods = [
+    'send',
+    'sendInputEvent',
+    'executeJavaScript',
+    'insertCSS'
   ]
 
   # Forward proto.foo* method calls to WebViewImpl.foo*.
-  createHandler = (m) ->
+  createBlockHandler = (m) ->
     (args...) ->
       internal = v8Util.getHiddenValue this, 'internal'
       internal.webContents[m] args...
-  proto[m] = createHandler m for m in methods
+  proto[m] = createBlockHandler m for m in methods
+
+  createNonBlockHandler = (m) ->
+    (args...) ->
+      internal = v8Util.getHiddenValue this, 'internal'
+      ipcRenderer.send('ATOM_BROWSER_ASYNC_CALL_TO_GUEST_VIEW', internal.guestInstanceId, m, args...)
+
+  proto[m] = createNonBlockHandler m for m in nonblockMethods
 
   # Deprecated.
   deprecate.rename proto, 'getUrl', 'getURL'


### PR DESCRIPTION
When the browser process is busy, calling webview.send (a method that appears on its face to be non-blocking) will actually block, because most webview methods are remoted to a guest view instance in the browser process. Instead, define a few methods which will instead send its call over an async IPC message.