### PR TITLE
Clears the delegate when window is going to be closed

### DIFF
--- a/atom/browser/api/lib/app.coffee
+++ b/atom/browser/api/lib/app.coffee
@@ -54,7 +54,7 @@ deprecate.event app, 'finish-launching', 'ready', ->
   setImmediate => # give default app a chance to setup default menu.
     @emit 'finish-launching'
 deprecate.event app, 'activate-with-no-open-windows', 'activate', (event, hasVisibleWindows) ->
-  @emit 'activate-with-no-open-windows' if not hasVisibleWindows
+  @emit 'activate-with-no-open-windows', event if not hasVisibleWindows
 deprecate.event app, 'select-certificate', 'select-client-certificate'
 
 # Wrappers for native classes.

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -192,6 +192,11 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 - (void)windowWillClose:(NSNotification*)notification {
   shell_->NotifyWindowClosed();
+
+  // Clears the delegate when window is going to be closed, since EL Capitan it
+  // is possible that the methods of delegate would get called after the window
+  // has been closed.
+  [shell_->GetNativeWindow() setDelegate:nil];
 }
 
 - (BOOL)windowShouldClose:(id)window {


### PR DESCRIPTION
Since EL Capitan it is possible that the methods of delegate would get called after the window has been closed.

Refs atom/atom#9584.