### PR TITLE
Update docs for webContents.addWorkSpace

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -499,7 +499,14 @@ win.webContents.on("did-finish-load", function() {
 
 * `path` String
 
-Adds the specified path to DevTools workspace.
+Adds the specified path to DevTools workspace. Must be used after DevTools
+creation:
+
+```javascript
+mainWindow.webContents.on('devtools-opened', function() {
+  mainWindow.webContents.addWorkSpace(__dirname);
+});
+```
 
 ### `webContents.removeWorkSpace(path)`
 


### PR DESCRIPTION
Specify that webContents.addWorkSpace cannot be called before DevTools
creation and include example.

Fix: #3536