### PR TITLE
fix misspelling in "rotation" string

### DIFF
--- a/atom/browser/api/atom_api_screen.cc
+++ b/atom/browser/api/atom_api_screen.cc
@@ -41,7 +41,7 @@ std::vector<std::string> MetricsToArray(uint32_t metrics) {
   if (metrics & gfx::DisplayObserver::DISPLAY_METRIC_DEVICE_SCALE_FACTOR)
     array.push_back("scaleFactor");
   if (metrics & gfx::DisplayObserver::DISPLAY_METRIC_ROTATION)
-    array.push_back("rotaion");
+    array.push_back("rotation");
   return array;
 }
 


### PR DESCRIPTION
To comply with https://github.com/atom/electron/blob/3a5160f79968998ef214eb1d81c00993b0737637/docs/api/screen.md#event-display-metrics-changed

Fixes #3613