### PR TITLE
Delete BridgeTaskRunner when main message loop is ready

### DIFF
--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -114,7 +114,8 @@ void AtomBrowserMainParts::PreMainMessageLoopRun() {
                  1000));
 
   brightray::BrowserMainParts::PreMainMessageLoopRun();
-  BridgeTaskRunner::MessageLoopIsReady();
+  bridge_task_runner_->MessageLoopIsReady();
+  bridge_task_runner_ = nullptr;
 
 #if defined(USE_X11)
   libgtk2ui::GtkInitFromCommandLine(*base::CommandLine::ForCurrentProcess());

--- a/atom/browser/bridge_task_runner.cc
+++ b/atom/browser/bridge_task_runner.cc
@@ -8,11 +8,6 @@
 
 namespace atom {
 
-// static
-std::vector<BridgeTaskRunner::TaskPair> BridgeTaskRunner::tasks_;
-std::vector<BridgeTaskRunner::TaskPair> BridgeTaskRunner::non_nestable_tasks_;
-
-// static
 void BridgeTaskRunner::MessageLoopIsReady() {
   auto message_loop = base::MessageLoop::current();
   CHECK(message_loop);

--- a/atom/browser/bridge_task_runner.h
+++ b/atom/browser/bridge_task_runner.h
@@ -20,7 +20,7 @@ class BridgeTaskRunner : public base::SingleThreadTaskRunner {
   ~BridgeTaskRunner() override {}
 
   // Called when message loop is ready.
-  static void MessageLoopIsReady();
+  void MessageLoopIsReady();
 
   // base::SingleThreadTaskRunner:
   bool PostDelayedTask(const tracked_objects::Location& from_here,
@@ -35,8 +35,8 @@ class BridgeTaskRunner : public base::SingleThreadTaskRunner {
  private:
   using TaskPair = base::Tuple<
       tracked_objects::Location, base::Closure, base::TimeDelta>;
-  static std::vector<TaskPair> tasks_;
-  static std::vector<TaskPair> non_nestable_tasks_;
+  std::vector<TaskPair> tasks_;
+  std::vector<TaskPair> non_nestable_tasks_;
 
   DISALLOW_COPY_AND_ASSIGN(BridgeTaskRunner);
 };


### PR DESCRIPTION
Some tasks posted to BridgeTaskRunner are holding objects that should be deleted before the JavaScript environment gets deleted, otherwise crash would happen on exit.

Fix #3570.