### PR TITLE
Add process.noAsar to toggle asar support

### DIFF
--- a/atom/common/lib/asar.coffee
+++ b/atom/common/lib/asar.coffee
@@ -18,6 +18,7 @@ process.on 'exit', ->
 
 # Separate asar package's path from full path.
 splitPath = (p) ->
+  return [false] if process.noAsar  # shortcut to disable asar.
   return [false] if typeof p isnt 'string'
   return [true, p, ''] if p.substr(-5) is '.asar'
   p = path.normalize p

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -31,11 +31,18 @@ process.once('loaded', function() {
 });
 ```
 
+## Properties
+
+### `process.noAsar`
+
+Setting this to `true` can disable the support for `asar` archives in Node's
+built-in modules.
+
 ## Methods
 
 The `process` object has the following method:
 
-### `process.hang`
+### `process.hang()`
 
 Causes the main thread of the current process hang.
 

--- a/docs/tutorial/application-packaging.md
+++ b/docs/tutorial/application-packaging.md
@@ -103,6 +103,14 @@ var originalFs = require('original-fs');
 originalFs.readFileSync('/path/to/example.asar');
 ```
 
+You can also set `process.noAsar` to `true` to disable the support for `asar` in
+the `fs` module:
+
+```javascript
+process.noAsar = true;
+fs.readFileSync('/path/to/example.asar');
+```
+
 ## Limitations on Node API
 
 Even though we tried hard to make `asar` archives in the Node API work like


### PR DESCRIPTION
Users can now use `process.noAsar` to toggle whether to allow `asar` support in Node API. This makes it easy to use third party modules that deals with filesystem:

```js
process.noAsar = true;
fs.createReadStream('./my-electron-app.tar.gz')
  .pipe(zlib.Gunzip())
  .pipe(tar.extract('./extract'))
  .on('finish', function() { process.noAsar = false; });
```

Close #2446.