### PR TITLE
Delay the did-fail-provisional-load event to next tick

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -460,14 +460,13 @@ void WebContents::DidFinishLoad(content::RenderFrameHost* render_frame_host,
     Emit("did-finish-load");
 }
 
-// this error occurs when host could not be found
 void WebContents::DidFailProvisionalLoad(
     content::RenderFrameHost* render_frame_host,
-    const GURL& validated_url,
+    const GURL& url,
     int error_code,
     const base::string16& error_description,
     bool was_ignored_by_handler) {
-  Emit("did-fail-load", error_code, error_description, validated_url);
+  Emit("did-fail-provisional-load", error_code, error_description, url);
 }
 
 void WebContents::DidFailLoad(content::RenderFrameHost* render_frame_host,

--- a/atom/browser/api/lib/web-contents.coffee
+++ b/atom/browser/api/lib/web-contents.coffee
@@ -70,6 +70,12 @@ wrapWebContents = (webContents) ->
     menu = Menu.buildFromTemplate params.menu
     menu.popup params.x, params.y
 
+  # This error occurs when host could not be found.
+  webContents.on 'did-fail-provisional-load', (args...) ->
+    # Calling loadURL during this event might cause crash, so delay the event
+    # until next tick.
+    setImmediate => @emit 'did-fail-load', args...
+
   # Deprecated.
   deprecate.rename webContents, 'loadUrl', 'loadURL'
   deprecate.rename webContents, 'getUrl', 'getURL'


### PR DESCRIPTION
Chrome is doing some stuff after the DidFailProvisionalLoad event, if we call LoadURL at this time crash would happen.

Fix #3185.