### PR TITLE
Delay the page-title-updated event to next tick

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -519,9 +519,10 @@ void WebContents::DidNavigateMainFrame(
 
 void WebContents::TitleWasSet(content::NavigationEntry* entry,
                               bool explicit_set) {
-  // Back/Forward navigation may have pruned entries.
   if (entry)
     Emit("page-title-set", entry->GetTitle(), explicit_set);
+  else
+    Emit("page-title-set", "", explicit_set);
 }
 
 void WebContents::DidUpdateFaviconURL(

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -520,9 +520,9 @@ void WebContents::DidNavigateMainFrame(
 void WebContents::TitleWasSet(content::NavigationEntry* entry,
                               bool explicit_set) {
   if (entry)
-    Emit("-page-title-set", entry->GetTitle(), explicit_set);
+    Emit("-page-title-updated", entry->GetTitle(), explicit_set);
   else
-    Emit("-page-title-set", "", explicit_set);
+    Emit("-page-title-updated", "", explicit_set);
 }
 
 void WebContents::DidUpdateFaviconURL(

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -520,9 +520,9 @@ void WebContents::DidNavigateMainFrame(
 void WebContents::TitleWasSet(content::NavigationEntry* entry,
                               bool explicit_set) {
   if (entry)
-    Emit("page-title-set", entry->GetTitle(), explicit_set);
+    Emit("-page-title-set", entry->GetTitle(), explicit_set);
   else
-    Emit("page-title-set", "", explicit_set);
+    Emit("-page-title-set", "", explicit_set);
 }
 
 void WebContents::DidUpdateFaviconURL(

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -161,11 +161,6 @@ Window::~Window() {
     Destroy();
 }
 
-void Window::OnPageTitleUpdated(bool* prevent_default,
-                                const std::string& title) {
-  *prevent_default = Emit("page-title-updated", title);
-}
-
 void Window::WillCloseWindow(bool* prevent_default) {
   *prevent_default = Emit("close");
 }

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -54,8 +54,6 @@ class Window : public mate::TrackableObject<Window>,
   virtual ~Window();
 
   // NativeWindowObserver:
-  void OnPageTitleUpdated(bool* prevent_default,
-                          const std::string& title) override;
   void WillCloseWindow(bool* prevent_default) override;
   void OnWindowClosed() override;
   void OnWindowBlur() override;

--- a/atom/browser/api/lib/browser-window.coffee
+++ b/atom/browser/api/lib/browser-window.coffee
@@ -31,6 +31,11 @@ BrowserWindow::_init = ->
   @webContents.on 'crashed', =>
     @emit 'crashed'
 
+  # Change window title to page title.
+  @webContents.on 'page-title-set', (event, title, explicitSet) =>
+    @emit 'page-title-updated', event, title
+    @setTitle title unless event.defaultPrevented
+
   # Sometimes the webContents doesn't get focus when window is shown, so we have
   # to force focusing on webContents in this case. The safest way is to focus it
   # when we first start to load URL, if we do it earlier it won't have effect,

--- a/atom/browser/api/lib/browser-window.coffee
+++ b/atom/browser/api/lib/browser-window.coffee
@@ -32,7 +32,7 @@ BrowserWindow::_init = ->
     @emit 'crashed'
 
   # Change window title to page title.
-  @webContents.on 'page-title-set', (event, title, explicitSet) =>
+  @webContents.on 'page-title-updated', (event, title, explicitSet) =>
     @emit 'page-title-updated', event, title
     @setTitle title unless event.defaultPrevented
 

--- a/atom/browser/api/lib/web-contents.coffee
+++ b/atom/browser/api/lib/web-contents.coffee
@@ -76,13 +76,15 @@ wrapWebContents = (webContents) ->
     # until next tick.
     setImmediate => @emit 'did-fail-load', args...
 
-  # Delays the page-title-set event to next tick.
-  webContents.on '-page-title-set', (args...) ->
-    setImmediate => @emit 'page-title-set', args...
+  # Delays the page-title-updated event to next tick.
+  webContents.on '-page-title-updated', (args...) ->
+    setImmediate => @emit 'page-title-updated', args...
 
   # Deprecated.
   deprecate.rename webContents, 'loadUrl', 'loadURL'
   deprecate.rename webContents, 'getUrl', 'getURL'
+  deprecate.event webContents, 'page-title-set', 'page-title-updated', (args...) ->
+    @emit 'page-title-set', args...
 
   webContents.printToPDF = (options, callback) ->
     printingSetting =

--- a/atom/browser/api/lib/web-contents.coffee
+++ b/atom/browser/api/lib/web-contents.coffee
@@ -76,6 +76,10 @@ wrapWebContents = (webContents) ->
     # until next tick.
     setImmediate => @emit 'did-fail-load', args...
 
+  # Delays the page-title-set event to next tick.
+  webContents.on '-page-title-set', (args...) ->
+    setImmediate => @emit 'page-title-set', args...
+
   # Deprecated.
   deprecate.rename webContents, 'loadUrl', 'loadURL'
   deprecate.rename webContents, 'getUrl', 'getURL'

--- a/atom/browser/lib/guest-view-manager.coffee
+++ b/atom/browser/lib/guest-view-manager.coffee
@@ -19,7 +19,7 @@ supportedWebViewEvents = [
   'gpu-crashed'
   'plugin-crashed'
   'destroyed'
-  'page-title-set'
+  'page-title-updated'
   'page-favicon-updated'
   'enter-html-full-screen'
   'leave-html-full-screen'

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -505,17 +505,6 @@ void NativeWindow::BeforeUnloadDialogCancelled() {
   window_unresposive_closure_.Cancel();
 }
 
-void NativeWindow::TitleWasSet(content::NavigationEntry* entry,
-                               bool explicit_set) {
-  bool prevent_default = false;
-  std::string text = entry ? base::UTF16ToUTF8(entry->GetTitle()) : "";
-  FOR_EACH_OBSERVER(NativeWindowObserver,
-                    observers_,
-                    OnPageTitleUpdated(&prevent_default, text));
-  if (!prevent_default && !is_closed_)
-    SetTitle(text);
-}
-
 bool NativeWindow::OnMessageReceived(const IPC::Message& message) {
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(NativeWindow, message)

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -262,7 +262,6 @@ class NativeWindow : public base::SupportsUserData,
   // content::WebContentsObserver:
   void RenderViewCreated(content::RenderViewHost* render_view_host) override;
   void BeforeUnloadDialogCancelled() override;
-  void TitleWasSet(content::NavigationEntry* entry, bool explicit_set) override;
   bool OnMessageReceived(const IPC::Message& message) override;
 
  private:

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -21,10 +21,6 @@ class NativeWindowObserver {
  public:
   virtual ~NativeWindowObserver() {}
 
-  // Called when the web page of the window has updated it's document title.
-  virtual void OnPageTitleUpdated(bool* prevent_default,
-                                  const std::string& title) {}
-
   // Called when the web page in window wants to create a popup window.
   virtual void WillCreatePopupWindow(const base::string16& frame_name,
                                      const GURL& target_url,

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -452,15 +452,15 @@ Fired when a redirect was received while requesting a resource.
 
 Fired when document in the given frame is loaded.
 
-### Event: 'page-title-set'
+### Event: 'page-title-updated'
 
 Returns:
 
 * `title` String
 * `explicitSet` Boolean
 
-Fired when page title is set during navigation. `explicitSet` is false when title is synthesised from file
-url.
+Fired when page title is set during navigation. `explicitSet` is false when
+title is synthesised from file url.
 
 ### Event: 'page-favicon-updated'
 


### PR DESCRIPTION
Similar to #3643, Chromium is doing something with webContents after the `page-title-updated` event, so if users close the window during it a crash will happen.

Fix #3380.