### PR TITLE
Fix `window.open` not respecting the features string

### DIFF
--- a/atom/browser/lib/guest-window-manager.coffee
+++ b/atom/browser/lib/guest-window-manager.coffee
@@ -5,7 +5,7 @@ frameToGuest = {}
 
 # Copy attribute of |parent| to |child| if it is not defined in |child|.
 mergeOptions = (child, parent) ->
-  for own key, value of parent when key not in child
+  for own key, value of parent when key not in Object.keys child
     if typeof value is 'object'
       child[key] = mergeOptions {}, value
     else

--- a/spec/chromium-spec.coffee
+++ b/spec/chromium-spec.coffee
@@ -82,6 +82,15 @@ describe 'chromium feature', ->
       window.addEventListener 'message', listener
       b = window.open "file://#{fixtures}/pages/window-open-size.html", '', 'show=no'
 
+    it 'does not override child options', (done) ->
+      size = {width: 350, height: 450}
+      listener = (event) ->
+        assert.equal event.data, "size: #{size.width} #{size.height}"
+        b.close()
+        done()
+      window.addEventListener 'message', listener
+      b = window.open "file://#{fixtures}/pages/window-open-size.html", '', "show=no,width=#{size.width},height=#{size.height}"
+
   describe 'window.opener', ->
     @timeout 10000
 

--- a/spec/chromium-spec.coffee
+++ b/spec/chromium-spec.coffee
@@ -75,8 +75,8 @@ describe 'chromium feature', ->
 
     it 'inherit options of parent window', (done) ->
       listener = (event) ->
-        size = remote.getCurrentWindow().getSize()
-        assert.equal event.data, "size: #{size.width} #{size.height}"
+        [width, height] = remote.getCurrentWindow().getSize()
+        assert.equal event.data, "size: #{width} #{height}"
         b.close()
         done()
       window.addEventListener 'message', listener

--- a/spec/fixtures/pages/window-open-size.html
+++ b/spec/fixtures/pages/window-open-size.html
@@ -2,7 +2,7 @@
 <body>
 <script type="text/javascript" charset="utf-8">
   var size = require('electron').remote.getCurrentWindow().getSize();
-  window.opener.postMessage('size: ' + size.width + ' ' + size.height, '*')
+  window.opener.postMessage('size: ' + size[0] + ' ' + size[1], '*')
 </script>
 </body>
 </html>


### PR DESCRIPTION
Also fixes the existing test for inheritance.

Fixes https://github.com/atom/electron/issues/3652.