### PR TITLE
DownloadURL from webContents

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -634,6 +634,15 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
   web_contents()->GetController().LoadURLWithParams(params);
 }
 
+void WebContents::DownloadURL(const GURL& url) {
+  auto browser_context = web_contents()->GetBrowserContext();
+  auto download_manager =
+    content::BrowserContext::GetDownloadManager(browser_context);
+
+  download_manager->DownloadUrl(
+    content::DownloadUrlParameters::FromWebContents(web_contents(), url));
+}
+
 GURL WebContents::GetURL() const {
   return web_contents()->GetURL();
 }
@@ -996,6 +1005,7 @@ mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
         .SetMethod("getId", &WebContents::GetID)
         .SetMethod("equal", &WebContents::Equal)
         .SetMethod("_loadURL", &WebContents::LoadURL)
+        .SetMethod("downloadURL", &WebContents::DownloadURL)
         .SetMethod("_getURL", &WebContents::GetURL)
         .SetMethod("getTitle", &WebContents::GetTitle)
         .SetMethod("isLoading", &WebContents::IsLoading)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -60,6 +60,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   int GetID() const;
   bool Equal(const WebContents* web_contents) const;
   void LoadURL(const GURL& url, const mate::Dictionary& options);
+  void DownloadURL(const GURL& url);
   GURL GetURL() const;
   base::string16 GetTitle() const;
   bool IsLoading() const;

--- a/atom/renderer/lib/web-view/web-view.coffee
+++ b/atom/renderer/lib/web-view/web-view.coffee
@@ -288,6 +288,7 @@ registerWebViewElement = ->
     'replace'
     'replaceMisspelling'
     'getId'
+    'downloadURL'
     'inspectServiceWorker'
     'print'
     'printToPDF'

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -242,6 +242,13 @@ const options = {"extraHeaders" : "pragma: no-cache\n"}
 webContents.loadURL(url, options)
 ```
 
+### `webContents.downloadURL(url)`
+
+* `url` URL
+
+Initiates a download of the resource at `url` without navigating. The
+`will-download` event of `session` will be triggered.
+
 ### `webContents.getURL()`
 
 Returns URL of the current web page.

--- a/spec/api-browser-window-spec.coffee
+++ b/spec/api-browser-window-spec.coffee
@@ -262,6 +262,7 @@ describe 'browser-window module', ->
       w.loadURL "file://#{fixtures}/pages/window-open.html"
 
     it 'emits when link with target is called', (done) ->
+      @timeout 10000
       w.webContents.once 'new-window', (e, url, frameName) ->
         e.preventDefault()
         assert.equal url, 'http://host/'

--- a/spec/api-session-spec.coffee
+++ b/spec/api-session-spec.coffee
@@ -87,22 +87,42 @@ describe 'session module', ->
       res.end mockPDF
       downloadServer.close()
 
-    it 'can download successfully', (done) ->
+    assertDownload = (event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, port) ->
+      assert.equal state, 'completed'
+      assert.equal filename, 'mock.pdf'
+      assert.equal url, "http://127.0.0.1:#{port}/"
+      assert.equal mimeType, 'application/pdf'
+      assert.equal receivedBytes, mockPDF.length
+      assert.equal totalBytes, mockPDF.length
+      assert.equal disposition, contentDisposition
+      assert fs.existsSync downloadFilePath
+      fs.unlinkSync downloadFilePath
+
+    it 'can download using BrowserWindow.loadURL', (done) ->
       downloadServer.listen 0, '127.0.0.1', ->
         {port} = downloadServer.address()
         ipcRenderer.sendSync 'set-download-option', false
         w.loadURL "#{url}:#{port}"
         ipcRenderer.once 'download-done', (event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename) ->
-          assert.equal state, 'completed'
-          assert.equal filename, 'mock.pdf'
-          assert.equal url, "http://127.0.0.1:#{port}/"
-          assert.equal mimeType, 'application/pdf'
-          assert.equal receivedBytes, mockPDF.length
-          assert.equal totalBytes, mockPDF.length
-          assert.equal disposition, contentDisposition
-          assert fs.existsSync downloadFilePath
-          fs.unlinkSync downloadFilePath
+          assertDownload event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, port
           done()
+
+    it 'can download using WebView.downloadURL', (done) ->
+      downloadServer.listen 0, '127.0.0.1', ->
+        {port} = downloadServer.address()
+        ipcRenderer.sendSync 'set-download-option', false
+
+        webview = new WebView
+        webview.src = "file://#{fixtures}/api/blank.html"
+        webview.addEventListener 'did-finish-load', ->
+          webview.downloadURL "#{url}:#{port}/"
+
+        ipcRenderer.once 'download-done', (event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename) ->
+          assertDownload event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, port
+          document.body.removeChild(webview)
+          done()
+
+        document.body.appendChild webview
 
     it 'can cancel download', (done) ->
       downloadServer.listen 0, '127.0.0.1', ->


### PR DESCRIPTION
This PR resolves https://github.com/atom/electron/issues/3433. After some discussion with @zcbenz, it makes sense to have this method on `webContents` rather than `session`, as we can't create the download parameters without `webContents`.

Fixes #3433 