### PR TITLE
Make sure V8 handles are deleted on UI thread

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -322,14 +322,6 @@ void Cookies::OnSetCookies(const CookiesCallback& callback,
                  callback));
 }
 
-mate::ObjectTemplateBuilder Cookies::GetObjectTemplateBuilder(
-    v8::Isolate* isolate) {
-  return mate::ObjectTemplateBuilder(isolate)
-      .SetMethod("get", &Cookies::Get)
-      .SetMethod("remove", &Cookies::Remove)
-      .SetMethod("set", &Cookies::Set);
-}
-
 net::CookieStore* Cookies::GetCookieStore() {
   return request_context_getter_->GetURLRequestContext()->cookie_store();
 }
@@ -339,6 +331,15 @@ mate::Handle<Cookies> Cookies::Create(
     v8::Isolate* isolate,
     content::BrowserContext* browser_context) {
   return mate::CreateHandle(isolate, new Cookies(browser_context));
+}
+
+// static
+void Cookies::BuildPrototype(v8::Isolate* isolate,
+                             v8::Local<v8::ObjectTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype)
+      .SetMethod("get", &Cookies::Get)
+      .SetMethod("remove", &Cookies::Remove)
+      .SetMethod("set", &Cookies::Set);
 }
 
 }  // namespace api

--- a/atom/browser/api/atom_api_cookies.h
+++ b/atom/browser/api/atom_api_cookies.h
@@ -7,8 +7,8 @@
 
 #include <string>
 
+#include "atom/browser/api/trackable_object.h"
 #include "base/callback.h"
-#include "native_mate/wrappable.h"
 #include "native_mate/handle.h"
 #include "net/cookies/canonical_cookie.h"
 
@@ -33,7 +33,7 @@ namespace atom {
 
 namespace api {
 
-class Cookies : public mate::Wrappable {
+class Cookies : public mate::TrackableObject<Cookies> {
  public:
   // node.js style callback function(error, result)
   typedef base::Callback<void(v8::Local<v8::Value>, v8::Local<v8::Value>)>
@@ -41,6 +41,10 @@ class Cookies : public mate::Wrappable {
 
   static mate::Handle<Cookies> Create(v8::Isolate* isolate,
                                       content::BrowserContext* browser_context);
+
+  // mate::TrackableObject:
+  static void BuildPrototype(v8::Isolate* isolate,
+                             v8::Local<v8::ObjectTemplate> prototype);
 
  protected:
   explicit Cookies(content::BrowserContext* browser_context);
@@ -69,10 +73,6 @@ class Cookies : public mate::Wrappable {
                             const CookiesCallback& callback);
   void OnSetCookies(const CookiesCallback& callback,
                     bool set_success);
-
-  // mate::Wrappable:
-  mate::ObjectTemplateBuilder GetObjectTemplateBuilder(
-      v8::Isolate* isolate) override;
 
  private:
   // Must be called on IO thread.

--- a/atom/browser/api/atom_api_download_item.cc
+++ b/atom/browser/api/atom_api_download_item.cc
@@ -135,9 +135,10 @@ void DownloadItem::Cancel() {
   download_item_->Cancel(true);
 }
 
-mate::ObjectTemplateBuilder DownloadItem::GetObjectTemplateBuilder(
-    v8::Isolate* isolate) {
-  return mate::ObjectTemplateBuilder(isolate)
+// static
+void DownloadItem::BuildPrototype(v8::Isolate* isolate,
+                                  v8::Local<v8::ObjectTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype)
       .MakeDestroyable()
       .SetMethod("pause", &DownloadItem::Pause)
       .SetMethod("resume", &DownloadItem::Resume)

--- a/atom/browser/api/atom_api_download_item.cc
+++ b/atom/browser/api/atom_api_download_item.cc
@@ -70,29 +70,20 @@ DownloadItem::DownloadItem(content::DownloadItem* download_item) :
 }
 
 DownloadItem::~DownloadItem() {
-  Destroy();
-}
-
-void DownloadItem::Destroy() {
-  if (download_item_) {
-    download_item_->RemoveObserver(this);
-    auto iter = g_download_item_objects.find(download_item_->GetId());
-    if (iter != g_download_item_objects.end())
-      g_download_item_objects.erase(iter);
-    download_item_ = nullptr;
-  }
-}
-
-bool DownloadItem::IsDestroyed() const {
-  return download_item_ == nullptr;
+  if (download_item_)
+    OnDownloadDestroyed(download_item_);
 }
 
 void DownloadItem::OnDownloadUpdated(content::DownloadItem* item) {
   download_item_->IsDone() ? Emit("done", item->GetState()) : Emit("updated");
 }
 
-void DownloadItem::OnDownloadDestroyed(content::DownloadItem* download) {
-  Destroy();
+void DownloadItem::OnDownloadDestroyed(content::DownloadItem* download_item) {
+  download_item_->RemoveObserver(this);
+  auto iter = g_download_item_objects.find(download_item_->GetId());
+  if (iter != g_download_item_objects.end())
+    g_download_item_objects.erase(iter);
+  download_item_ = nullptr;
 }
 
 int64 DownloadItem::GetReceivedBytes() {
@@ -147,6 +138,7 @@ void DownloadItem::Cancel() {
 mate::ObjectTemplateBuilder DownloadItem::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
   return mate::ObjectTemplateBuilder(isolate)
+      .MakeDestroyable()
       .SetMethod("pause", &DownloadItem::Pause)
       .SetMethod("resume", &DownloadItem::Resume)
       .SetMethod("cancel", &DownloadItem::Cancel)

--- a/atom/browser/api/atom_api_download_item.h
+++ b/atom/browser/api/atom_api_download_item.h
@@ -17,7 +17,7 @@ namespace atom {
 
 namespace api {
 
-class DownloadItem : public mate::EventEmitter,
+class DownloadItem : public mate::TrackableObject<DownloadItem>,
                      public content::DownloadItem::Observer {
  public:
   class SavePathData : public base::SupportsUserData::Data {
@@ -31,6 +31,10 @@ class DownloadItem : public mate::EventEmitter,
   static mate::Handle<DownloadItem> Create(v8::Isolate* isolate,
                                            content::DownloadItem* item);
   static void* UserDataKey();
+
+  // mate::TrackableObject:
+  static void BuildPrototype(v8::Isolate* isolate,
+                             v8::Local<v8::ObjectTemplate> prototype);
 
  protected:
   explicit DownloadItem(content::DownloadItem* download_item);
@@ -53,10 +57,6 @@ class DownloadItem : public mate::EventEmitter,
   void SetSavePath(const base::FilePath& path);
 
  private:
-  // mate::Wrappable:
-  mate::ObjectTemplateBuilder GetObjectTemplateBuilder(
-      v8::Isolate* isolate) override;
-
   content::DownloadItem* download_item_;
 
   DISALLOW_COPY_AND_ASSIGN(DownloadItem);

--- a/atom/browser/api/atom_api_download_item.h
+++ b/atom/browser/api/atom_api_download_item.h
@@ -56,9 +56,6 @@ class DownloadItem : public mate::EventEmitter,
   // mate::Wrappable:
   mate::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;
-  bool IsDestroyed() const override;
-
-  void Destroy();
 
   content::DownloadItem* download_item_;
 

--- a/atom/browser/api/atom_api_global_shortcut.cc
+++ b/atom/browser/api/atom_api_global_shortcut.cc
@@ -23,9 +23,6 @@ GlobalShortcut::GlobalShortcut() {
 }
 
 GlobalShortcut::~GlobalShortcut() {
-}
-
-void GlobalShortcut::Destroy() {
   UnregisterAll();
 }
 

--- a/atom/browser/api/atom_api_global_shortcut.h
+++ b/atom/browser/api/atom_api_global_shortcut.h
@@ -27,9 +27,6 @@ class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
   GlobalShortcut();
   ~GlobalShortcut() override;
 
-  // mate::TrackableObject:
-  void Destroy() override;
-
   // mate::Wrappable implementations:
   mate::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/atom/browser/api/atom_api_menu.cc
+++ b/atom/browser/api/atom_api_menu.cc
@@ -27,14 +27,6 @@ Menu::Menu()
 Menu::~Menu() {
 }
 
-void Menu::Destroy() {
-  model_.reset();
-}
-
-bool Menu::IsDestroyed() const {
-  return !model_;
-}
-
 void Menu::AfterInit(v8::Isolate* isolate) {
   mate::Dictionary wrappable(isolate, GetWrapper(isolate));
   mate::Dictionary delegate;
@@ -159,6 +151,7 @@ bool Menu::IsVisibleAt(int index) const {
 void Menu::BuildPrototype(v8::Isolate* isolate,
                           v8::Local<v8::ObjectTemplate> prototype) {
   mate::ObjectTemplateBuilder(isolate, prototype)
+      .MakeDestroyable()
       .SetMethod("insertItem", &Menu::InsertItemAt)
       .SetMethod("insertCheckItem", &Menu::InsertCheckItemAt)
       .SetMethod("insertRadioItem", &Menu::InsertRadioItemAt)

--- a/atom/browser/api/atom_api_menu.h
+++ b/atom/browser/api/atom_api_menu.h
@@ -39,11 +39,7 @@ class Menu : public mate::TrackableObject<Menu>,
   Menu();
   ~Menu() override;
 
-  // mate::TrackableObject:
-  void Destroy() override;
-
   // mate::Wrappable:
-  bool IsDestroyed() const override;
   void AfterInit(v8::Isolate* isolate) override;
 
   // ui::SimpleMenuModel::Delegate:

--- a/atom/browser/api/atom_api_menu_mac.h
+++ b/atom/browser/api/atom_api_menu_mac.h
@@ -19,7 +19,6 @@ class MenuMac : public Menu {
  protected:
   MenuMac();
 
-  void Destroy() override;
   void Popup(Window* window) override;
   void PopupAt(Window* window, int x, int y) override;
 

--- a/atom/browser/api/atom_api_menu_mac.mm
+++ b/atom/browser/api/atom_api_menu_mac.mm
@@ -18,11 +18,6 @@ namespace api {
 MenuMac::MenuMac() {
 }
 
-void MenuMac::Destroy() {
-  menu_controller_.reset();
-  Menu::Destroy();
-}
-
 void MenuMac::Popup(Window* window) {
   NativeWindow* native_window = window->window();
   if (!native_window)

--- a/atom/browser/api/atom_api_power_monitor.cc
+++ b/atom/browser/api/atom_api_power_monitor.cc
@@ -19,9 +19,6 @@ PowerMonitor::PowerMonitor() {
 }
 
 PowerMonitor::~PowerMonitor() {
-}
-
-void PowerMonitor::Destroy() {
   base::PowerMonitor::Get()->RemoveObserver(this);
 }
 

--- a/atom/browser/api/atom_api_power_monitor.h
+++ b/atom/browser/api/atom_api_power_monitor.h
@@ -23,9 +23,6 @@ class PowerMonitor : public mate::TrackableObject<PowerMonitor>,
   PowerMonitor();
   ~PowerMonitor() override;
 
-  // mate::TrackableObject:
-  void Destroy() override;
-
   // base::PowerObserver implementations:
   void OnPowerStateChange(bool on_battery_power) override;
   void OnSuspend() override;

--- a/atom/browser/api/atom_api_power_save_blocker.cc
+++ b/atom/browser/api/atom_api_power_save_blocker.cc
@@ -45,11 +45,6 @@ PowerSaveBlocker::PowerSaveBlocker()
 PowerSaveBlocker::~PowerSaveBlocker() {
 }
 
-void PowerSaveBlocker::Destroy() {
-  power_save_blocker_types_.clear();
-  power_save_blocker_.reset();
-}
-
 void PowerSaveBlocker::UpdatePowerSaveBlocker() {
   if (power_save_blocker_types_.empty()) {
     power_save_blocker_.reset();

--- a/atom/browser/api/atom_api_power_save_blocker.h
+++ b/atom/browser/api/atom_api_power_save_blocker.h
@@ -28,9 +28,6 @@ class PowerSaveBlocker : public mate::TrackableObject<PowerSaveBlocker> {
   PowerSaveBlocker();
   ~PowerSaveBlocker() override;
 
-  // mate::TrackableObject:
-  void Destroy() override;
-
   // mate::Wrappable implementations:
   mate::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -253,7 +253,6 @@ Session::Session(AtomBrowserContext* browser_context)
 Session::~Session() {
   content::BrowserContext::GetDownloadManager(browser_context())->
       RemoveObserver(this);
-  Destroy();
 }
 
 void Session::OnDownloadCreated(content::DownloadManager* manager,
@@ -269,14 +268,6 @@ void Session::OnDownloadCreated(content::DownloadManager* manager,
     item->Cancel(true);
     item->Remove();
   }
-}
-
-bool Session::IsDestroyed() const {
-  return !browser_context_;
-}
-
-void Session::Destroy() {
-  browser_context_ = nullptr;
 }
 
 void Session::ResolveProxy(const GURL& url, ResolveProxyCallback callback) {
@@ -379,6 +370,7 @@ v8::Local<v8::Value> Session::Cookies(v8::Isolate* isolate) {
 mate::ObjectTemplateBuilder Session::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
   return mate::ObjectTemplateBuilder(isolate)
+      .MakeDestroyable()
       .SetMethod("resolveProxy", &Session::ResolveProxy)
       .SetMethod("clearCache", &Session::ClearCache)
       .SetMethod("clearStorageData", &Session::ClearStorageData)

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -367,21 +367,6 @@ v8::Local<v8::Value> Session::Cookies(v8::Isolate* isolate) {
   return v8::Local<v8::Value>::New(isolate, cookies_);
 }
 
-mate::ObjectTemplateBuilder Session::GetObjectTemplateBuilder(
-    v8::Isolate* isolate) {
-  return mate::ObjectTemplateBuilder(isolate)
-      .MakeDestroyable()
-      .SetMethod("resolveProxy", &Session::ResolveProxy)
-      .SetMethod("clearCache", &Session::ClearCache)
-      .SetMethod("clearStorageData", &Session::ClearStorageData)
-      .SetMethod("setProxy", &Session::SetProxy)
-      .SetMethod("setDownloadPath", &Session::SetDownloadPath)
-      .SetMethod("enableNetworkEmulation", &Session::EnableNetworkEmulation)
-      .SetMethod("disableNetworkEmulation", &Session::DisableNetworkEmulation)
-      .SetMethod("setCertificateVerifyProc", &Session::SetCertVerifyProc)
-      .SetProperty("cookies", &Session::Cookies);
-}
-
 // static
 mate::Handle<Session> Session::CreateFrom(
     v8::Isolate* isolate, AtomBrowserContext* browser_context) {
@@ -400,6 +385,22 @@ mate::Handle<Session> Session::FromPartition(
   auto browser_context = brightray::BrowserContext::From(partition, in_memory);
   return CreateFrom(isolate,
                     static_cast<AtomBrowserContext*>(browser_context.get()));
+}
+
+// static
+void Session::BuildPrototype(v8::Isolate* isolate,
+                             v8::Local<v8::ObjectTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype)
+      .MakeDestroyable()
+      .SetMethod("resolveProxy", &Session::ResolveProxy)
+      .SetMethod("clearCache", &Session::ClearCache)
+      .SetMethod("clearStorageData", &Session::ClearStorageData)
+      .SetMethod("setProxy", &Session::SetProxy)
+      .SetMethod("setDownloadPath", &Session::SetDownloadPath)
+      .SetMethod("enableNetworkEmulation", &Session::EnableNetworkEmulation)
+      .SetMethod("disableNetworkEmulation", &Session::DisableNetworkEmulation)
+      .SetMethod("setCertificateVerifyProc", &Session::SetCertVerifyProc)
+      .SetProperty("cookies", &Session::Cookies);
 }
 
 void ClearWrapSession() {

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -59,12 +59,8 @@ class Session: public mate::TrackableObject<Session>,
   // mate::Wrappable:
   mate::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;
-  bool IsDestroyed() const override;
 
  private:
-  // mate::TrackableObject:
-  void Destroy() override;
-
   void ResolveProxy(const GURL& url, ResolveProxyCallback callback);
   void ClearCache(const net::CompletionCallback& callback);
   void ClearStorageData(mate::Arguments* args);

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -48,6 +48,10 @@ class Session: public mate::TrackableObject<Session>,
 
   AtomBrowserContext* browser_context() const { return browser_context_.get(); }
 
+  // mate::TrackableObject:
+  static void BuildPrototype(v8::Isolate* isolate,
+                             v8::Local<v8::ObjectTemplate> prototype);
+
  protected:
   explicit Session(AtomBrowserContext* browser_context);
   ~Session();
@@ -55,10 +59,6 @@ class Session: public mate::TrackableObject<Session>,
   // content::DownloadManager::Observer:
   void OnDownloadCreated(content::DownloadManager* manager,
                          content::DownloadItem* item) override;
-
-  // mate::Wrappable:
-  mate::ObjectTemplateBuilder GetObjectTemplateBuilder(
-      v8::Isolate* isolate) override;
 
  private:
   void ResolveProxy(const GURL& url, ResolveProxyCallback callback);

--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -94,14 +94,6 @@ void Tray::OnDragEnded() {
   Emit("drag-end");
 }
 
-bool Tray::IsDestroyed() const {
-  return !tray_icon_;
-}
-
-void Tray::Destroy() {
-  tray_icon_.reset();
-}
-
 void Tray::SetImage(mate::Arguments* args, const gfx::Image& image) {
   tray_icon_->SetImage(image);
 }
@@ -162,8 +154,7 @@ v8::Local<v8::Object> Tray::ModifiersToObject(v8::Isolate* isolate,
 void Tray::BuildPrototype(v8::Isolate* isolate,
                           v8::Local<v8::ObjectTemplate> prototype) {
   mate::ObjectTemplateBuilder(isolate, prototype)
-      .SetMethod("destroy", &Tray::Destroy, true)
-      .SetMethod("isDestroyed", &Tray::IsDestroyed, true)
+      .MakeDestroyable()
       .SetMethod("setImage", &Tray::SetImage)
       .SetMethod("setPressedImage", &Tray::SetPressedImage)
       .SetMethod("setToolTip", &Tray::SetToolTip)

--- a/atom/browser/api/atom_api_tray.h
+++ b/atom/browser/api/atom_api_tray.h
@@ -54,12 +54,6 @@ class Tray : public mate::TrackableObject<Tray>,
   void OnDragExited() override;
   void OnDragEnded() override;
 
-  // mate::Wrappable:
-  bool IsDestroyed() const override;
-
-  // mate::TrackableObject:
-  void Destroy() override;
-
   void SetImage(mate::Arguments* args, const gfx::Image& image);
   void SetPressedImage(mate::Arguments* args, const gfx::Image& image);
   void SetToolTip(mate::Arguments* args, const std::string& tool_tip);

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -194,8 +194,6 @@ namespace api {
 
 namespace {
 
-v8::Persistent<v8::ObjectTemplate> template_;
-
 // The wrapWebContents function which is implemented in JavaScript
 using WrapWebContentsCallback = base::Callback<void(v8::Local<v8::Value>)>;
 WrapWebContentsCallback g_wrap_web_contents;
@@ -982,76 +980,72 @@ v8::Local<v8::Value> WebContents::DevToolsWebContents(v8::Isolate* isolate) {
     return v8::Local<v8::Value>::New(isolate, devtools_web_contents_);
 }
 
-mate::ObjectTemplateBuilder WebContents::GetObjectTemplateBuilder(
-    v8::Isolate* isolate) {
-  if (template_.IsEmpty())
-    template_.Reset(isolate, mate::ObjectTemplateBuilder(isolate)
-        .MakeDestroyable()
-        .SetMethod("getId", &WebContents::GetID)
-        .SetMethod("equal", &WebContents::Equal)
-        .SetMethod("_loadURL", &WebContents::LoadURL)
-        .SetMethod("_getURL", &WebContents::GetURL)
-        .SetMethod("getTitle", &WebContents::GetTitle)
-        .SetMethod("isLoading", &WebContents::IsLoading)
-        .SetMethod("isWaitingForResponse", &WebContents::IsWaitingForResponse)
-        .SetMethod("_stop", &WebContents::Stop)
-        .SetMethod("_goBack", &WebContents::GoBack)
-        .SetMethod("_goForward", &WebContents::GoForward)
-        .SetMethod("_goToOffset", &WebContents::GoToOffset)
-        .SetMethod("isCrashed", &WebContents::IsCrashed)
-        .SetMethod("setUserAgent", &WebContents::SetUserAgent)
-        .SetMethod("getUserAgent", &WebContents::GetUserAgent)
-        .SetMethod("insertCSS", &WebContents::InsertCSS)
-        .SetMethod("savePage", &WebContents::SavePage)
-        .SetMethod("_executeJavaScript", &WebContents::ExecuteJavaScript)
-        .SetMethod("openDevTools", &WebContents::OpenDevTools)
-        .SetMethod("closeDevTools", &WebContents::CloseDevTools)
-        .SetMethod("isDevToolsOpened", &WebContents::IsDevToolsOpened)
-        .SetMethod("enableDeviceEmulation",
-                   &WebContents::EnableDeviceEmulation)
-        .SetMethod("disableDeviceEmulation",
-                   &WebContents::DisableDeviceEmulation)
-        .SetMethod("toggleDevTools", &WebContents::ToggleDevTools)
-        .SetMethod("inspectElement", &WebContents::InspectElement)
-        .SetMethod("setAudioMuted", &WebContents::SetAudioMuted)
-        .SetMethod("isAudioMuted", &WebContents::IsAudioMuted)
-        .SetMethod("undo", &WebContents::Undo)
-        .SetMethod("redo", &WebContents::Redo)
-        .SetMethod("cut", &WebContents::Cut)
-        .SetMethod("copy", &WebContents::Copy)
-        .SetMethod("paste", &WebContents::Paste)
-        .SetMethod("pasteAndMatchStyle", &WebContents::PasteAndMatchStyle)
-        .SetMethod("delete", &WebContents::Delete)
-        .SetMethod("selectAll", &WebContents::SelectAll)
-        .SetMethod("unselect", &WebContents::Unselect)
-        .SetMethod("replace", &WebContents::Replace)
-        .SetMethod("replaceMisspelling", &WebContents::ReplaceMisspelling)
-        .SetMethod("focus", &WebContents::Focus)
-        .SetMethod("tabTraverse", &WebContents::TabTraverse)
-        .SetMethod("_send", &WebContents::SendIPCMessage)
-        .SetMethod("sendInputEvent", &WebContents::SendInputEvent)
-        .SetMethod("beginFrameSubscription",
-                   &WebContents::BeginFrameSubscription)
-        .SetMethod("endFrameSubscription", &WebContents::EndFrameSubscription)
-        .SetMethod("setSize", &WebContents::SetSize)
-        .SetMethod("setAllowTransparency", &WebContents::SetAllowTransparency)
-        .SetMethod("isGuest", &WebContents::IsGuest)
-        .SetMethod("getWebPreferences", &WebContents::GetWebPreferences)
-        .SetMethod("getOwnerBrowserWindow", &WebContents::GetOwnerBrowserWindow)
-        .SetMethod("hasServiceWorker", &WebContents::HasServiceWorker)
-        .SetMethod("unregisterServiceWorker",
-                   &WebContents::UnregisterServiceWorker)
-        .SetMethod("inspectServiceWorker", &WebContents::InspectServiceWorker)
-        .SetMethod("print", &WebContents::Print)
-        .SetMethod("_printToPDF", &WebContents::PrintToPDF)
-        .SetMethod("addWorkSpace", &WebContents::AddWorkSpace)
-        .SetMethod("removeWorkSpace", &WebContents::RemoveWorkSpace)
-        .SetProperty("session", &WebContents::Session)
-        .SetProperty("devToolsWebContents", &WebContents::DevToolsWebContents)
-        .Build());
-
-  return mate::ObjectTemplateBuilder(
-      isolate, v8::Local<v8::ObjectTemplate>::New(isolate, template_));
+// static
+void WebContents::BuildPrototype(v8::Isolate* isolate,
+                                 v8::Local<v8::ObjectTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype)
+      .MakeDestroyable()
+      .SetMethod("getId", &WebContents::GetID)
+      .SetMethod("equal", &WebContents::Equal)
+      .SetMethod("_loadURL", &WebContents::LoadURL)
+      .SetMethod("_getURL", &WebContents::GetURL)
+      .SetMethod("getTitle", &WebContents::GetTitle)
+      .SetMethod("isLoading", &WebContents::IsLoading)
+      .SetMethod("isWaitingForResponse", &WebContents::IsWaitingForResponse)
+      .SetMethod("_stop", &WebContents::Stop)
+      .SetMethod("_goBack", &WebContents::GoBack)
+      .SetMethod("_goForward", &WebContents::GoForward)
+      .SetMethod("_goToOffset", &WebContents::GoToOffset)
+      .SetMethod("isCrashed", &WebContents::IsCrashed)
+      .SetMethod("setUserAgent", &WebContents::SetUserAgent)
+      .SetMethod("getUserAgent", &WebContents::GetUserAgent)
+      .SetMethod("insertCSS", &WebContents::InsertCSS)
+      .SetMethod("savePage", &WebContents::SavePage)
+      .SetMethod("_executeJavaScript", &WebContents::ExecuteJavaScript)
+      .SetMethod("openDevTools", &WebContents::OpenDevTools)
+      .SetMethod("closeDevTools", &WebContents::CloseDevTools)
+      .SetMethod("isDevToolsOpened", &WebContents::IsDevToolsOpened)
+      .SetMethod("enableDeviceEmulation",
+                 &WebContents::EnableDeviceEmulation)
+      .SetMethod("disableDeviceEmulation",
+                 &WebContents::DisableDeviceEmulation)
+      .SetMethod("toggleDevTools", &WebContents::ToggleDevTools)
+      .SetMethod("inspectElement", &WebContents::InspectElement)
+      .SetMethod("setAudioMuted", &WebContents::SetAudioMuted)
+      .SetMethod("isAudioMuted", &WebContents::IsAudioMuted)
+      .SetMethod("undo", &WebContents::Undo)
+      .SetMethod("redo", &WebContents::Redo)
+      .SetMethod("cut", &WebContents::Cut)
+      .SetMethod("copy", &WebContents::Copy)
+      .SetMethod("paste", &WebContents::Paste)
+      .SetMethod("pasteAndMatchStyle", &WebContents::PasteAndMatchStyle)
+      .SetMethod("delete", &WebContents::Delete)
+      .SetMethod("selectAll", &WebContents::SelectAll)
+      .SetMethod("unselect", &WebContents::Unselect)
+      .SetMethod("replace", &WebContents::Replace)
+      .SetMethod("replaceMisspelling", &WebContents::ReplaceMisspelling)
+      .SetMethod("focus", &WebContents::Focus)
+      .SetMethod("tabTraverse", &WebContents::TabTraverse)
+      .SetMethod("_send", &WebContents::SendIPCMessage)
+      .SetMethod("sendInputEvent", &WebContents::SendInputEvent)
+      .SetMethod("beginFrameSubscription",
+                 &WebContents::BeginFrameSubscription)
+      .SetMethod("endFrameSubscription", &WebContents::EndFrameSubscription)
+      .SetMethod("setSize", &WebContents::SetSize)
+      .SetMethod("setAllowTransparency", &WebContents::SetAllowTransparency)
+      .SetMethod("isGuest", &WebContents::IsGuest)
+      .SetMethod("getWebPreferences", &WebContents::GetWebPreferences)
+      .SetMethod("getOwnerBrowserWindow", &WebContents::GetOwnerBrowserWindow)
+      .SetMethod("hasServiceWorker", &WebContents::HasServiceWorker)
+      .SetMethod("unregisterServiceWorker",
+                 &WebContents::UnregisterServiceWorker)
+      .SetMethod("inspectServiceWorker", &WebContents::InspectServiceWorker)
+      .SetMethod("print", &WebContents::Print)
+      .SetMethod("_printToPDF", &WebContents::PrintToPDF)
+      .SetMethod("addWorkSpace", &WebContents::AddWorkSpace)
+      .SetMethod("removeWorkSpace", &WebContents::RemoveWorkSpace)
+      .SetProperty("session", &WebContents::Session)
+      .SetProperty("devToolsWebContents", &WebContents::DevToolsWebContents);
 }
 
 AtomBrowserContext* WebContents::GetBrowserContext() const {

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -54,9 +54,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
   static mate::Handle<WebContents> Create(
       v8::Isolate* isolate, const mate::Dictionary& options);
 
-  // mate::TrackableObject:
-  void Destroy() override;
-
   int GetID() const;
   bool Equal(const WebContents* web_contents) const;
   void LoadURL(const GURL& url, const mate::Dictionary& options);
@@ -152,7 +149,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
   // mate::Wrappable:
   mate::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;
-  bool IsDestroyed() const override;
 
   // content::WebContentsDelegate:
   bool AddMessageToConsole(content::WebContents* source,

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -141,14 +141,14 @@ class WebContents : public mate::TrackableObject<WebContents>,
   v8::Local<v8::Value> Session(v8::Isolate* isolate);
   v8::Local<v8::Value> DevToolsWebContents(v8::Isolate* isolate);
 
+  // mate::TrackableObject:
+  static void BuildPrototype(v8::Isolate* isolate,
+                             v8::Local<v8::ObjectTemplate> prototype);
+
  protected:
   explicit WebContents(content::WebContents* web_contents);
   WebContents(v8::Isolate* isolate, const mate::Dictionary& options);
   ~WebContents();
-
-  // mate::Wrappable:
-  mate::ObjectTemplateBuilder GetObjectTemplateBuilder(
-      v8::Isolate* isolate) override;
 
   // content::WebContentsDelegate:
   bool AddMessageToConsole(content::WebContents* source,

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -77,13 +77,7 @@ class Window : public mate::TrackableObject<Window>,
   void OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) override;
   #endif
 
-  // mate::Wrappable:
-  bool IsDestroyed() const override;
-
  private:
-  // mate::TrackableObject:
-  void Destroy() override;
-
   // APIs for NativeWindow.
   void Close();
   void Focus();

--- a/atom/browser/api/trackable_object.cc
+++ b/atom/browser/api/trackable_object.cc
@@ -30,8 +30,7 @@ class IDUserData : public base::SupportsUserData::Data {
 
 TrackableObjectBase::TrackableObjectBase()
     : weak_map_id_(0), wrapped_(nullptr), weak_factory_(this) {
-  RegisterDestructionCallback(
-      base::Bind(&TrackableObjectBase::Destroy, weak_factory_.GetWeakPtr()));
+  RegisterDestructionCallback(GetDestroyClosure());
 }
 
 TrackableObjectBase::~TrackableObjectBase() {
@@ -40,6 +39,18 @@ TrackableObjectBase::~TrackableObjectBase() {
 void TrackableObjectBase::AfterInit(v8::Isolate* isolate) {
   if (wrapped_)
     AttachAsUserData(wrapped_);
+}
+
+void TrackableObjectBase::MarkDestroyed() {
+  GetWrapper(isolate())->SetAlignedPointerInInternalField(0, nullptr);
+}
+
+base::Closure TrackableObjectBase::GetDestroyClosure() {
+  return base::Bind(&TrackableObjectBase::Destroy, weak_factory_.GetWeakPtr());
+}
+
+void TrackableObjectBase::Destroy() {
+  delete this;
 }
 
 void TrackableObjectBase::AttachAsUserData(base::SupportsUserData* wrapped) {

--- a/atom/browser/api/trackable_object.cc
+++ b/atom/browser/api/trackable_object.cc
@@ -30,10 +30,11 @@ class IDUserData : public base::SupportsUserData::Data {
 
 TrackableObjectBase::TrackableObjectBase()
     : weak_map_id_(0), wrapped_(nullptr), weak_factory_(this) {
-  RegisterDestructionCallback(GetDestroyClosure());
+  cleanup_ = RegisterDestructionCallback(GetDestroyClosure());
 }
 
 TrackableObjectBase::~TrackableObjectBase() {
+  cleanup_.Run();
 }
 
 void TrackableObjectBase::AfterInit(v8::Isolate* isolate) {
@@ -74,9 +75,9 @@ int32_t TrackableObjectBase::GetIDFromWrappedClass(base::SupportsUserData* w) {
 }
 
 // static
-void TrackableObjectBase::RegisterDestructionCallback(
-    const base::Closure& closure) {
-  atom::AtomBrowserMainParts::Get()->RegisterDestructionCallback(closure);
+base::Closure TrackableObjectBase::RegisterDestructionCallback(
+    const base::Closure& c) {
+  return atom::AtomBrowserMainParts::Get()->RegisterDestructionCallback(c);
 }
 
 }  // namespace mate

--- a/atom/browser/api/trackable_object.h
+++ b/atom/browser/api/trackable_object.h
@@ -48,7 +48,7 @@ class TrackableObjectBase : public mate::EventEmitter {
 
   // Register a callback that should be destroyed before JavaScript environment
   // gets destroyed.
-  static void RegisterDestructionCallback(const base::Closure& closure);
+  static base::Closure RegisterDestructionCallback(const base::Closure& c);
 
   int32_t weak_map_id_;
   base::SupportsUserData* wrapped_;
@@ -56,6 +56,7 @@ class TrackableObjectBase : public mate::EventEmitter {
  private:
   void Destroy();
 
+  base::Closure cleanup_;
   base::WeakPtrFactory<TrackableObjectBase> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(TrackableObjectBase);

--- a/atom/browser/api/trackable_object.h
+++ b/atom/browser/api/trackable_object.h
@@ -30,14 +30,17 @@ class TrackableObjectBase : public mate::EventEmitter {
   // Wrap TrackableObject into a class that SupportsUserData.
   void AttachAsUserData(base::SupportsUserData* wrapped);
 
-  // Subclasses should implement this to destroy their native types.
-  virtual void Destroy() = 0;
-
  protected:
   ~TrackableObjectBase() override;
 
   // mate::Wrappable:
   void AfterInit(v8::Isolate* isolate) override;
+
+  // Mark the JS object as destroyed.
+  void MarkDestroyed();
+
+  // Returns a closure that can destroy the native class.
+  base::Closure GetDestroyClosure();
 
   // Get the weak_map_id from SupportsUserData.
   static int32_t GetIDFromWrappedClass(base::SupportsUserData* wrapped);
@@ -50,6 +53,8 @@ class TrackableObjectBase : public mate::EventEmitter {
   base::SupportsUserData* wrapped_;
 
  private:
+  void Destroy();
+
   base::WeakPtrFactory<TrackableObjectBase> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(TrackableObjectBase);

--- a/atom/browser/atom_browser_main_parts.h
+++ b/atom/browser/atom_browser_main_parts.h
@@ -36,7 +36,8 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
 
   // Register a callback that should be destroyed before JavaScript environment
   // gets destroyed.
-  void RegisterDestructionCallback(const base::Closure& callback);
+  // Returns a closure that can be used to remove |callback| from the list.
+  base::Closure RegisterDestructionCallback(const base::Closure& callback);
 
   Browser* browser() { return browser_.get(); }
 
@@ -82,7 +83,7 @@ class AtomBrowserMainParts : public brightray::BrowserMainParts {
   base::Timer gc_timer_;
 
   // List of callbacks should be executed before destroying JS env.
-  std::list<base::Closure> destruction_callbacks_;
+  std::list<base::Closure> destructors_;
 
   static AtomBrowserMainParts* self_;
 

--- a/atom/browser/lib/guest-window-manager.coffee
+++ b/atom/browser/lib/guest-window-manager.coffee
@@ -39,11 +39,12 @@ createGuest = (embedder, url, frameName, options) ->
   # When |embedder| is destroyed we should also destroy attached guest, and if
   # guest is closed by user then we should prevent |embedder| from double
   # closing guest.
+  guestId = guest.id
   closedByEmbedder = ->
     guest.removeListener 'closed', closedByUser
     guest.destroy()
   closedByUser = ->
-    embedder.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSED', guest.id
+    embedder.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSED', guestId
     embedder.removeListener 'render-view-deleted', closedByEmbedder
   embedder.once 'render-view-deleted', closedByEmbedder
   guest.once 'closed', closedByUser

--- a/atom/common/native_mate_converters/callback.cc
+++ b/atom/common/native_mate_converters/callback.cc
@@ -5,6 +5,9 @@
 #include "atom/common/native_mate_converters/callback.h"
 
 #include "atom/browser/atom_browser_main_parts.h"
+#include "content/public/browser/browser_thread.h"
+
+using content::BrowserThread;
 
 namespace mate {
 
@@ -56,31 +59,72 @@ v8::Local<v8::Value> BindFunctionWith(v8::Isolate* isolate,
 
 }  // namespace
 
+// Destroy the class on UI thread when possible.
+struct DeleteOnUIThread {
+  template<typename T>
+  static void Destruct(const T* x) {
+    if (Locker::IsBrowserProcess() &&
+        !BrowserThread::CurrentlyOn(BrowserThread::UI)) {
+      BrowserThread::DeleteSoon(BrowserThread::UI, FROM_HERE, x);
+    } else {
+      delete x;
+    }
+  }
+};
+
+// Like v8::Global, but ref-counted.
+template<typename T>
+class RefCountedGlobal : public base::RefCountedThreadSafe<RefCountedGlobal<T>,
+                                                           DeleteOnUIThread> {
+ public:
+  RefCountedGlobal(v8::Isolate* isolate, v8::Local<v8::Value> value)
+      : handle_(isolate, v8::Local<T>::Cast(value)),
+        weak_factory_(this) {
+    // In browser process, we need to ensure the V8 handle is destroyed before
+    // the JavaScript env gets destroyed.
+    if (Locker::IsBrowserProcess() && atom::AtomBrowserMainParts::Get()) {
+      atom::AtomBrowserMainParts::Get()->RegisterDestructionCallback(
+          base::Bind(&RefCountedGlobal<T>::FreeHandle,
+                     weak_factory_.GetWeakPtr()));
+    }
+  }
+
+  bool IsAlive() const {
+    return !handle_.IsEmpty();
+  }
+
+  v8::Local<T> NewHandle(v8::Isolate* isolate) const {
+    return v8::Local<T>::New(isolate, handle_);
+  }
+
+ private:
+  void FreeHandle() {
+    handle_.Reset();
+  }
+
+  v8::Global<T> handle_;
+  base::WeakPtrFactory<RefCountedGlobal<T>> weak_factory_;
+
+  DISALLOW_COPY_AND_ASSIGN(RefCountedGlobal);
+};
+
 SafeV8Function::SafeV8Function(v8::Isolate* isolate, v8::Local<v8::Value> value)
-    : v8_function_(new RefCountedPersistent<v8::Function>(isolate, value)),
-      weak_factory_(this) {
-  Init();
+    : v8_function_(new RefCountedGlobal<v8::Function>(isolate, value)) {
 }
 
 SafeV8Function::SafeV8Function(const SafeV8Function& other)
-    : v8_function_(other.v8_function_),
-      weak_factory_(this) {
-  Init();
+    : v8_function_(other.v8_function_) {
 }
 
-v8::Local<v8::Function> SafeV8Function::NewHandle() const {
-  return v8_function_->NewHandle();
+SafeV8Function::~SafeV8Function() {
 }
 
-void SafeV8Function::Init() {
-  if (Locker::IsBrowserProcess() && atom::AtomBrowserMainParts::Get())
-    atom::AtomBrowserMainParts::Get()->RegisterDestructionCallback(
-        base::Bind(&SafeV8Function::FreeHandle, weak_factory_.GetWeakPtr()));
+bool SafeV8Function::IsAlive() const {
+  return v8_function_.get() && v8_function_->IsAlive();
 }
 
-void SafeV8Function::FreeHandle() {
-  Locker locker(v8_function_->isolate());
-  v8_function_ = nullptr;
+v8::Local<v8::Function> SafeV8Function::NewHandle(v8::Isolate* isolate) const {
+  return v8_function_->NewHandle(isolate);
 }
 
 v8::Local<v8::Value> CreateFunctionFromTranslater(

--- a/atom/common/native_mate_converters/callback.h
+++ b/atom/common/native_mate_converters/callback.h
@@ -19,23 +19,21 @@ namespace mate {
 
 namespace internal {
 
-// Manages the V8 function with RAII, and automatically cleans the handle when
-// JavaScript context is destroyed, even when the class is not destroyed.
+template<typename T>
+class RefCountedGlobal;
+
+// Manages the V8 function with RAII.
 class SafeV8Function {
  public:
   SafeV8Function(v8::Isolate* isolate, v8::Local<v8::Value> value);
   SafeV8Function(const SafeV8Function& other);
+  ~SafeV8Function();
 
-  bool is_alive() const { return v8_function_.get(); }
-
-  v8::Local<v8::Function> NewHandle() const;
+  bool IsAlive() const;
+  v8::Local<v8::Function> NewHandle(v8::Isolate* isolate) const;
 
  private:
-  void Init();
-  void FreeHandle();
-
-  scoped_refptr<RefCountedPersistent<v8::Function>> v8_function_;
-  base::WeakPtrFactory<SafeV8Function> weak_factory_;
+  scoped_refptr<RefCountedGlobal<v8::Function>> v8_function_;
 };
 
 // Helper to invoke a V8 function with C++ parameters.
@@ -49,12 +47,12 @@ struct V8FunctionInvoker<v8::Local<v8::Value>(ArgTypes...)> {
                                  ArgTypes... raw) {
     Locker locker(isolate);
     v8::EscapableHandleScope handle_scope(isolate);
-    if (!function.is_alive())
+    if (!function.IsAlive())
       return v8::Null(isolate);
     scoped_ptr<blink::WebScopedRunV8Script> script_scope(
         Locker::IsBrowserProcess() ?
         nullptr : new blink::WebScopedRunV8Script(isolate));
-    v8::Local<v8::Function> holder = function.NewHandle();
+    v8::Local<v8::Function> holder = function.NewHandle(isolate);
     v8::Local<v8::Context> context = holder->CreationContext();
     v8::Context::Scope context_scope(context);
     std::vector<v8::Local<v8::Value>> args = { ConvertToV8(isolate, raw)... };
@@ -70,12 +68,12 @@ struct V8FunctionInvoker<void(ArgTypes...)> {
                  ArgTypes... raw) {
     Locker locker(isolate);
     v8::HandleScope handle_scope(isolate);
-    if (!function.is_alive())
+    if (!function.IsAlive())
       return;
     scoped_ptr<blink::WebScopedRunV8Script> script_scope(
         Locker::IsBrowserProcess() ?
         nullptr : new blink::WebScopedRunV8Script(isolate));
-    v8::Local<v8::Function> holder = function.NewHandle();
+    v8::Local<v8::Function> holder = function.NewHandle(isolate);
     v8::Local<v8::Context> context = holder->CreationContext();
     v8::Context::Scope context_scope(context);
     std::vector<v8::Local<v8::Value>> args = { ConvertToV8(isolate, raw)... };
@@ -91,12 +89,12 @@ struct V8FunctionInvoker<ReturnType(ArgTypes...)> {
     Locker locker(isolate);
     v8::HandleScope handle_scope(isolate);
     ReturnType ret = ReturnType();
-    if (!function.is_alive())
+    if (!function.IsAlive())
       return ret;
     scoped_ptr<blink::WebScopedRunV8Script> script_scope(
         Locker::IsBrowserProcess() ?
         nullptr : new blink::WebScopedRunV8Script(isolate));
-    v8::Local<v8::Function> holder = function.NewHandle();
+    v8::Local<v8::Function> holder = function.NewHandle(isolate);
     v8::Local<v8::Context> context = holder->CreationContext();
     v8::Context::Scope context_scope(context);
     std::vector<v8::Local<v8::Value>> args = { ConvertToV8(isolate, raw)... };


### PR DESCRIPTION
This PR fixes a problem that some V8 handles are deleted on IO thread when a V8 function is used as protocol handlers, close #3419.

There also some more improvements on the management of JavaScript objects' lifetime to make the fix possible, currently a native JavaScript object could be deleted in following ways:
* V8 garbage collected the object.
* User calls the `destroy` method.
* When JavaScript environment is destroyed, all objects get deleted by Electron.
* When the holder of a V8 object gets deleted on IO thread, transfer the deletion to UI thread.