### PR TITLE
Use https for downloading libchromiumcontent

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -7,7 +7,7 @@ import sys
 
 
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
-    'http://gh-contractor-zcbenz.s3.amazonaws.com/libchromiumcontent'
+    'https://s3.amazonaws.com/gh-contractor-zcbenz/libchromiumcontent'
 LIBCHROMIUMCONTENT_COMMIT = '17a4337f7948a45b5ea4b8f391df152ba8db5979'
 
 PLATFORM = {


### PR DESCRIPTION
Uses `https://s3.amazonaws.com/gh-contractor-zcbenz/` instead of `https://gh-contractor-zcbenz.s3.amazonaws.com/` so should work with python versions that don't deal with subdomain certs properly.