### PR TITLE
Docs: Fix link to webcontents send channel

### DIFF
--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -68,4 +68,4 @@ Returns the `webContents` that sent the message, you can call
 `event.sender.send` to reply to the asynchronous message, see
 [webContents.send][webcontents-send] for more information.
 
-[webcontents-send]: web-contents.md#webcontentssendchannel-args
+[webcontents-send]: web-contents.md#webcontentssendchannel-arg1-arg2-


### PR DESCRIPTION
Fixes https://github.com/atom/electron/issues/3693
As much as is possible considering https://github.com/atom/electron.atom.io/issues/80

I've gone for the link generated in the raw markdown by github rather than the one generated on the electron website because a) the electron website one is more likely to change that the github one (I would have thought?) b) the electron website is broken no matter what because the path is also wrong.