### PR TITLE
protocol: provide upload data when available

### DIFF
--- a/atom/browser/net/url_request_fetch_job.cc
+++ b/atom/browser/net/url_request_fetch_job.cc
@@ -90,12 +90,14 @@ void URLRequestFetchJob::StartAsync(scoped_ptr<base::Value> options) {
 
   std::string url, method, referrer;
   base::Value* session = nullptr;
+  base::DictionaryValue* upload_data = nullptr;
   base::DictionaryValue* dict =
       static_cast<base::DictionaryValue*>(options.get());
   dict->GetString("url", &url);
   dict->GetString("method", &method);
   dict->GetString("referrer", &referrer);
   dict->Get("session", &session);
+  dict->GetDictionary("uploadData", &upload_data);
 
   // Check if URL is valid.
   GURL formated_url(url);
@@ -126,6 +128,14 @@ void URLRequestFetchJob::StartAsync(scoped_ptr<base::Value> options) {
     fetcher_->SetReferrer(request()->referrer());
   else
     fetcher_->SetReferrer(referrer);
+
+  // Set the data needed for POSTs.
+  if (upload_data && request_type == net::URLFetcher::POST) {
+    std::string content_type, data;
+    upload_data->GetString("contentType", &content_type);
+    upload_data->GetString("data", &data);
+    fetcher_->SetUploadData(content_type, data);
+  }
 
   // Use |request|'s headers.
   fetcher_->SetExtraRequestHeaders(

--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -5,9 +5,14 @@
 #include "atom/common/native_mate_converters/net_converter.h"
 
 #include <string>
+#include <vector>
 
 #include "atom/common/node_includes.h"
 #include "native_mate/dictionary.h"
+#include "net/base/upload_bytes_element_reader.h"
+#include "net/base/upload_data_stream.h"
+#include "net/base/upload_element_reader.h"
+#include "net/base/upload_file_element_reader.h"
 #include "net/cert/x509_certificate.h"
 #include "net/url_request/url_request.h"
 
@@ -20,6 +25,30 @@ v8::Local<v8::Value> Converter<const net::URLRequest*>::ToV8(
   dict.Set("method", val->method());
   dict.Set("url", val->url().spec());
   dict.Set("referrer", val->referrer());
+  const net::UploadDataStream* upload_data = val->get_upload();
+  if (upload_data) {
+    const ScopedVector<net::UploadElementReader>* readers =
+        upload_data->GetElementReaders();
+    std::vector<mate::Dictionary> upload_data_list;
+    upload_data_list.reserve(readers->size());
+    for (const auto& reader : *readers) {
+      auto upload_data_dict = mate::Dictionary::CreateEmpty(isolate);
+      if (reader->AsBytesReader()) {
+        const net::UploadBytesElementReader* bytes_reader =
+            reader->AsBytesReader();
+        auto bytes =
+            node::Buffer::Copy(isolate, bytes_reader->bytes(),
+                               bytes_reader->length()).ToLocalChecked();
+        upload_data_dict.Set("bytes", bytes);
+      } else if (reader->AsFileReader()) {
+        const net::UploadFileElementReader* file_reader =
+            reader->AsFileReader();
+        upload_data_dict.Set("file", file_reader->path().AsUTF8Unsafe());
+      }
+      upload_data_list.push_back(upload_data_dict);
+    }
+    dict.Set("uploadData", upload_data_list);
+  }
   return mate::ConvertToV8(isolate, dict);
 }
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -103,10 +103,15 @@ Registers a protocol of `scheme` that will send a `String` as a response. The
 
 Registers a protocol of `scheme` that will send an HTTP request as a response.
 The `callback` should be called with an object that has the `url`, `method`,
-`referrer`, and `session` properties.
+`referrer`, `uploadData` and `session` properties.
 
 By default the HTTP request will reuse the current session. If you want the
 request to have a different session you should set `session` to `null`.
+
+POST request should provide an `uploadData` object.
+* `uploadData` object
+  * `contentType` String - MIME type of the content.
+  *  `data` String - Content to be sent.
 
 ### `protocol.unregisterProtocol(scheme[, completion])`
 


### PR DESCRIPTION
Fixes #3684 

```
* uploadData [object]
  * bytes Buffer - content to be sent for the request
  * file String - Path of file to be uploaded
```

Also `*HttpProtocol` handles content to be set for POST request now.
```
* uploadData Object
  * contentType String
  * data String 
```