### PR TITLE
support an api with SetIgnoreMouseEvents for osx

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -488,6 +488,10 @@ bool Window::IsDocumentEdited() {
   return window_->IsDocumentEdited();
 }
 
+void Window::SetIgnoreMouseEvents(bool ignore) {
+  return window_->SetIgnoreMouseEvents(ignore);
+}
+
 void Window::CapturePage(mate::Arguments* args) {
   gfx::Rect rect;
   base::Callback<void(const gfx::Image&)> callback;
@@ -662,6 +666,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getRepresentedFilename", &Window::GetRepresentedFilename)
       .SetMethod("setDocumentEdited", &Window::SetDocumentEdited)
       .SetMethod("isDocumentEdited", &Window::IsDocumentEdited)
+      .SetMethod("setIgnoreMouseEvents", &Window::SetIgnoreMouseEvents)
       .SetMethod("focusOnWebView", &Window::FocusOnWebView)
       .SetMethod("blurWebView", &Window::BlurWebView)
       .SetMethod("isWebViewFocused", &Window::IsWebViewFocused)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -126,6 +126,7 @@ class Window : public mate::TrackableObject<Window>,
   std::string GetRepresentedFilename();
   void SetDocumentEdited(bool edited);
   bool IsDocumentEdited();
+  void SetIgnoreMouseEvents(bool ignore);
   void CapturePage(mate::Arguments* args);
   void SetProgressBar(double progress);
   void SetOverlayIcon(const gfx::Image& overlay,

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -245,6 +245,9 @@ bool NativeWindow::IsDocumentEdited() {
   return false;
 }
 
+void NativeWindow::SetIgnoreMouseEvents(bool ignore) {
+}
+
 void NativeWindow::SetMenu(ui::MenuModel* menu) {
 }
 

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -139,6 +139,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual std::string GetRepresentedFilename();
   virtual void SetDocumentEdited(bool edited);
   virtual bool IsDocumentEdited();
+  virtual void SetIgnoreMouseEvents(bool ignore);
   virtual void SetMenu(ui::MenuModel* menu);
   virtual bool HasModalDialog();
   virtual gfx::NativeWindow GetNativeWindow() = 0;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -62,6 +62,7 @@ class NativeWindowMac : public NativeWindow {
   std::string GetRepresentedFilename() override;
   void SetDocumentEdited(bool edited) override;
   bool IsDocumentEdited() override;
+  void SetIgnoreMouseEvents(bool ignore) override;
   bool HasModalDialog() override;
   gfx::NativeWindow GetNativeWindow() override;
   void SetProgressBar(double progress) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -687,6 +687,10 @@ bool NativeWindowMac::IsDocumentEdited() {
   return [window_ isDocumentEdited];
 }
 
+void NativeWindowMac::SetIgnoreMouseEvents(bool ignore) {
+  [window_ setIgnoresMouseEvents:ignore];
+}
+
 bool NativeWindowMac::HasModalDialog() {
   return [window_ attachedSheet] != nil;
 }


### PR DESCRIPTION
as https://github.com/atom/electron/issues/2864 said, i also wanner if can support that feature,so i write a PR for it,but it only works with osx:
```
var win = new BrowserWindow({...});
win.setIgnoreMouseEvents(true); //enable ignore all events in osx
```