### PR TITLE
Do not modify the specified menu template

### DIFF
--- a/atom/browser/api/lib/menu-item.coffee
+++ b/atom/browser/api/lib/menu-item.coffee
@@ -24,8 +24,10 @@ class MenuItem
   constructor: (options) ->
     {Menu} = require 'electron'
 
-    {click, @selector, @type, @role, @label, @sublabel, @accelerator, @icon, @enabled, @visible, @checked, @submenu} = options
+    {click, @selector, @type, @role, @label, @sublabel, @accelerator, @icon, @enabled, @visible, @checked} = options
 
+    if options.submenu? and options.submenu.constructor isnt Menu
+      @submenu = Menu.buildFromTemplate options.submenu
     @type = 'submenu' if not @type? and @submenu?
     throw new Error('Invalid submenu') if @type is 'submenu' and @submenu?.constructor isnt Menu
 

--- a/atom/browser/api/lib/menu-item.coffee
+++ b/atom/browser/api/lib/menu-item.coffee
@@ -26,8 +26,11 @@ class MenuItem
 
     {click, @selector, @type, @role, @label, @sublabel, @accelerator, @icon, @enabled, @visible, @checked} = options
 
-    if options.submenu? and options.submenu.constructor isnt Menu
-      @submenu = Menu.buildFromTemplate options.submenu
+    if options.submenu?
+      if options.submenu.constructor is Menu
+        @submenu = options.submenu
+      else
+        @submenu = Menu.buildFromTemplate options.submenu
     @type = 'submenu' if not @type? and @submenu?
     throw new Error('Invalid submenu') if @type is 'submenu' and @submenu?.constructor isnt Menu
 

--- a/atom/browser/api/lib/menu-item.coffee
+++ b/atom/browser/api/lib/menu-item.coffee
@@ -24,13 +24,10 @@ class MenuItem
   constructor: (options) ->
     {Menu} = require 'electron'
 
-    {click, @selector, @type, @role, @label, @sublabel, @accelerator, @icon, @enabled, @visible, @checked} = options
+    {click, @selector, @type, @role, @label, @sublabel, @accelerator, @icon, @enabled, @visible, @checked, @submenu} = options
 
-    if options.submenu?
-      if options.submenu.constructor is Menu
-        @submenu = options.submenu
-      else
-        @submenu = Menu.buildFromTemplate options.submenu
+    if @submenu? and @submenu.constructor isnt Menu
+      @submenu = Menu.buildFromTemplate @submenu
     @type = 'submenu' if not @type? and @submenu?
     throw new Error('Invalid submenu') if @type is 'submenu' and @submenu?.constructor isnt Menu
 

--- a/atom/browser/api/lib/menu.coffee
+++ b/atom/browser/api/lib/menu.coffee
@@ -170,7 +170,7 @@ Menu.buildFromTemplate = (template) ->
     throw new TypeError('Invalid template for MenuItem') unless typeof item is 'object'
 
     menuItem = new MenuItem(item)
-    menuItem[key] = value for key, value of item when not menuItem[key]?
+    menuItem[key] ?= value for key, value of item
     menu.append menuItem
 
   menu

--- a/atom/browser/api/lib/menu.coffee
+++ b/atom/browser/api/lib/menu.coffee
@@ -169,7 +169,6 @@ Menu.buildFromTemplate = (template) ->
   for item in positionedTemplate
     throw new TypeError('Invalid template for MenuItem') unless typeof item is 'object'
 
-    item.submenu = Menu.buildFromTemplate item.submenu if item.submenu?
     menuItem = new MenuItem(item)
     menuItem[key] = value for key, value of item when not menuItem[key]?
     menu.append menuItem

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -26,7 +26,9 @@ Create a new `MenuItem` with the following method:
   * `visible` Boolean
   * `checked` Boolean
   * `submenu` Menu - Should be specified for `submenu` type menu item, when
-     it's specified the `type: 'submenu'` can be omitted for the menu item
+     it's specified the `type: 'submenu'` can be omitted for the menu item.
+     If the value is not a `Menu` then it will be automatically converted to one
+     using `Menu.buildFromTemplate`.
   * `id` String - Unique within a single menu. If defined then it can be used
      as a reference to this item by the position attribute.
   * `position` String - This field allows fine-grained definition of the

--- a/spec/api-menu-spec.coffee
+++ b/spec/api-menu-spec.coffee
@@ -1,6 +1,6 @@
 assert = require 'assert'
 
-{remote} = require 'electron'
+{remote, ipcRenderer} = require 'electron'
 {Menu, MenuItem} = remote.require 'electron'
 
 describe 'menu module', ->
@@ -8,6 +8,11 @@ describe 'menu module', ->
     it 'should be able to attach extra fields', ->
       menu = Menu.buildFromTemplate [label: 'text', extra: 'field']
       assert.equal menu.items[0].extra, 'field'
+
+    it 'does not modify the specified template', ->
+      template = [label: 'text', submenu: [label: 'sub']]
+      builtTemplate = ipcRenderer.sendSync('menu-build-from-template', template)
+      assert.deepStrictEqual builtTemplate, template
 
     describe 'Menu.buildFromTemplate should reorder based on item position specifiers', ->
       it 'should position before existing item', ->

--- a/spec/api-menu-spec.coffee
+++ b/spec/api-menu-spec.coffee
@@ -10,9 +10,12 @@ describe 'menu module', ->
       assert.equal menu.items[0].extra, 'field'
 
     it 'does not modify the specified template', ->
-      template = [label: 'text', submenu: [label: 'sub']]
-      builtTemplate = ipcRenderer.sendSync('menu-build-from-template', template)
-      assert.deepStrictEqual builtTemplate, template
+      template = ipcRenderer.sendSync 'eval', """
+        var template = [{label: 'text', submenu: [{label: 'sub'}]}];
+        require('electron').Menu.buildFromTemplate(template);
+        template;
+      """
+      assert.deepStrictEqual template, [label: 'text', submenu: [label: 'sub']]
 
     describe 'Menu.buildFromTemplate should reorder based on item position specifiers', ->
       it 'should position before existing item', ->

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -3,7 +3,6 @@ const app           = electron.app;
 const ipcMain       = electron.ipcMain;
 const dialog        = electron.dialog;
 const BrowserWindow = electron.BrowserWindow;
-const Menu          = electron.Menu;
 
 const path = require('path');
 
@@ -42,12 +41,6 @@ ipcMain.on('eval', function(event, script) {
 ipcMain.on('echo', function(event, msg) {
   event.returnValue = msg;
 });
-
-// Verify Menu.buildFromTemplate does not modify the specified template
-ipcMain.on('menu-build-from-template', function(event, template) {
-  Menu.buildFromTemplate(template);
-  event.returnValue = template;
-})
 
 if (process.argv[2] == '--ci') {
   process.removeAllListeners('uncaughtException');

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -43,6 +43,12 @@ ipcMain.on('echo', function(event, msg) {
   event.returnValue = msg;
 });
 
+// Verify Menu.buildFromTemplate does not modify the specified template
+ipcMain.on('menu-build-from-template', function(event, template) {
+  Menu.buildFromTemplate(template);
+  event.returnValue = template;
+})
+
 if (process.argv[2] == '--ci') {
   process.removeAllListeners('uncaughtException');
   process.on('uncaughtException', function(error) {
@@ -101,10 +107,4 @@ app.on('ready', function() {
         });
     event.returnValue = "done";
   });
-
-  // Verify Menu.buildFromTemplate does not modify the specified template
-  ipcMain.on('menu-build-from-template', function(event, template) {
-    Menu.buildFromTemplate(template);
-    event.returnValue = template;
-  })
 });

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -3,6 +3,7 @@ const app           = electron.app;
 const ipcMain       = electron.ipcMain;
 const dialog        = electron.dialog;
 const BrowserWindow = electron.BrowserWindow;
+const Menu          = electron.Menu;
 
 const path = require('path');
 
@@ -100,4 +101,10 @@ app.on('ready', function() {
         });
     event.returnValue = "done";
   });
+
+  // Verify Menu.buildFromTemplate does not modify the specified template
+  ipcMain.on('menu-build-from-template', function(event, template) {
+    Menu.buildFromTemplate(template);
+    event.returnValue = template;
+  })
 });


### PR DESCRIPTION
Don't re-assign the `submenu` field on the template passed to `Menu.buildFromTemplate`.

This also changes the `new MenuItem(options)` constructor to convert `options.submenu` to a `Menu` if it isn't one already which seems beneficial.

Closes #3596 