### PR TITLE
Fix grammatical error in desktop notification docs

### DIFF
--- a/docs/tutorial/desktop-environment-integration.md
+++ b/docs/tutorial/desktop-environment-integration.md
@@ -25,7 +25,7 @@ myNotification.onclick = function () {
 }
 ```
 
-While code and user experience across operating systems are similar, but there
+While code and user experience across operating systems are similar, there
 are fine differences.
 
 ### Windows


### PR DESCRIPTION
Noticed this as I was reading along in the documentation.