### PR TITLE
fix chrome app and user path conflicts

### DIFF
--- a/chromium_src/chrome/common/chrome_paths.h
+++ b/chromium_src/chrome/common/chrome_paths.h
@@ -17,7 +17,7 @@ class FilePath;
 namespace chrome {
 
 enum {
-  PATH_START = 1000,
+  PATH_START = 2000,
 
   DIR_APP = PATH_START,         // Directory where dlls and data reside.
   DIR_LOGS,                     // Directory where logs should be written.


### PR DESCRIPTION
Fixes https://github.com/atom/electron/issues/3709

https://github.com/atom/electron/pull/3421 enum values of `chrome::DIR_APP` and `chrome::DIR_USER_DATA` conflict with our brightray values and register in pathservice.

