### PR TITLE
protocol: api to register schemes that can handle service worker

### DIFF
--- a/atom/app/atom_content_client.h
+++ b/atom/app/atom_content_client.h
@@ -5,6 +5,7 @@
 #ifndef ATOM_APP_ATOM_CONTENT_CLIENT_H_
 #define ATOM_APP_ATOM_CONTENT_CLIENT_H_
 
+#include <set>
 #include <string>
 #include <vector>
 
@@ -26,6 +27,8 @@ class AtomContentClient : public brightray::ContentClient {
       std::vector<std::string>* savable_schemes) override;
   void AddPepperPlugins(
       std::vector<content::PepperPluginInfo>* plugins) override;
+  void AddServiceWorkerSchemes(
+      std::set<std::string>* service_worker_schemes) override;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(AtomContentClient);

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -32,6 +32,8 @@ mate::ObjectTemplateBuilder Protocol::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
   return mate::ObjectTemplateBuilder(isolate)
       .SetMethod("registerStandardSchemes", &Protocol::RegisterStandardSchemes)
+      .SetMethod("registerServiceWorkerSchemes",
+                 &Protocol::RegisterServiceWorkerSchemes)
       .SetMethod("registerStringProtocol",
                  &Protocol::RegisterProtocol<URLRequestStringJob>)
       .SetMethod("registerBufferProtocol",
@@ -56,6 +58,11 @@ mate::ObjectTemplateBuilder Protocol::GetObjectTemplateBuilder(
 void Protocol::RegisterStandardSchemes(
     const std::vector<std::string>& schemes) {
   atom::AtomBrowserClient::SetCustomSchemes(schemes);
+}
+
+void Protocol::RegisterServiceWorkerSchemes(
+    const std::vector<std::string>& schemes) {
+  atom::AtomBrowserClient::SetCustomServiceWorkerSchemes(schemes);
 }
 
 void Protocol::UnregisterProtocol(

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -92,6 +92,9 @@ class Protocol : public mate::Wrappable {
   // Register schemes to standard scheme list.
   void RegisterStandardSchemes(const std::vector<std::string>& schemes);
 
+  // Register schemes that can handle service worker.
+  void RegisterServiceWorkerSchemes(const std::vector<std::string>& schemes);
+
   // Register the protocol with certain request job.
   template<typename RequestJob>
   void RegisterProtocol(const std::string& scheme,

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -54,6 +54,8 @@ bool g_suppress_renderer_process_restart = false;
 
 // Custom schemes to be registered to standard.
 std::string g_custom_schemes = "";
+// Custom schemes to be registered to handle service worker.
+std::string g_custom_service_worker_schemes = "";
 
 scoped_refptr<net::X509Certificate> ImportCertFromFile(
     const base::FilePath& path) {
@@ -85,6 +87,11 @@ void AtomBrowserClient::SuppressRendererProcessRestartForOnce() {
 void AtomBrowserClient::SetCustomSchemes(
     const std::vector<std::string>& schemes) {
   g_custom_schemes = base::JoinString(schemes, ",");
+}
+
+void AtomBrowserClient::SetCustomServiceWorkerSchemes(
+    const std::vector<std::string>& schemes) {
+  g_custom_service_worker_schemes = base::JoinString(schemes, ",");
 }
 
 AtomBrowserClient::AtomBrowserClient() : delegate_(nullptr) {
@@ -171,6 +178,11 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
   if (!g_custom_schemes.empty())
     command_line->AppendSwitchASCII(switches::kRegisterStandardSchemes,
                                     g_custom_schemes);
+
+  // The registered service worker schemes.
+  if (!g_custom_service_worker_schemes.empty())
+    command_line->AppendSwitchASCII(switches::kRegisterServiceWorkerSchemes,
+                                    g_custom_service_worker_schemes);
 
 #if defined(OS_WIN)
   // Append --app-user-model-id.

--- a/atom/browser/atom_browser_client.h
+++ b/atom/browser/atom_browser_client.h
@@ -38,6 +38,9 @@ class AtomBrowserClient : public brightray::BrowserClient,
   static void SuppressRendererProcessRestartForOnce();
   // Custom schemes to be registered to standard.
   static void SetCustomSchemes(const std::vector<std::string>& schemes);
+  // Custom schemes to be registered to handle service worker.
+  static void SetCustomServiceWorkerSchemes(
+      const std::vector<std::string>& schemes);
 
  protected:
   // content::ContentBrowserClient:

--- a/atom/browser/net/asar/url_request_asar_job.cc
+++ b/atom/browser/net/asar/url_request_asar_job.cc
@@ -7,13 +7,14 @@
 #include <string>
 #include <vector>
 
+#include "atom/common/asar/archive.h"
+#include "atom/common/asar/asar_util.h"
+#include "atom/common/atom_constants.h"
 #include "base/bind.h"
 #include "base/files/file_util.h"
 #include "base/strings/string_util.h"
 #include "base/synchronization/lock.h"
 #include "base/task_runner.h"
-#include "atom/common/asar/archive.h"
-#include "atom/common/asar/asar_util.h"
 #include "net/base/file_stream.h"
 #include "net/base/filename_util.h"
 #include "net/base/io_buffer.h"
@@ -225,6 +226,19 @@ void URLRequestAsarJob::SetExtraRequestHeaders(
       }
     }
   }
+}
+
+int URLRequestAsarJob::GetResponseCode() const {
+  // Request Job gets created only if path exists.
+  return 200;
+}
+
+void URLRequestAsarJob::GetResponseInfo(net::HttpResponseInfo* info) {
+  std::string status("HTTP/1.1 200 OK");
+  net::HttpResponseHeaders* headers = new net::HttpResponseHeaders(status);
+
+  headers->AddHeader(atom::kCORSHeader);
+  info->headers = headers;
 }
 
 void URLRequestAsarJob::FetchMetaInfo(const base::FilePath& file_path,

--- a/atom/browser/net/asar/url_request_asar_job.h
+++ b/atom/browser/net/asar/url_request_asar_job.h
@@ -61,6 +61,8 @@ class URLRequestAsarJob : public net::URLRequestJob {
   net::Filter* SetupFilter() const override;
   bool GetMimeType(std::string* mime_type) const override;
   void SetExtraRequestHeaders(const net::HttpRequestHeaders& headers) override;
+  int GetResponseCode() const override;
+  void GetResponseInfo(net::HttpResponseInfo* info) override;
 
  private:
   // Meta information about the file. It's used as a member in the

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -119,6 +119,9 @@ const char kDisableHttpCache[] = "disable-http-cache";
 // Register schemes to standard.
 const char kRegisterStandardSchemes[] = "register-standard-schemes";
 
+// Register schemes to handle service worker.
+const char kRegisterServiceWorkerSchemes[] = "register-service-worker-schemes";
+
 // The minimum SSL/TLS version ("tls1", "tls1.1", or "tls1.2") that
 // TLS fallback will accept.
 const char kSSLVersionFallbackMin[] = "ssl-version-fallback-min";

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -66,6 +66,7 @@ extern const char kPpapiFlashVersion[];
 extern const char kClientCertificate[];
 extern const char kDisableHttpCache[];
 extern const char kRegisterStandardSchemes[];
+extern const char kRegisterServiceWorkerSchemes[];
 extern const char kSSLVersionFallbackMin[];
 extern const char kCipherSuiteBlacklist[];
 extern const char kAppUserModelId[];

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -27,6 +27,7 @@
 #include "third_party/WebKit/public/web/WebLocalFrame.h"
 #include "third_party/WebKit/public/web/WebPluginParams.h"
 #include "third_party/WebKit/public/web/WebKit.h"
+#include "third_party/WebKit/public/web/WebSecurityPolicy.h"
 #include "third_party/WebKit/public/web/WebRuntimeFeatures.h"
 #include "third_party/WebKit/public/web/WebView.h"
 
@@ -129,6 +130,9 @@ void AtomRendererClient::RenderFrameCreated(
     content::RenderFrame* render_frame) {
   new PepperHelper(render_frame);
   new AtomRenderFrameObserver(render_frame, this);
+
+  // Allow file scheme to handle service worker by default.
+  blink::WebSecurityPolicy::registerURLSchemeAsAllowingServiceWorkers("file");
 }
 
 void AtomRendererClient::RenderViewCreated(content::RenderView* render_view) {

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -38,6 +38,10 @@ A standard `scheme` adheres to what RFC 3986 calls
 [generic URI syntax](https://tools.ietf.org/html/rfc3986#section-3). This
 includes `file:` and `filesystem:`.
 
+### `protocol.registerServiceWorkerSchemes(schemes)`
+
+* `schemes` Array - Custom schemes to be registered to handle service workers.
+
 ### `protocol.registerFileProtocol(scheme, handler[, completion])`
 
 * `scheme` String


### PR DESCRIPTION
https://github.com/atom/electron/issues/2831 is now completely addressed. Have enabled service worker for file scheme by default. For privileged custom schemes users can use the api.
