### PR TITLE
Allow running specs with --grep option from command line

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "private": true,
   "scripts": {
-    "preinstall": "node -e 'process.exit(0)'"
+    "preinstall": "node -e 'process.exit(0)'",
+    "test": "python ./script/test.py"
   }
 }

--- a/spec/api-browser-window-spec.coffee
+++ b/spec/api-browser-window-spec.coffee
@@ -8,7 +8,7 @@ os     = require 'os'
 {remote, screen} = require 'electron'
 {ipcMain, BrowserWindow} = remote.require 'electron'
 
-isCI = remote.process.argv[2] == '--ci'
+isCI = remote.getGlobal('isCi')
 
 describe 'browser-window module', ->
   fixtures = path.resolve __dirname, 'fixtures'

--- a/spec/api-crash-reporter-spec.coffee
+++ b/spec/api-crash-reporter-spec.coffee
@@ -18,7 +18,7 @@ describe 'crash-reporter module', ->
   return if process.mas
 
   # The crash-reporter test is not reliable on CI machine.
-  isCI = remote.process.argv[2] == '--ci'
+  isCI = remote.getGlobal('isCi')
   return if isCI
 
   it 'should send minidump when renderer crashes', (done) ->

--- a/spec/package.json
+++ b/spec/package.json
@@ -5,13 +5,14 @@
   "version": "0.1.0",
   "devDependencies": {
     "basic-auth": "^1.0.0",
-    "multiparty": "4.1.2",
     "graceful-fs": "3.0.5",
     "mocha": "2.1.0",
+    "multiparty": "4.1.2",
     "q": "0.9.7",
     "temp": "0.8.1",
     "walkdir": "0.0.7",
-    "ws": "0.7.2"
+    "ws": "0.7.2",
+    "yargs": "^3.31.0"
   },
   "optionalDependencies": {
     "ffi": "2.0.0",

--- a/spec/static/index.html
+++ b/spec/static/index.html
@@ -18,8 +18,7 @@
   var remote = electron.remote;
   var ipcRenderer = electron.ipcRenderer;
 
-  var argv = remote.process.argv;
-  var isCi = argv[2] == '--ci';
+  var isCi = remote.getGlobal('isCi')
 
   if (!isCi) {
     var win = remote.getCurrentWindow();

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -42,7 +42,8 @@ ipcMain.on('echo', function(event, msg) {
   event.returnValue = msg;
 });
 
-if (process.argv[2] == '--ci') {
+global.isCi = !!argv.ci;
+if (global.isCi) {
   process.removeAllListeners('uncaughtException');
   process.on('uncaughtException', function(error) {
     console.error(error, error.stack);

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -10,6 +10,7 @@ const url  = require('url');
 var argv = require('yargs')
   .boolean('ci')
   .string('g').alias('g', 'grep')
+  .boolean('i').alias('i', 'invert')
   .argv;
 
 var window = null;
@@ -78,7 +79,8 @@ app.on('ready', function() {
     pathname: __dirname + '/index.html',
     protocol: 'file',
     query: {
-      grep: argv.grep
+      grep: argv.grep,
+      invert: argv.invert ? 'true': ''
     }
   }));
   window.on('unresponsive', function() {

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -5,6 +5,12 @@ const dialog        = electron.dialog;
 const BrowserWindow = electron.BrowserWindow;
 
 const path = require('path');
+const url  = require('url');
+
+var argv = require('yargs')
+  .boolean('ci')
+  .string('g').alias('g', 'grep')
+  .argv;
 
 var window = null;
 process.port = 0;  // will be used by crash-reporter spec.
@@ -68,7 +74,13 @@ app.on('ready', function() {
       javascript: true  // Test whether web-preferences crashes.
     },
   });
-  window.loadURL('file://' + __dirname + '/index.html');
+  window.loadURL(url.format({
+    pathname: __dirname + '/index.html',
+    protocol: 'file',
+    query: {
+      grep: argv.grep
+    }
+  }));
   window.on('unresponsive', function() {
     var chosen = dialog.showMessageBox(window, {
       type: 'warning',


### PR DESCRIPTION
This passes through the `-g/--grep` and `-i/--invert` options from the command line to the spec app so you can easily run a single Electron spec from the command line.

This also adds an `npm test` script to allow you to run specs via something like `npm test -- -g "emit unload handler"`.

@jlord and myself paired on this :pear: