### PR TITLE
Reuse BrowserWindowProxy objects across events

### DIFF
--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -13,13 +13,13 @@ class BrowserWindowProxy
   @getOrCreate: (guestId) ->
     @proxies[guestId] ?= new BrowserWindowProxy(guestId)
 
-  @removeWindow: (guestId) ->
+  @remove: (guestId) ->
     delete @proxies[guestId]
 
   constructor: (@guestId) ->
     @closed = false
     ipcRenderer.once "ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSED_#{@guestId}", =>
-      BrowserWindowProxy.removeWindow(@guestId)
+      BrowserWindowProxy.remove(@guestId)
       @closed = true
 
   close: ->

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -8,9 +8,18 @@ resolveURL = (url) ->
 
 # Window object returned by "window.open".
 class BrowserWindowProxy
+  @proxies: {}
+
+  @getOrCreate: (guestId) ->
+    @proxies[guestId] ?= new BrowserWindowProxy(guestId)
+
+  @removeWindow: (guestId) ->
+    delete @proxies[guestId]
+
   constructor: (@guestId) ->
     @closed = false
     ipcRenderer.once "ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSED_#{@guestId}", =>
+      BrowserWindowProxy.removeWindow(@guestId)
       @closed = true
 
   close: ->
@@ -60,7 +69,7 @@ window.open = (url, frameName='', features='') ->
 
   guestId = ipcRenderer.sendSync 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPEN', url, frameName, options
   if guestId
-    new BrowserWindowProxy(guestId)
+    BrowserWindowProxy.getOrCreate(guestId)
   else
     null
 
@@ -96,7 +105,7 @@ ipcRenderer.on 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', (event, guestId, message, 
   event.initEvent 'message', false, false
   event.data = message
   event.origin = sourceOrigin
-  event.source = new BrowserWindowProxy(guestId)
+  event.source = BrowserWindowProxy.getOrCreate(guestId)
   window.dispatchEvent event
 
 # Forward history operations to browser.

--- a/spec/chromium-spec.coffee
+++ b/spec/chromium-spec.coffee
@@ -210,7 +210,7 @@ describe 'chromium feature', ->
       setImmediate ->
         called = false
         Promise.resolve().then ->
-          done(if called then undefined else new Error('wrong sequnce'))
+          done(if called then undefined else new Error('wrong sequence'))
         document.createElement 'x-element'
         called = true
 
@@ -224,6 +224,6 @@ describe 'chromium feature', ->
       remote.getGlobal('setImmediate') ->
         called = false
         Promise.resolve().then ->
-          done(if called then undefined else new Error('wrong sequnce'))
+          done(if called then undefined else new Error('wrong sequence'))
         document.createElement 'y-element'
         called = true

--- a/spec/chromium-spec.coffee
+++ b/spec/chromium-spec.coffee
@@ -120,7 +120,7 @@ describe 'chromium feature', ->
       listener = (event) ->
         window.removeEventListener 'message', listener
         b.close()
-        assert.equal event.source.guestId, b.guestId
+        assert.equal event.source, b
         assert.equal event.origin, 'file://'
         done()
       window.addEventListener 'message', listener


### PR DESCRIPTION
Reuse `BrowserWindowProxy` objects across events and `window.open` to that `event.source` can use `===` to see if it is a specific window returned from `window.open`.

Closes #3735