### PR TITLE
Make window.opener a BrowserWindowProxy

### DIFF
--- a/atom/browser/lib/guest-window-manager.coffee
+++ b/atom/browser/lib/guest-window-manager.coffee
@@ -74,23 +74,27 @@ ipcMain.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', (event, guestId, met
   BrowserWindow.fromId(guestId)?[method] args...
 
 ipcMain.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', (event, guestId, message, targetOrigin, sourceOrigin) ->
+  sourceId = BrowserWindow.fromWebContents(event.sender)?.id
+  return unless sourceId?
+
   guestContents = BrowserWindow.fromId(guestId)?.webContents
   if guestContents?.getURL().indexOf(targetOrigin) is 0 or targetOrigin is '*'
-    guestContents?.send 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', guestId, message, sourceOrigin
+    guestContents?.send 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin
 
-ipcMain.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', (event, guestId, message, targetOrigin, sourceOrigin) ->
+ipcMain.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', (event, message, targetOrigin, sourceOrigin) ->
+  sourceId = BrowserWindow.fromWebContents(event.sender)?.id
+  return unless sourceId?
+
   embedder = v8Util.getHiddenValue event.sender, 'embedder'
   if embedder?.getURL().indexOf(targetOrigin) is 0 or targetOrigin is '*'
-    embedder?.send 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', guestId, message, sourceOrigin
+    embedder?.send 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin
 
 ipcMain.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', (event, guestId, method, args...) ->
   BrowserWindow.fromId(guestId)?.webContents?[method] args...
 
-ipcMain.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_GET_GUEST_ID', (event) ->
+ipcMain.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_GET_OPENER_ID', (event) ->
   embedder = v8Util.getHiddenValue event.sender, 'embedder'
+  openerId = null
   if embedder?
-    guest = BrowserWindow.fromWebContents event.sender
-    if guest?
-      event.returnValue = guest.id
-      return
-  event.returnValue = null
+    openerId = BrowserWindow.fromWebContents(embedder)?.id
+  event.returnValue = openerId

--- a/atom/browser/lib/guest-window-manager.coffee
+++ b/atom/browser/lib/guest-window-manager.coffee
@@ -81,14 +81,6 @@ ipcMain.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', (event, guestId
   if guestContents?.getURL().indexOf(targetOrigin) is 0 or targetOrigin is '*'
     guestContents?.send 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin
 
-ipcMain.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', (event, message, targetOrigin, sourceOrigin) ->
-  sourceId = BrowserWindow.fromWebContents(event.sender)?.id
-  return unless sourceId?
-
-  embedder = v8Util.getHiddenValue event.sender, 'embedder'
-  if embedder?.getURL().indexOf(targetOrigin) is 0 or targetOrigin is '*'
-    embedder?.send 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin
-
 ipcMain.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', (event, guestId, method, args...) ->
   BrowserWindow.fromId(guestId)?.webContents?[method] args...
 

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -91,22 +91,20 @@ window.confirm = (message, title='') ->
 window.prompt = ->
   throw new Error('prompt() is and will not be supported.')
 
-guestId = ipcRenderer.sendSync 'ATOM_SHELL_GUEST_WINDOW_MANAGER_GET_GUEST_ID'
-if guestId?
-  window.opener = BrowserWindowProxy.getOrCreate(guestId)
-  # Remove BrowserWindowProxy API and give it a custom postMessage method
-  Object.setPrototypeOf(window.opener, null)
+openerId = ipcRenderer.sendSync 'ATOM_SHELL_GUEST_WINDOW_MANAGER_GET_OPENER_ID'
+if openerId?
+  window.opener = BrowserWindowProxy.getOrCreate(openerId)
   window.opener.postMessage = (message, targetOrigin='*') ->
-    ipcRenderer.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', guestId, message, targetOrigin, location.origin
+    ipcRenderer.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', message, targetOrigin, location.origin
 
-ipcRenderer.on 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', (event, guestId, message, sourceOrigin) ->
+ipcRenderer.on 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', (event, sourceId, message, sourceOrigin) ->
   # Manually dispatch event instead of using postMessage because we also need to
   # set event.source.
   event = document.createEvent 'Event'
   event.initEvent 'message', false, false
   event.data = message
   event.origin = sourceOrigin
-  event.source = BrowserWindowProxy.getOrCreate(guestId)
+  event.source = BrowserWindowProxy.getOrCreate(sourceId)
   window.dispatchEvent event
 
 # Forward history operations to browser.

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -94,9 +94,10 @@ window.prompt = ->
 # Implement window.postMessage if current window is a guest window.
 guestId = ipcRenderer.sendSync 'ATOM_SHELL_GUEST_WINDOW_MANAGER_GET_GUEST_ID'
 if guestId?
-  window.opener =
-    postMessage: (message, targetOrigin='*') ->
-      ipcRenderer.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', guestId, message, targetOrigin, location.origin
+  window.opener = BrowserWindowProxy.getOrCreate(guestId)
+  Object.setPrototypeOf(window.opener, null)
+  window.opener.postMessage = (message, targetOrigin='*') ->
+    ipcRenderer.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', guestId, message, targetOrigin, location.origin
 
 ipcRenderer.on 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', (event, guestId, message, sourceOrigin) ->
   # Manually dispatch event instead of using postMessage because we also need to

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -92,10 +92,7 @@ window.prompt = ->
   throw new Error('prompt() is and will not be supported.')
 
 openerId = ipcRenderer.sendSync 'ATOM_SHELL_GUEST_WINDOW_MANAGER_GET_OPENER_ID'
-if openerId?
-  window.opener = BrowserWindowProxy.getOrCreate(openerId)
-  window.opener.postMessage = (message, targetOrigin='*') ->
-    ipcRenderer.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', message, targetOrigin, location.origin
+window.opener = BrowserWindowProxy.getOrCreate(openerId) if openerId?
 
 ipcRenderer.on 'ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', (event, sourceId, message, sourceOrigin) ->
   # Manually dispatch event instead of using postMessage because we also need to

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -91,10 +91,10 @@ window.confirm = (message, title='') ->
 window.prompt = ->
   throw new Error('prompt() is and will not be supported.')
 
-# Implement window.postMessage if current window is a guest window.
 guestId = ipcRenderer.sendSync 'ATOM_SHELL_GUEST_WINDOW_MANAGER_GET_GUEST_ID'
 if guestId?
   window.opener = BrowserWindowProxy.getOrCreate(guestId)
+  # Remove BrowserWindowProxy API and give it a custom postMessage method
   Object.setPrototypeOf(window.opener, null)
   window.opener.postMessage = (message, targetOrigin='*') ->
     ipcRenderer.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', guestId, message, targetOrigin, location.origin

--- a/spec/chromium-spec.coffee
+++ b/spec/chromium-spec.coffee
@@ -117,6 +117,7 @@ describe 'chromium feature', ->
 
   describe 'window.postMessage', ->
     it 'sets the origin correctly', (done) ->
+      sourceId = remote.getCurrentWindow().id
       listener = (event) ->
         window.removeEventListener 'message', listener
         b.close()
@@ -124,6 +125,7 @@ describe 'chromium feature', ->
         assert.equal message.data, 'testing'
         assert.equal message.origin, 'file://'
         assert.equal message.sourceEqualsOpener, true
+        assert.equal message.sourceId, sourceId
         assert.equal event.origin, 'file://'
         done()
       window.addEventListener 'message', listener

--- a/spec/chromium-spec.coffee
+++ b/spec/chromium-spec.coffee
@@ -120,7 +120,10 @@ describe 'chromium feature', ->
       listener = (event) ->
         window.removeEventListener 'message', listener
         b.close()
-        assert.equal event.data, 'file://testing'
+        message = JSON.parse(event.data)
+        assert.equal message.data, 'testing'
+        assert.equal message.origin, 'file://'
+        assert.equal message.sourceEqualsOpener, true
         assert.equal event.origin, 'file://'
         done()
       window.addEventListener 'message', listener

--- a/spec/chromium-spec.coffee
+++ b/spec/chromium-spec.coffee
@@ -116,7 +116,7 @@ describe 'chromium feature', ->
       b = window.open url, '', 'show=no'
 
   describe 'window.postMessage', ->
-    it 'sets the origin correctly', (done) ->
+    it 'sets the source and origin correctly', (done) ->
       sourceId = remote.getCurrentWindow().id
       listener = (event) ->
         window.removeEventListener 'message', listener

--- a/spec/fixtures/pages/window-open-postMessage.html
+++ b/spec/fixtures/pages/window-open-postMessage.html
@@ -5,7 +5,8 @@
     var reply = JSON.stringify({
       origin: e.origin,
       data: e.data,
-      sourceEqualsOpener: e.source === window.opener
+      sourceEqualsOpener: e.source === window.opener,
+      sourceId: e.source.guestId
     })
     window.opener.postMessage(reply, '*');
   });

--- a/spec/fixtures/pages/window-open-postMessage.html
+++ b/spec/fixtures/pages/window-open-postMessage.html
@@ -2,7 +2,12 @@
 <body>
 <script type="text/javascript" charset="utf-8">
   window.addEventListener('message', function (e) {
-    window.opener.postMessage(e.origin + e.data, '*');
+    var reply = JSON.stringify({
+      origin: e.origin,
+      data: e.data,
+      sourceEqualsOpener: e.source === window.opener
+    })
+    window.opener.postMessage(reply, '*');
   });
 </script>
 </body>

--- a/spec/fixtures/pages/window-open-postMessage.html
+++ b/spec/fixtures/pages/window-open-postMessage.html
@@ -2,13 +2,12 @@
 <body>
 <script type="text/javascript" charset="utf-8">
   window.addEventListener('message', function (e) {
-    var reply = JSON.stringify({
+    window.opener.postMessage(JSON.stringify({
       origin: e.origin,
       data: e.data,
       sourceEqualsOpener: e.source === window.opener,
       sourceId: e.source.guestId
-    })
-    window.opener.postMessage(reply, '*');
+    }), '*');
   });
 </script>
 </body>


### PR DESCRIPTION
This pull request makes the following changes to `window.opener`.

* Now has entire `BrowserWindowProxy` API which includes things like `eval`, `focus`, and `close`.
* `event.source` on `postMessage` events now matches `window.opener`
* `window.opener` no longer has a custom `postMessage` method, it just uses the default `BrowserWindowProxy` implementation.

Previously it appeared like the `guestId` on the `source` object on message events was the id of the target window so I changed it to be the source window id instead which allowed the removal of the `ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE` ipc event completely.

Fixes #3775