### PR TITLE
Add A5 Page Size to printToPDF

### DIFF
--- a/atom/browser/api/lib/web-contents.coffee
+++ b/atom/browser/api/lib/web-contents.coffee
@@ -7,6 +7,11 @@ nextId = 0
 getNextId = -> ++nextId
 
 PDFPageSize =
+  A5:
+    custom_display_name: "A5"
+    height_microns: 210000
+    name: "ISO_A5"
+    width_microns: 148000
   A4:
     custom_display_name: "A4"
     height_microns: 297000

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -454,6 +454,7 @@ size.
   * 1 - none
   * 2 - minimum
 * `pageSize` String - Specify page size of the generated PDF.
+  * `A5` 
   * `A4`
   * `A3`
   * `Legal`


### PR DESCRIPTION
resolves #3796

i have taken the size values from [here](https://en.wikipedia.org/wiki/Paper_size#Overview:_ISO_paper_Sizes)

anything missing?