### PR TITLE
Fix crash when passing invalid path to addRecentDocument

### DIFF
--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -19,7 +19,12 @@ void Browser::Focus() {
 }
 
 void Browser::AddRecentDocument(const base::FilePath& path) {
-  NSURL* u = [NSURL fileURLWithPath:base::mac::FilePathToNSString(path)];
+  NSString* path_string = base::mac::FilePathToNSString(path);
+  if (!path_string)
+    return;
+  NSURL* u = [NSURL fileURLWithPath:path_string];
+  if (!u)
+    return;
   [[NSDocumentController sharedDocumentController] noteNewRecentDocumentURL:u];
 }
 


### PR DESCRIPTION
Found the crash when creating empty tab in Atom.