### PR TITLE
:bug: Support strict mode on Tutorial

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -78,6 +78,8 @@ The `main.js` should create windows and handle system events, a typical
 example being:
 
 ```javascript
+'use strict';
+
 const electron = require('electron');
 const app = electron.app;  // Module to control application life.
 const BrowserWindow = electron.BrowserWindow;  // Module to create native browser window.


### PR DESCRIPTION
[ci skip]

Thank you for your `electron` !

In the below environment, the `main.js` in `docs/tutorial/quick-start.md` didn't work well.

process.versions:

* chrome: "47.0.2526.73"
* electron: "0.36.0"
* node: "5.1.1"
* v8: "4.7.80.23"

and process.platform is "win32".

A poped up error window was like below.

![error](https://cloud.githubusercontent.com/assets/13907611/11816233/ed92edc4-a392-11e5-927d-a01793a84845.png)

At the same time, an error message was also printed on the console.

```
App threw an error when running [SyntaxError: Block-scoped declarations (let, co
nst, function, class) not yet supported outside strict mode]
```

I'm not sure whether Node or V8 emittes this error, but just in case, it may be better to specify a 'use strict' directive explicitly...?

Thanks!






