### PR TITLE
Require submitURL and companyName options to crashReporter.start

### DIFF
--- a/atom/common/api/lib/crash-reporter.coffee
+++ b/atom/common/api/lib/crash-reporter.coffee
@@ -28,11 +28,11 @@ class CrashReporter
     extra._version ?= app.getVersion()
 
     unless companyName?
-      deprecate.log('companyName is now a required option to CrashReporter::start')
+      deprecate.log('companyName is now a required option to crashReporter.start')
       return
 
     unless submitURL?
-      deprecate.log('submitURL is now a required option to CrashReporter::start')
+      deprecate.log('submitURL is now a required option to crashReporter.start')
       return
 
     start = => binding.start @productName, companyName, submitURL, autoSubmit, ignoreSystemCrashHandler, extra

--- a/atom/common/api/lib/crash-reporter.coffee
+++ b/atom/common/api/lib/crash-reporter.coffee
@@ -40,9 +40,7 @@ class CrashReporter
       env = ATOM_SHELL_INTERNAL_CRASH_SERVICE: 1
 
       spawn process.execPath, args, {env, detached: true}
-      start()
-    else
-      start()
+    start()
 
   getLastCrashReport: ->
     reports = this.getUploadedReports()

--- a/atom/common/api/lib/crash-reporter.coffee
+++ b/atom/common/api/lib/crash-reporter.coffee
@@ -19,8 +19,6 @@ class CrashReporter
     {app} = if process.type is 'browser' then electron else electron.remote
 
     @productName ?= app.getName()
-    companyName ?= 'GitHub, Inc'
-    submitURL ?= 'http://54.249.141.255:1127/post'
     autoSubmit ?= true
     ignoreSystemCrashHandler ?= false
     extra ?= {}
@@ -28,6 +26,14 @@ class CrashReporter
     extra._productName ?= @productName
     extra._companyName ?= companyName
     extra._version ?= app.getVersion()
+
+    unless companyName?
+      deprecate.log('companyName is now a required option to CrashReporter::start')
+      return
+
+    unless submitURL?
+      deprecate.log('submitURL is now a required option to CrashReporter::start')
+      return
 
     start = => binding.start @productName, companyName, submitURL, autoSubmit, ignoreSystemCrashHandler, extra
 
@@ -58,7 +64,6 @@ class CrashReporter
       else
         path.join tmpdir, "#{@productName} Crashes", 'uploads.log'
     binding._getUploadedReports log
-
 
 crashRepoter = new CrashReporter
 module.exports = crashRepoter

--- a/atom/common/api/lib/deprecate.coffee
+++ b/atom/common/api/lib/deprecate.coffee
@@ -52,7 +52,7 @@ deprecate.event = (emitter, oldName, newName, fn) ->
       else
         @emit oldName, args...
 
-# Print deprecate warning.
+# Print deprecation warning.
 deprecate.warn = (oldName, newName) ->
   deprecate.log("#{oldName} is deprecated. Use #{newName} instead.")
 
@@ -64,6 +64,5 @@ deprecate.log = (message) ->
     console.trace message
   else
     console.warn "(electron) #{message}"
-
 
 module.exports = deprecate

--- a/atom/common/api/lib/deprecate.coffee
+++ b/atom/common/api/lib/deprecate.coffee
@@ -54,12 +54,16 @@ deprecate.event = (emitter, oldName, newName, fn) ->
 
 # Print deprecate warning.
 deprecate.warn = (oldName, newName) ->
-  message = "#{oldName} is deprecated. Use #{newName} instead."
+  deprecate.log("#{oldName} is deprecated. Use #{newName} instead.")
+
+# Print deprecation message
+deprecate.log = (message) ->
   if process.throwDeprecation
     throw new Error(message)
   else if process.traceDeprecation
     console.trace message
   else
     console.warn "(electron) #{message}"
+
 
 module.exports = deprecate

--- a/atom/common/api/lib/deprecate.coffee
+++ b/atom/common/api/lib/deprecate.coffee
@@ -54,7 +54,7 @@ deprecate.event = (emitter, oldName, newName, fn) ->
 
 # Print deprecation warning.
 deprecate.warn = (oldName, newName) ->
-  deprecate.log("#{oldName} is deprecated. Use #{newName} instead.")
+  deprecate.log "#{oldName} is deprecated. Use #{newName} instead."
 
 # Print deprecation message
 deprecate.log = (message) ->

--- a/atom/common/api/lib/deprecate.coffee
+++ b/atom/common/api/lib/deprecate.coffee
@@ -56,7 +56,7 @@ deprecate.event = (emitter, oldName, newName, fn) ->
 deprecate.warn = (oldName, newName) ->
   deprecate.log "#{oldName} is deprecated. Use #{newName} instead."
 
-# Print deprecation message
+# Print deprecation message.
 deprecate.log = (message) ->
   if process.throwDeprecation
     throw new Error(message)

--- a/docs-translations/es/tutorial/quick-start.md
+++ b/docs-translations/es/tutorial/quick-start.md
@@ -70,9 +70,6 @@ El `main.js` debería crear las ventanas y gestionar los eventos del sistema, un
 var app = require('app');  // Módulo para controlar el ciclo de vida de la aplicación.
 var BrowserWindow = require('browser-window');  // Módulo para crear uan ventana de navegador.
 
-// Reportar crashes a nuestro servidor.
-require('crash-reporter').start();
-
 // Mantener una referencia global al objeto window, si no lo haces, esta ventana
 // se cerrará automáticamente cuando el objeto JavaScript sea recolectado (garbage collected):
 var mainWindow = null;

--- a/docs-translations/es/tutorial/using-pepper-flash-plugin.md
+++ b/docs-translations/es/tutorial/using-pepper-flash-plugin.md
@@ -15,9 +15,6 @@ También puedes agregar la opción `plugins` de `browser-window`. Por ejemplo,
 var app = require('app');
 var BrowserWindow = require('browser-window');
 
-// Report crashes to our server.
-require('crash-reporter').start();
-
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the javascript object is GCed.
 var mainWindow = null;

--- a/docs-translations/jp/tutorial/quick-start.md
+++ b/docs-translations/jp/tutorial/quick-start.md
@@ -53,9 +53,6 @@ your-app/
 var app = require('app');  // Module to control application life.
 var BrowserWindow = require('browser-window');  // Module to create native browser window.
 
-// Report crashes to our server.
-require('crash-reporter').start();
-
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the javascript object is GCed.
 var mainWindow = null;

--- a/docs-translations/ko-KR/tutorial/quick-start.md
+++ b/docs-translations/ko-KR/tutorial/quick-start.md
@@ -78,9 +78,6 @@ const electron = require('electron');
 const app = electron.app;  // 어플리케이션 기반을 조작 하는 모듈.
 const BrowserWindow = electron.BrowserWindow;  // 네이티브 브라우저 창을 만드는 모듈.
 
-// Electron 개발자에게 crash-report를 보냄.
-electron.crashReporter.start();
-
 // 윈도우 객체를 전역에 유지합니다. 만약 이렇게 하지 않으면
 // 자바스크립트 GC가 일어날 때 창이 멋대로 닫혀버립니다.
 var mainWindow = null;

--- a/docs-translations/pt-BR/tutorial/quick-start.md
+++ b/docs-translations/pt-BR/tutorial/quick-start.md
@@ -81,9 +81,6 @@ exemplo:
 var app = require('app');  // Módulo para controlar o ciclo de vida do app.
 var BrowserWindow = require('browser-window');  // Módulo para criar uma janela nativa do browser.
 
-// Relate falhas para nossos servidores.
-require('crash-reporter').start();
-
 // Mantenha uma referência global para o objeto window, se você não o fizer,
 // a janela será fechada automaticamente quando o objeto JavaScript for
 // coletado pelo garbage collector.

--- a/docs-translations/pt-BR/tutorial/using-pepper-flash-plugin.md
+++ b/docs-translations/pt-BR/tutorial/using-pepper-flash-plugin.md
@@ -23,9 +23,6 @@ Por exemplo:
 var app = require('app');
 var BrowserWindow = require('browser-window');
 
-// Informa os erros ao ao servidor.
-require('crash-reporter').start();
-
 // Mantém uma referência global da janela, se não manter, a janela irá fechar
 // automaticamente quando o objeto javascript for GCed.
 var mainWindow = null;

--- a/docs-translations/zh-CN/tutorial/quick-start.md
+++ b/docs-translations/zh-CN/tutorial/quick-start.md
@@ -45,9 +45,6 @@ your-app/
 var app = require('app');  // 控制应用生命周期的模块。
 var BrowserWindow = require('browser-window');  // 创建原生浏览器窗口的模块
 
-// 给我们的服务器发送异常报告。
-require('crash-reporter').start();
-
 // 保持一个对于 window 对象的全局引用，不然，当 JavaScript 被 GC，
 // window 会被自动地关闭
 var mainWindow = null;

--- a/docs-translations/zh-TW/tutorial/quick-start.md
+++ b/docs-translations/zh-TW/tutorial/quick-start.md
@@ -62,9 +62,6 @@ __注意__：如果 `main` 沒有在 `package.json` 裏， Electron會嘗試載�
 var app = require('app'); // 控制應用程式生命週期的模組。
 var BrowserWindow = require('browser-window'); // 創造原生瀏覽器窗口的模組
 
-// 對我們的伺服器傳送異常報告。
-require('crash-reporter').start();
-
 // 保持一個對於 window 物件的全域的引用，不然，當 JavaScript 被GC，
 // window 會被自動地關閉
 var mainWindow = null;

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -25,8 +25,8 @@ The `crash-reporter` module has the following methods:
 `options` Object, properties:
 
 * `productName` String, default: Electron.
-* `companyName` String, default: GitHub, Inc.
-* `submitURL` String, default: http://54.249.141.255:1127/post.
+* `companyName` String (**required**)
+* `submitURL` String, (**required**)
   * URL that crash reports will be sent to as POST.
 * `autoSubmit` Boolean, default: `true`.
   * Send the crash report without user interaction.

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -82,9 +82,6 @@ const electron = require('electron');
 const app = electron.app;  // Module to control application life.
 const BrowserWindow = electron.BrowserWindow;  // Module to create native browser window.
 
-// Report crashes to our server.
-electron.crashReporter.start();
-
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 var mainWindow = null;

--- a/spec/api-crash-reporter-spec.coffee
+++ b/spec/api-crash-reporter-spec.coffee
@@ -61,6 +61,6 @@ describe 'crash-reporter module', ->
       w.loadURL url
 
   describe ".start(options)", ->
-    it 'requires that the companyName and submitURL option fields be specified', ->
+    it 'requires that the companyName and submitURL options be specified', ->
       assert.throws(-> crashReporter.start({companyName: 'Missing submitURL'}))
       assert.throws(-> crashReporter.start({submitURL: 'Missing companyName'}))

--- a/spec/api-crash-reporter-spec.coffee
+++ b/spec/api-crash-reporter-spec.coffee
@@ -55,5 +55,12 @@ describe 'crash-reporter module', ->
         pathname: path.join fixtures, 'api', 'crash.html'
         search: "?port=#{port}"
       if process.platform is 'darwin'
-        crashReporter.start {'submitURL': 'http://127.0.0.1:' + port}
+        crashReporter.start
+          companyName: 'Umbrella Corporation'
+          submitURL: "http://127.0.0.1:#{port}"
       w.loadURL url
+
+  describe ".start(options)", ->
+    it 'requires that the companyName and submitURL option fields be specified', ->
+      assert.throws(-> crashReporter.start({companyName: 'Missing submitURL'}))
+      assert.throws(-> crashReporter.start({submitURL: 'Missing companyName'}))

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -1,11 +1,11 @@
+// Disable use of deprecated functions.
+process.throwDeprecation = true;
+
 const electron      = require('electron');
 const app           = electron.app;
 const ipcMain       = electron.ipcMain;
 const dialog        = electron.dialog;
 const BrowserWindow = electron.BrowserWindow;
-
-// Disable use of deprecated functions.
-process.throwDeprecation = true;
 
 const path = require('path');
 const url  = require('url');

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -4,6 +4,9 @@ const ipcMain       = electron.ipcMain;
 const dialog        = electron.dialog;
 const BrowserWindow = electron.BrowserWindow;
 
+// Disable use of deprecated functions.
+process.throwDeprecation = true;
+
 const path = require('path');
 const url  = require('url');
 


### PR DESCRIPTION
Previously `companyName` defaulted to `GitHub, Inc.` and `submitURL` defaulted to a server URL managed by the Electron team.

Now these fields are both required and the crashReporter will log a deprecation when they are missing.

This also removes starting the crash reporter from the quick start docs since this is a more advanced concept that requires hosting a crash reporter server. /cc @jlord 

Closes #3673