### PR TITLE
Update libchromiumcontent

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -8,7 +8,7 @@ import sys
 
 BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
     'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
-LIBCHROMIUMCONTENT_COMMIT = '66bd8d1c705b7258f76c82436e4b16e82afbbd33'
+LIBCHROMIUMCONTENT_COMMIT = 'e334f07f86371385c51a9cda528ea531ea81bffa'
 
 PLATFORM = {
   'cygwin': 'win32',


### PR DESCRIPTION
Remove usages of private xpc_ APIs, fix #3823.

Refs https://github.com/atom/libchromiumcontent/commit/8e9772b93b4e46d0614842f28664d33f10d47b98.