### PR TITLE
Don't pump message loop when sending sync msg

### DIFF
--- a/atom/renderer/api/atom_api_renderer_ipc.cc
+++ b/atom/renderer/api/atom_api_renderer_ipc.cc
@@ -54,8 +54,6 @@ base::string16 SendSync(mate::Arguments* args,
 
   IPC::SyncMessage* message = new AtomViewHostMsg_Message_Sync(
       render_view->GetRoutingID(), channel, arguments, &json);
-  // Enable the UI thread in browser to receive messages.
-  message->EnableMessagePumping();
   bool success = render_view->Send(message);
 
   if (!success)

--- a/atom/renderer/api/lib/ipc-renderer.coffee
+++ b/atom/renderer/api/lib/ipc-renderer.coffee
@@ -6,12 +6,6 @@ v8Util  = process.atomBinding 'v8_util'
 # Created by init.coffee.
 ipcRenderer = v8Util.getHiddenValue global, 'ipc'
 
-# Delay the callback to next tick in case the browser is still in the middle
-# of sending a message while the callback sends a sync message to browser,
-# which can fail sometimes.
-ipcRenderer.emit = (args...) ->
-  setTimeout (-> EventEmitter::emit.call ipcRenderer, args...), 0
-
 ipcRenderer.send = (args...) ->
   binding.send 'ipc-message', [args...]
 

--- a/atom/renderer/lib/inspector.coffee
+++ b/atom/renderer/lib/inspector.coffee
@@ -27,7 +27,9 @@ convertToMenuTemplate = (items) ->
           label: item.label
           enabled: item.enabled
       if item.id?
-        transformed.click = -> DevToolsAPI.contextMenuItemSelected item.id
+        transformed.click = ->
+          DevToolsAPI.contextMenuItemSelected item.id
+          DevToolsAPI.contextMenuCleared()
       template.push transformed
   template
 
@@ -37,9 +39,7 @@ createMenu = (x, y, items, document) ->
 
   menu = Menu.buildFromTemplate convertToMenuTemplate(items)
   # The menu is expected to show asynchronously.
-  setImmediate ->
-    menu.popup remote.getCurrentWindow()
-    DevToolsAPI.contextMenuCleared()
+  setTimeout -> menu.popup remote.getCurrentWindow()
 
 showFileChooserDialog = (callback) ->
   {remote} = require 'electron'


### PR DESCRIPTION
In old days sending sync message to browser process requires pumping
message loop in the renderer process, but now in Chrome 47 it is not
true anymore. And even when we do it, the Send method may fail
sometimes, so this change seems to be required for the Chrome 47
upgrade.

Fix #1966.