### PR TITLE
Emit quit events when autoUpdater.quitAndInstall is called

### DIFF
--- a/atom/browser/api/atom_api_auto_updater.cc
+++ b/atom/browser/api/atom_api_auto_updater.cc
@@ -87,6 +87,10 @@ mate::ObjectTemplateBuilder AutoUpdater::GetObjectTemplateBuilder(
 }
 
 void AutoUpdater::QuitAndInstall() {
+  bool should_quit = Browser::Get()->HandleBeforeQuit();
+  if (!should_quit)
+    return;
+
   // If we don't have any window then quitAndInstall immediately.
   WindowList* window_list = WindowList::GetInstance();
   if (window_list->size() == 0) {

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -141,6 +141,11 @@ class Browser : public WindowListObserver {
   bool is_quiting() const { return is_quiting_; }
   bool is_ready() const { return is_ready_; }
 
+  // Send the before-quit message. Does not actually start closing windows.
+  // Exposed so that other parts of the application can implement specialized
+  // quit flows while still emitting the proper quit events.
+  bool HandleBeforeQuit();
+
  protected:
   // Returns the version of application bundle or executable file.
   std::string GetExecutableFileVersion() const;
@@ -150,9 +155,6 @@ class Browser : public WindowListObserver {
 
   // Send the will-quit message and then shutdown the application.
   void NotifyAndShutdown();
-
-  // Send the before-quit message and start closing windows.
-  bool HandleBeforeQuit();
 
   bool is_quiting_;
 

--- a/spec/api-auto-updater-spec.coffee
+++ b/spec/api-auto-updater-spec.coffee
@@ -1,0 +1,21 @@
+assert = require 'assert'
+path = require 'path'
+
+{remote} = require 'electron'
+{app, autoUpdater, BrowserWindow} = remote.require 'electron'
+
+describe 'autoUpdater module', ->
+  afterEach ->
+    remote.getCurrentWindow().webContents.executeJavaScript 'window.onbeforeunload = function() {};'
+    autoUpdater.removeAllListeners()
+
+  describe 'autoUpdater.quitAndInstall()', ->
+    # Fails: `quitAndInstall` will cause the app to quit and then it will not reopen.
+    xit 'should emit an error if called before \'update-downloaded\' is emitted', (done) ->
+      autoUpdater.on 'error', ->
+        done()
+      autoUpdater.quitAndInstall()
+
+    it 'should not quit if all windows do not close', ->
+      remote.getCurrentWindow().webContents.executeJavaScript 'window.onbeforeunload = function() { return false; }'
+      autoUpdater.quitAndInstall()

--- a/spec/api-auto-updater-spec.coffee
+++ b/spec/api-auto-updater-spec.coffee
@@ -8,6 +8,7 @@ describe 'autoUpdater module', ->
   afterEach ->
     remote.getCurrentWindow().webContents.executeJavaScript 'window.onbeforeunload = function() {};'
     autoUpdater.removeAllListeners()
+    app.removeAllListeners()
 
   describe 'autoUpdater.quitAndInstall()', ->
     # Fails: `quitAndInstall` will cause the app to quit and then it will not reopen.
@@ -18,4 +19,14 @@ describe 'autoUpdater module', ->
 
     it 'should not quit if all windows do not close', ->
       remote.getCurrentWindow().webContents.executeJavaScript 'window.onbeforeunload = function() { return false; }'
+      autoUpdater.quitAndInstall()
+
+    # At this point it would be nicer to mock out `auto_updater::AutoUpdater::QuitAndInstall`
+    # so that we could test the entire shutdown flow (including windows closing)
+    # up until that point, but I (wearhere) don't know how to do that, so we
+    # still abort the quit process by preventing the window from closing.
+    it 'should emit before-quit event', (done) ->
+      remote.getCurrentWindow().webContents.executeJavaScript 'window.onbeforeunload = function() { return false; }'
+      app.on 'before-quit', ->
+        done()
       autoUpdater.quitAndInstall()


### PR DESCRIPTION
This is a work-in-progress to fix #3837. It currently fixes the 'before-quit' event not being emitted.

I've stopped here for two reasons. The first is that I wish to seek feedback on the approach of having the `autoUpdater` ask the `app` to emit the normal events rather than having the `autoUpdater` emit them itself. Having the `app` emit them reuses code from the normal quit process, but it is a bit weird to have the `autoUpdater` call what were formerly protected methods.

(Then again, if the `autoUpdater` was to assume the responsibility of emitting the events itself, it would need access to the `app`'s event listeners which would also require sharing protected state.)

The other reason I've stopped here is that I'm not sure how to test further shutdown events. If I let the shutdown process proceed to close the windows, I'll need to be able to reopen the testing window.

I also need to prevent the app from _actually_ quitting because, without an update to install, it won't reopen. (Though that is IMO a bug in `autoUpdater`—it should emit an error (#3840), and I've added a spec to that effect. If I fixed that, then the app would not quit. I'm not sure where to fix that though, in Electron or in Squirrel.)