### PR TITLE
browser: check for rvh existence

### DIFF
--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -197,9 +197,16 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
   if (ContainsKey(pending_processes_, process_id))
     process_id = pending_processes_[process_id];
 
+
+  // Certain render process will be created with no associated render view,
+  // for example: ServiceWorker.
+  auto rvh = content::RenderViewHost::FromID(process_id, kDefaultRoutingID);
+  if (!rvh)
+    return;
+
   // Get the WebContents of the render process.
-  content::WebContents* web_contents = content::WebContents::FromRenderViewHost(
-      content::RenderViewHost::FromID(process_id, kDefaultRoutingID));
+  content::WebContents* web_contents =
+      content::WebContents::FromRenderViewHost(rvh);
   if (!web_contents)
     return;
 


### PR DESCRIPTION
Fixes #3835 

When render process is not available during service worker registration, it creates a new one.
https://code.google.com/p/chromium/codesearch#chromium/src/content/browser/service_worker/service_worker_process_manager.cc&sq=package:chromium&l=180