### PR TITLE
browser: fix document.hidden value

### DIFF
--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -122,7 +122,7 @@ Object.defineProperty window.history, 'length',
 Object.defineProperty document, 'hidden',
   get: ->
     currentWindow = remote.getCurrentWindow()
-    !currentWindow.isFocused() || !currentWindow.isVisible()
+    currentWindow.isMinimized() || !currentWindow.isVisible()
 
 Object.defineProperty document, 'visibilityState',
   get: ->

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -118,6 +118,12 @@ Object.defineProperty window.history, 'length',
   get: ->
     getHistoryOperation 'length'
 
-# Make document.hidden return the correct value.
+# Make document.hidden and document.visibilityState return the correct value.
 Object.defineProperty document, 'hidden',
-  get: -> !remote.getCurrentWindow().isVisible()
+  get: ->
+    currentWindow = remote.getCurrentWindow()
+    !currentWindow.isFocused() || !currentWindow.isVisible()
+
+Object.defineProperty document, 'visibilityState',
+  get: ->
+    if document.hidden then "hidden" else "visible"

--- a/spec/chromium-spec.coffee
+++ b/spec/chromium-spec.coffee
@@ -45,6 +45,14 @@ describe 'chromium feature', ->
         done()
       w.loadURL url
 
+    it 'is set correctly when window is inactive', (done) ->
+      w = new BrowserWindow(show:false)
+      w.webContents.on 'ipc-message', (event, args) ->
+        assert.deepEqual args, ['hidden', false]
+        done()
+      w.showInactive()
+      w.loadURL url
+
   xdescribe 'navigator.webkitGetUserMedia', ->
     it 'calls its callbacks', (done) ->
       @timeout 5000


### PR DESCRIPTION
As @paulcbetts noted, users can emulate the behviour with blur/focus events (actually they should use these instead). Anyways just fixing for compatibility. Also have fixed the value of `document.hidden` being incorrect.