### PR TITLE
navigaton: handle history operations from renderer

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -421,6 +421,11 @@ bool WebContents::HandleContextMenu(const content::ContextMenuParams& params) {
   return true;
 }
 
+bool WebContents::OnGoToEntryOffset(int offset) {
+  GoToOffset(offset);
+  return false;
+}
+
 void WebContents::BeforeUnloadFired(const base::TimeTicks& proceed_time) {
   // Do nothing, we override this method just to avoid compilation error since
   // there are two virtual functions named BeforeUnloadFired.

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -186,6 +186,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void RendererUnresponsive(content::WebContents* source) override;
   void RendererResponsive(content::WebContents* source) override;
   bool HandleContextMenu(const content::ContextMenuParams& params) override;
+  bool OnGoToEntryOffset(int offset) override;
 
   // content::WebContentsObserver:
   void BeforeUnloadFired(const base::TimeTicks& proceed_time) override;


### PR DESCRIPTION
fixes #3734 

allows us to suppress renderer restarts on sub-frame history navigations.

