### PR TITLE
Fixes #2810: correct look of hidden-inset windows in full screen.

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -78,6 +78,10 @@ class NativeWindowMac : public NativeWindow {
     UpdateDraggableRegionViews(draggable_regions_);
   }
 
+  bool ShouldHideNativeToolbarInFullscreen() const {
+    return should_hide_native_toolbar_in_fullscreen_;
+  }
+
  protected:
   // NativeWindow:
   void HandleKeyboardEvent(
@@ -117,6 +121,8 @@ class NativeWindowMac : public NativeWindow {
 
   // The presentation options before entering kiosk mode.
   NSApplicationPresentationOptions kiosk_options_;
+
+  bool should_hide_native_toolbar_in_fullscreen_;
 
   DISALLOW_COPY_AND_ASSIGN(NativeWindowMac);
 };


### PR DESCRIPTION
`hidden` and `hidden-inset` windows differ only by the hidden-inset window having a toolbar. Yet, the toolbar yields an incorrect look in fullscreen mode. So, we hide and recreate the toolbar for such windows when going to/from fullscreen.

There are some visible artifacts during the fullscreen animations, as the toolbar gets created and destroyed. When entering fullscreen, you see a toolbar that then disappears. When going back to normal window, you see the traffic light buttons jump around a little bit. Yet, this is definitely better than the current broken fullscreen look.