### PR TITLE
Fix crash when using webRequest API

### DIFF
--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -185,32 +185,6 @@ void ReadFromResponseObject(const base::DictionaryValue& response,
   }
 }
 
-// Deal with the results of Listener.
-template<typename T>
-void OnListenerResultInIO(const net::CompletionCallback& callback,
-                          T out,
-                          scoped_ptr<base::DictionaryValue> response) {
-  // The request has been destroyed.
-  if (callback.is_null())
-    return;
-
-  ReadFromResponseObject(*response.get(), out);
-
-  bool cancel = false;
-  response->GetBoolean("cancel", &cancel);
-  callback.Run(cancel ? net::ERR_BLOCKED_BY_CLIENT : net::OK);
-}
-
-template<typename T>
-void OnListenerResultInUI(const net::CompletionCallback& callback,
-                          T out,
-                          const base::DictionaryValue& response) {
-  scoped_ptr<base::DictionaryValue> copy = response.CreateDeepCopy();
-  BrowserThread::PostTask(
-      BrowserThread::IO, FROM_HERE,
-      base::Bind(OnListenerResultInIO<T>, callback, out, base::Passed(&copy)));
-}
-
 }  // namespace
 
 AtomNetworkDelegate::AtomNetworkDelegate() {
@@ -313,6 +287,9 @@ void AtomNetworkDelegate::OnResponseStarted(net::URLRequest* request) {
 }
 
 void AtomNetworkDelegate::OnCompleted(net::URLRequest* request, bool started) {
+  // OnCompleted may happen before other events.
+  callbacks_.erase(request->identifier());
+
   if (request->status().status() == net::URLRequestStatus::FAILED ||
       request->status().status() == net::URLRequestStatus::CANCELED) {
     // Error event.
@@ -365,11 +342,11 @@ int AtomNetworkDelegate::HandleResponseEvent(
   FillDetailsObject(details.get(), request, args...);
 
   // The |request| could be destroyed before the |callback| is called.
-  callbacks_[request->identifier()].Reset(callback);
-  const auto& cancelable = callbacks_[request->identifier()].callback();
+  callbacks_[request->identifier()] = callback;
 
   ResponseCallback response =
-      base::Bind(OnListenerResultInUI<Out>, cancelable, out);
+      base::Bind(&AtomNetworkDelegate::OnListenerResultInUI<Out>,
+                 base::Unretained(this), request->identifier(), out);
   BrowserThread::PostTask(
       BrowserThread::UI, FROM_HERE,
       base::Bind(RunResponseListener, info.listener, base::Passed(&details),
@@ -390,6 +367,30 @@ void AtomNetworkDelegate::HandleSimpleEvent(
   BrowserThread::PostTask(
       BrowserThread::UI, FROM_HERE,
       base::Bind(RunSimpleListener, info.listener, base::Passed(&details)));
+}
+
+template<typename T>
+void AtomNetworkDelegate::OnListenerResultInIO(
+    uint64_t id, T out, scoped_ptr<base::DictionaryValue> response) {
+  // The request has been destroyed.
+  if (!ContainsKey(callbacks_, id))
+    return;
+
+  ReadFromResponseObject(*response.get(), out);
+
+  bool cancel = false;
+  response->GetBoolean("cancel", &cancel);
+  callbacks_[id].Run(cancel ? net::ERR_BLOCKED_BY_CLIENT : net::OK);
+}
+
+template<typename T>
+void AtomNetworkDelegate::OnListenerResultInUI(
+    uint64_t id, T out, const base::DictionaryValue& response) {
+  scoped_ptr<base::DictionaryValue> copy = response.CreateDeepCopy();
+  BrowserThread::PostTask(
+      BrowserThread::IO, FROM_HERE,
+      base::Bind(&AtomNetworkDelegate::OnListenerResultInIO<T>,
+                 base::Unretained(this),  id, out, base::Passed(&copy)));
 }
 
 }  // namespace atom

--- a/atom/browser/net/atom_network_delegate.h
+++ b/atom/browser/net/atom_network_delegate.h
@@ -9,7 +9,7 @@
 #include <set>
 
 #include "brightray/browser/network_delegate.h"
-#include "base/cancelable_callback.h"
+#include "base/callback.h"
 #include "base/values.h"
 #include "extensions/common/url_pattern.h"
 #include "net/base/net_errors.h"
@@ -101,9 +101,17 @@ class AtomNetworkDelegate : public brightray::NetworkDelegate {
                           Out out,
                           Args... args);
 
+  // Deal with the results of Listener.
+  template<typename T>
+  void OnListenerResultInIO(
+      uint64_t id, T out, scoped_ptr<base::DictionaryValue> response);
+  template<typename T>
+  void OnListenerResultInUI(
+      uint64_t id, T out, const base::DictionaryValue& response);
+
   std::map<SimpleEvent, SimpleListenerInfo> simple_listeners_;
   std::map<ResponseEvent, ResponseListenerInfo> response_listeners_;
-  std::map<uint64_t, base::CancelableCallback<void(int)>> callbacks_;
+  std::map<uint64_t, net::CompletionCallback> callbacks_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomNetworkDelegate);
 };


### PR DESCRIPTION
The `URLRequest` might be deleted when the `callback` of a event is still pending, we need to make sure the `callback` is cancelled when this happens.

Close #3861.