### PR TITLE
Add note about required version of Visual Studio for building native modules

### DIFF
--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -18,6 +18,9 @@ Consider using [NAN](https://github.com/nodejs/nan/) for your own modules, since
 it makes it easier to support multiple versions of Node. It's also helpful for
 porting old modules to newer versions of Node so they can work with Electron.
 
+**Note:** Electron needs Visual Studio 2013 with Update 5 ([download VS 2013 Community Edition for
+  free](https://www.visualstudio.com/downloads/download-visual-studio-vs)) in order to build native modules on Windows. (Visual Studio 2015 won't work)
+  
 ## How to Install Native Modules
 
 Three ways to install native modules:


### PR DESCRIPTION
I've been trying to compile native modules for Electron with VS 2015 for about an hour before I stumbled upon this [issue](https://github.com/electronjs/electron-rebuild/issues/16#issuecomment-132283621) on electron-rebuild where it's mentioned that Electron needs VS 2013.

I've searched the docs here again and the only somewhat relevant mention about this is on the [Windows Build Instructions](https://github.com/atom/electron/blob/master/docs/development/build-instructions-windows.md) page for building Electron itself. Since this is a quite important information I believe it should be noted in the Native Modules tutorial.

PS: I'm not sure whether the Update 5 is needed or if any version of VS 2013 will suffice so please let me know so I can correct it if necessary.