### PR TITLE
renderer: dont fork the process when there is server redirect

### DIFF
--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -194,7 +194,7 @@ bool AtomRendererClient::ShouldFork(blink::WebLocalFrame* frame,
   // the OpenURLFromTab is triggered, which means form posting would not work,
   // we should solve this by patching Chromium in future.
   *send_referrer = true;
-  return http_method == "GET";
+  return http_method == "GET" && !is_server_redirect;
 }
 
 content::BrowserPluginDelegate* AtomRendererClient::CreateBrowserPluginDelegate(


### PR DESCRIPTION
Fixes #3471 

Otherwise `url_request` associated with the process will be destroyed. 

