### PR TITLE
tray: Support file-drop from OS X Dock

### DIFF
--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -281,14 +281,14 @@ const CGFloat kVerticalTitleMargin = 2;
 
 - (void)draggingEnded:(id <NSDraggingInfo>)sender {
   trayIcon_->NotifyDragEnded();
+
+  if (NSPointInRect([sender draggingLocation], self.frame)) {
+    trayIcon_->NotifyDrop();
+    [self handleDrop:sender];
+  }
 }
 
-- (BOOL)prepareForDragOperation:(id <NSDraggingInfo>)sender {
-  trayIcon_->NotifyDrop();
-  return YES;
-}
-
-- (BOOL)performDragOperation:(id <NSDraggingInfo>)sender {
+- (BOOL)handleDrop:(id <NSDraggingInfo>)sender {
   NSPasteboard* pboard = [sender draggingPasteboard];
 
   if ([[pboard types] containsObject:NSFilenamesPboardType]) {
@@ -300,6 +300,14 @@ const CGFloat kVerticalTitleMargin = 2;
     return YES;
   }
   return NO;
+}
+
+- (BOOL)prepareForDragOperation:(id <NSDraggingInfo>)sender {
+  return YES;
+}
+
+- (BOOL)performDragOperation:(id <NSDraggingInfo>)sender {
+  return YES;
 }
 
 - (BOOL)shouldHighlight {


### PR DESCRIPTION
A long-standing Apple bug does not call `prepareForDragOperation:sender`
for file drag-and-drop operations from the Dock. So we manually
call our custom `handleDrop:sender` for all drag-and-drop cases (that
is, from the Dock and from Finder).

References to the bug in question:
- http://stackoverflow.com/q/9534543/3309046
- http://openradar.appspot.com/radar?id=1745403

However, we still need to return YES from `prepareForDragOperation:sender`,
otherwise the "drag failed" animation occurs. For the same reason, we also
return YES from `performDragOperation:sender`.

The "drag failed" animation example: https://gfycat.com/DaringCourageousEelelephant.

Fixes #3008

Tested

- [x] OS X (fix only applies to OS X)