### PR TITLE
webFrame: support fetch api for schemes that are privileged.

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -112,6 +112,8 @@ void WebFrame::RegisterURLSchemeAsPrivileged(const std::string& scheme) {
       privileged_scheme);
   blink::WebSecurityPolicy::registerURLSchemeAsAllowingServiceWorkers(
       privileged_scheme);
+  blink::WebSecurityPolicy::registerURLSchemeAsSupportingFetchAPI(
+      privileged_scheme);
 }
 
 mate::ObjectTemplateBuilder WebFrame::GetObjectTemplateBuilder(

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -87,7 +87,7 @@ Content Security Policy.
 
 * `scheme` String
 
-Registers the `scheme` as secure, bypasses content security policy for resources and
-allows registering ServiceWorker.
+Registers the `scheme` as secure, bypasses content security policy for resources,
+allows registering ServiceWorker and supports fetch API.
 
 [spellchecker]: https://github.com/atom/node-spellchecker

--- a/spec/api-web-frame-spec.coffee
+++ b/spec/api-web-frame-spec.coffee
@@ -1,0 +1,18 @@
+assert = require 'assert'
+path = require 'path'
+
+{webFrame} = require 'electron'
+
+describe 'webFrame module', ->
+  fixtures = path.resolve __dirname, 'fixtures'
+
+  describe 'webFrame.registerURLSchemeAsPrivileged', ->
+    it 'supports fetch api', (done) ->
+      webFrame.registerURLSchemeAsPrivileged 'file'
+      url = "file://#{fixtures}/assets/logo.png"
+
+      fetch(url).then((response) ->
+        assert response.ok
+        done()
+      ).catch (err) ->
+        done('unexpected error : ' + err)


### PR DESCRIPTION
Related #3922 

Should file scheme support it by default, since we allow sw by default ?