### PR TITLE
:apple: fix #3864 where saving a file causes a crash if file extensio…

### DIFF
--- a/atom/browser/ui/file_dialog_mac.mm
+++ b/atom/browser/ui/file_dialog_mac.mm
@@ -34,7 +34,12 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
       [file_type_set addObject:base::mac::CFToNSCast(ext_cf.get())];
     }
   }
-  [dialog setAllowedFileTypes:[file_type_set allObjects]];
+
+  NSArray* file_types = nil;
+  if ([file_type_set count])
+    file_types = [file_type_set allObjects];
+
+  [dialog setAllowedFileTypes: file_types];
 }
 
 void SetupDialog(NSSavePanel* dialog,


### PR DESCRIPTION
…n array is empty

Hi! 

This fix for https://github.com/atom/electron/issues/3864 is pretty straight forward. allowedFileTypes/setAllowedFileTypes in NSSavePanel throws an exception when the array passed in is empty and is not nil. I just defaulted the array to nil to fix it.

See https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSSavePanel_Class/index.html#//apple_ref/occ/instp/NSSavePanel/allowedFileTypes

Happy new year! :fireworks: 