### PR TITLE
:apple: only add sub menus to Window when they actually have menu ite…

### DIFF
--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -148,10 +148,11 @@ Role kRolesMap[] = {
 
     // Set submenu's role.
     base::string16 role = model->GetRoleAt(index);
-    if (role == base::ASCIIToUTF16("window"))
+    if (role == base::ASCIIToUTF16("window") && [submenu numberOfItems])
       [NSApp setWindowsMenu:submenu];
     else if (role == base::ASCIIToUTF16("help"))
       [NSApp setHelpMenu:submenu];
+
     if (role == base::ASCIIToUTF16("services"))
       [NSApp setServicesMenu:submenu];
   } else {


### PR DESCRIPTION
…ms. fixes #3873

```NSMenu.insertItem``` was raising an ```NSInternalInconsistencyException``` ([see apple docs] (https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSMenu_Class/#//apple_ref/occ/instm/NSMenu/insertItem:atIndex:)) when empty Menus were given more empty Menus as submenus. This only happened when ```role``` was set to ```'window'```. Using this example taken from #3873: 

```
var menu = new Menu();
menu.append(new MenuItem({label: 'Window', submenu: new Menu(), type: 'submenu', role: 'window'}));
Menu.setApplicationMenu(menu);
```

```menu``` is empty. Adding a MenuItem that is also empty with ```submenu: new Menu()``` raises the exception and crashes Electron. 

The new behavior is that a submenu with no menu items is created as expected.