### PR TITLE
Rename did-navigate-to-different-page to did-navigate

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -566,7 +566,7 @@ void WebContents::DidNavigateMainFrame(
     const content::LoadCommittedDetails& details,
     const content::FrameNavigateParams& params) {
   if (details.is_navigation_to_different_page())
-    Emit("did-navigate-to-different-page", params.url);
+    Emit("did-navigate", params.url);
   else if (details.is_in_page)
     Emit("did-navigate-in-page", params.url);
 }

--- a/atom/browser/lib/guest-view-manager.coffee
+++ b/atom/browser/lib/guest-view-manager.coffee
@@ -18,7 +18,7 @@ supportedWebViewEvents = [
   'devtools-focused'
   'new-window'
   'will-navigate'
-  'did-navigate-to-different-page'
+  'did-navigate'
   'did-navigate-in-page'
   'close'
   'crashed'
@@ -57,7 +57,7 @@ createGuest = (embedder, params) ->
   guestInstances[id] = {guest, embedder}
 
   # Destroy guest when the embedder is gone or navigated.
-  destroyEvents = ['destroyed', 'crashed', 'did-navigate-to-different-page']
+  destroyEvents = ['destroyed', 'crashed', 'did-navigate']
   destroy = ->
     destroyGuest embedder, id if guestInstances[id]?
   for event in destroyEvents

--- a/atom/renderer/lib/web-view/guest-view-internal.coffee
+++ b/atom/renderer/lib/web-view/guest-view-internal.coffee
@@ -20,7 +20,7 @@ WEB_VIEW_EVENTS =
   'devtools-focused': []
   'new-window': ['url', 'frameName', 'disposition', 'options']
   'will-navigate': ['url']
-  'did-navigate-to-different-page': ['url']
+  'did-navigate': ['url']
   'did-navigate-in-page': ['url']
   'close': []
   'crashed': []

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -129,27 +129,43 @@ Returns:
 * `event` Event
 * `url` String
 
-Emitted when a user or the page wants to start navigation. It can happen when the
-`window.location` object is changed or a user clicks a link in the page.
+Emitted when a user or the page wants to start navigation. It can happen when
+the `window.location` object is changed or a user clicks a link in the page.
 
 This event will not emit when the navigation is started programmatically with
 APIs like `webContents.loadURL` and `webContents.back`.
 
-It is also not emitted during in-page navigation, such as clicking anchor links
-or updating the `window.location.hash`. Use `did-navigate-in-page` for this purpose.
+It is also not emitted for in-page navigations, such as clicking anchor links
+or updating the `window.location.hash`. Use `did-navigate-in-page` event for
+this purpose.
 
 Calling `event.preventDefault()` will prevent the navigation.
 
-### Event: 'did-navigate-to-different-page'
+### Event: 'did-navigate'
 
-Emitted when the new page that was navigated to is different from the previous
-page.
+Returns:
+
+* `event` Event
+* `url` String
+
+Emitted when a navigation is done.
+
+This event is not emitted for in-page navigations, such as clicking anchor links
+or updating the `window.location.hash`. Use `did-navigate-in-page` event for
+this purpose.
 
 ### Event: 'did-navigate-in-page'
 
-Emitted when the page url changes but does not cause navigation outside of the page.
-Examples of this occurring are when anchor links are clicked or when the
-DOM `hashchange` event is triggered.
+Returns:
+
+* `event` Event
+* `url` String
+
+Emitted when an in-page navigation happened.
+
+When in-page navigation happens, the page URL changes but does not cause
+navigation outside of the page. Examples of this occurring are when anchor links
+are clicked or when the DOM `hashchange` event is triggered.
 
 ### Event: 'crashed'
 

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -579,24 +579,44 @@ webview.addEventListener('new-window', function(e) {
 ### Event: 'will-navigate'
 
 Returns:
+
 * `url` String
 
-Emitted when a user or the page wants to start navigation. It can happen when the
-`window.location` object is changed or a user clicks a link in the page. It not
-emitted during in-page navigation such as clicking anchor links or updating the
-`window.location.hash`. Use `did-navigate-in-page` for this purpose.
+Emitted when a user or the page wants to start navigation. It can happen when
+the `window.location` object is changed or a user clicks a link in the page.
 
+This event will not emit when the navigation is started programmatically with
+APIs like `<webview>.loadURL` and `<webview>.back`.
 
-### Event: 'did-navigate-to-different-page'
+It is also not emitted during in-page navigation, such as clicking anchor links
+or updating the `window.location.hash`. Use `did-navigate-in-page` event for
+this purpose.
 
-Emitted when the new page that was navigated to is different from the previous
-page.
+Calling `event.preventDefault()` does __NOT__ have any effect.
+
+### Event: 'did-navigate'
+
+Returns:
+
+* `url` String
+
+Emitted when a navigation is done.
+
+This event is not emitted for in-page navigations, such as clicking anchor links
+or updating the `window.location.hash`. Use `did-navigate-in-page` event for
+this purpose.
 
 ### Event: 'did-navigate-in-page'
 
-Emitted when the page url changes but does not cause navigation outside of the page.
-Examples of this occurring are when anchor links are clicked or when the
-DOM `hashchange` event is triggered.
+Returns:
+
+* `url` String
+
+Emitted when an in-page navigation happened.
+
+When in-page navigation happens, the page URL changes but does not cause
+navigation outside of the page. Examples of this occurring are when anchor links
+are clicked or when the DOM `hashchange` event is triggered.
 
 ### Event: 'close'
 

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -280,25 +280,25 @@ describe '<webview> tag', ->
       webview.src = "file://#{fixtures}/pages/webview-will-navigate.html"
       document.body.appendChild webview
 
-  describe 'did-navigate-to-different-page event', ->
-    page_url = "file://#{fixtures}/pages/webview-will-navigate.html"
+  describe 'did-navigate event', ->
+    pageUrl = "file://#{fixtures}/pages/webview-will-navigate.html"
 
     it 'emits when a url that leads to outside of the page is clicked', (done) ->
-      webview.addEventListener 'did-navigate-to-different-page', (e) ->
-        assert.equal e.url, page_url
+      webview.addEventListener 'did-navigate', (e) ->
+        assert.equal e.url, pageUrl
         done()
 
-      webview.src = page_url
+      webview.src = pageUrl
       document.body.appendChild webview
 
   describe 'did-navigate-in-page event', ->
     it 'emits when an anchor link is clicked', (done) ->
-      page_url = "file://#{fixtures}/pages/webview-did-navigate-in-page.html"
+      pageUrl = "file://#{fixtures}/pages/webview-did-navigate-in-page.html"
       webview.addEventListener 'did-navigate-in-page', (e) ->
-        assert.equal e.url, "#{page_url}#test_content"
+        assert.equal e.url, "#{pageUrl}#test_content"
         done()
 
-      webview.src = page_url
+      webview.src = pageUrl
       document.body.appendChild webview
 
     it 'emits when window.history.replaceState is called', (done) ->
@@ -310,12 +310,12 @@ describe '<webview> tag', ->
       document.body.appendChild webview
 
     it 'emits when window.location.hash is changed', (done) ->
-      page_url = "file://#{fixtures}/pages/webview-did-navigate-in-page-with-hash.html"
+      pageUrl = "file://#{fixtures}/pages/webview-did-navigate-in-page-with-hash.html"
       webview.addEventListener 'did-navigate-in-page', (e) ->
-        assert.equal e.url, "#{page_url}#test"
+        assert.equal e.url, "#{pageUrl}#test"
         done()
 
-      webview.src = page_url
+      webview.src = pageUrl
       document.body.appendChild webview
 
   describe 'close event', ->


### PR DESCRIPTION
`did-navigate-to-different-page` is too long for an event's name, using `did-navigate` can perfectly match `will-navigate`.

Refs #3975.