### PR TITLE
Fix distorted image when calling `capturePage` with no rect

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -278,22 +278,22 @@ void NativeWindow::CapturePage(const gfx::Rect& rect,
   }
 
   // Capture full page if user doesn't specify a |rect|.
-  const gfx::Rect view_rect = rect.IsEmpty() ? view->GetViewBounds() :
-                                               rect;
+  const gfx::Size view_size = rect.IsEmpty() ? view->GetViewBounds().size() :
+                                               rect.size();
 
   // By default, the requested bitmap size is the view size in screen
   // coordinates.  However, if there's more pixel detail available on the
   // current system, increase the requested bitmap size to capture it all.
-  gfx::Size bitmap_size = view_rect.size();
+  gfx::Size bitmap_size = view_size;
   const gfx::NativeView native_view = view->GetNativeView();
   gfx::Screen* const screen = gfx::Screen::GetScreenFor(native_view);
   const float scale =
       screen->GetDisplayNearestWindow(native_view).device_scale_factor();
   if (scale > 1.0f)
-    bitmap_size = gfx::ScaleToCeiledSize(view_rect.size(), scale);
+    bitmap_size = gfx::ScaleToCeiledSize(view_size, scale);
 
   host->CopyFromBackingStore(
-      view_rect,
+      gfx::Rect(view_size),
       bitmap_size,
       base::Bind(&NativeWindow::OnCapturePageDone,
                  weak_factory_.GetWeakPtr(),

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -32,10 +32,10 @@
 #include "ipc/ipc_message_macros.h"
 #include "native_mate/dictionary.h"
 #include "ui/gfx/codec/png_codec.h"
-#include "ui/gfx/geometry/size_conversions.h"
 #include "ui/gfx/geometry/point.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/geometry/size.h"
+#include "ui/gfx/geometry/size_conversions.h"
 #include "ui/gfx/screen.h"
 #include "ui/gl/gpu_switching_manager.h"
 
@@ -293,7 +293,7 @@ void NativeWindow::CapturePage(const gfx::Rect& rect,
     bitmap_size = gfx::ScaleToCeiledSize(view_size, scale);
 
   host->CopyFromBackingStore(
-      gfx::Rect(view_size),
+      gfx::Rect(rect.origin(), view_size),
       bitmap_size,
       base::Bind(&NativeWindow::OnCapturePageDone,
                  weak_factory_.GetWeakPtr(),


### PR DESCRIPTION
Close #3953.

Also found an interesting fact, for the rect passed to `CopyFromBackingStore` API, the size must be scaled to device's DPI, but the origin must __not__ be scaled. it seems to be a bug of Chromium.