### PR TITLE
📝 Replace __dirname with app.getAppPath() in docs

### DIFF
--- a/docs-translations/es/tutorial/online-offline-events.md
+++ b/docs-translations/es/tutorial/online-offline-events.md
@@ -12,7 +12,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + app.getAppPath() + '/online-status.html');
 });
 ```
 
@@ -50,7 +50,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + app.getAppPath() + '/online-status.html');
 });
 
 ipc.on('online-status-changed', function(event, status) {

--- a/docs-translations/es/tutorial/quick-start.md
+++ b/docs-translations/es/tutorial/quick-start.md
@@ -91,7 +91,7 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({width: 800, height: 600});
 
   // cargar el index.html de nuestra aplicación.
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + app.getAppPath() + '/index.html');
 
   // Desplegar devtools.
   mainWindow.openDevTools();

--- a/docs-translations/es/tutorial/using-pepper-flash-plugin.md
+++ b/docs-translations/es/tutorial/using-pepper-flash-plugin.md
@@ -43,7 +43,7 @@ app.on('ready', function() {
       'plugins': true
     }
   });
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + app.getAppPath() + '/index.html');
   // Something else
 });
 ```

--- a/docs-translations/jp/tutorial/quick-start.md
+++ b/docs-translations/jp/tutorial/quick-start.md
@@ -71,7 +71,7 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({width: 800, height: 600});
 
   // and load the index.html of the app.
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + app.getAppPath() + '/index.html');
 
   // Open the devtools.
   mainWindow.openDevTools();

--- a/docs-translations/ko-KR/api/web-contents.md
+++ b/docs-translations/ko-KR/api/web-contents.md
@@ -641,7 +641,7 @@ mainWindow.webContents.on('devtools-opened', function() {
 var window = null;
 app.on('ready', function() {
   window = new BrowserWindow({width: 800, height: 600});
-  window.loadURL('file://' + __dirname + '/index.html');
+  window.loadURL('file://' + app.getAppPath() + '/index.html');
   window.webContents.on('did-finish-load', function() {
     window.webContents.send('ping', 'whoooooooh!');
   });

--- a/docs-translations/ko-KR/tutorial/online-offline-events.md
+++ b/docs-translations/ko-KR/tutorial/online-offline-events.md
@@ -13,7 +13,7 @@ const BrowserWindow = electron.BrowserWindow;
 var onlineStatusWindow;
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + app.getAppPath() + '/online-status.html');
 });
 ```
 
@@ -55,7 +55,7 @@ const BrowserWindow = electron.BrowserWindow;
 var onlineStatusWindow;
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + app.getAppPath() + '/online-status.html');
 });
 
 ipcMain.on('online-status-changed', function(event, status) {

--- a/docs-translations/ko-KR/tutorial/quick-start.md
+++ b/docs-translations/ko-KR/tutorial/quick-start.md
@@ -100,7 +100,7 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({width: 800, height: 600});
 
   // 그리고 현재 디렉터리의 index.html을 로드합니다.
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + app.getAppPath() + '/index.html');
 
   // 개발자 도구를 엽니다.
   mainWindow.webContents.openDevTools();

--- a/docs-translations/ko-KR/tutorial/using-pepper-flash-plugin.md
+++ b/docs-translations/ko-KR/tutorial/using-pepper-flash-plugin.md
@@ -33,7 +33,7 @@ app.on('ready', function() {
       'plugins': true
     }
   });
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + app.getAppPath() + '/index.html');
   // Something else
 });
 ```

--- a/docs-translations/pt-BR/tutorial/online-offline-events.md
+++ b/docs-translations/pt-BR/tutorial/online-offline-events.md
@@ -13,7 +13,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + app.getAppPath() + '/online-status.html');
 });
 ```
 
@@ -53,7 +53,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + app.getAppPath() + '/online-status.html');
 });
 
 ipc.on('online-status-changed', function(event, status) {

--- a/docs-translations/pt-BR/tutorial/quick-start.md
+++ b/docs-translations/pt-BR/tutorial/quick-start.md
@@ -103,7 +103,7 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({width: 800, height: 600});
 
   // e carrega o index.html do app.
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + app.getAppPath() + '/index.html');
 
   // Abre os DevTools.
   mainWindow.openDevTools();

--- a/docs-translations/pt-BR/tutorial/using-pepper-flash-plugin.md
+++ b/docs-translations/pt-BR/tutorial/using-pepper-flash-plugin.md
@@ -51,7 +51,7 @@ app.on('ready', function() {
       'plugins': true
     }
   });
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + app.getAppPath() + '/index.html');
   // Algo mais
 });
 ```

--- a/docs-translations/zh-CN/tutorial/online-offline-events.md
+++ b/docs-translations/zh-CN/tutorial/online-offline-events.md
@@ -9,7 +9,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + app.getAppPath() + '/online-status.html');
 });
 ```
 
@@ -43,7 +43,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + app.getAppPath() + '/online-status.html');
 });
 
 ipc.on('online-status-changed', function(event, status) {

--- a/docs-translations/zh-CN/tutorial/quick-start.md
+++ b/docs-translations/zh-CN/tutorial/quick-start.md
@@ -65,7 +65,7 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({width: 800, height: 600});
 
   // 加载应用的 index.html
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + app.getAppPath() + '/index.html');
 
   // 打开开发工具
   mainWindow.openDevTools();

--- a/docs-translations/zh-TW/tutorial/online-offline-events.md
+++ b/docs-translations/zh-TW/tutorial/online-offline-events.md
@@ -12,7 +12,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + app.getAppPath() + '/online-status.html');
 });
 ```
 
@@ -50,7 +50,7 @@ var onlineStatusWindow;
 
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + app.getAppPath() + '/online-status.html');
 });
 
 ipc.on('online-status-changed', function(event, status) {

--- a/docs-translations/zh-TW/tutorial/quick-start.md
+++ b/docs-translations/zh-TW/tutorial/quick-start.md
@@ -82,7 +82,7 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({width: 800, height: 600});
 
   // 載入應用程式的 index.html
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + app.getAppPath() + '/index.html');
 
   // 打開開發者工具
   mainWindow.webContents.openDevTools();

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -675,7 +675,7 @@ An example of sending messages from the main process to the renderer process:
 var window = null;
 app.on('ready', function() {
   window = new BrowserWindow({width: 800, height: 600});
-  window.loadURL('file://' + __dirname + '/index.html');
+  window.loadURL('file://' + app.getAppPath() + '/index.html');
   window.webContents.on('did-finish-load', function() {
     window.webContents.send('ping', 'whoooooooh!');
   });

--- a/docs/tutorial/online-offline-events.md
+++ b/docs/tutorial/online-offline-events.md
@@ -13,7 +13,7 @@ const BrowserWindow = electron.BrowserWindow;
 var onlineStatusWindow;
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + app.getAppPath() + '/online-status.html');
 });
 ```
 
@@ -54,7 +54,7 @@ const BrowserWindow = electron.BrowserWindow;
 var onlineStatusWindow;
 app.on('ready', function() {
   onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-  onlineStatusWindow.loadURL('file://' + __dirname + '/online-status.html');
+  onlineStatusWindow.loadURL('file://' + app.getAppPath() + '/online-status.html');
 });
 
 ipcMain.on('online-status-changed', function(event, status) {

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -104,7 +104,7 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({width: 800, height: 600});
 
   // and load the index.html of the app.
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + app.getAppPath() + '/index.html');
 
   // Open the DevTools.
   mainWindow.webContents.openDevTools();

--- a/docs/tutorial/using-pepper-flash-plugin.md
+++ b/docs/tutorial/using-pepper-flash-plugin.md
@@ -36,7 +36,7 @@ app.on('ready', function() {
       'plugins': true
     }
   });
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + app.getAppPath() + '/index.html');
   // Something else
 });
 ```


### PR DESCRIPTION
This PR changes the documentation only.
It changes the `loadURL` calls throughout all code examples when loading a local file from the apps bundle. Where `__dirname` was used before, `app.getAppPath()` is used now.

I spent two hours until I found the problem why my `index.html` was not able to load yesterday. `__dirname` referenced to the current working dir from my terminal session and not to the `app/` directory of my electron application.
`app.getAppPath()` fixed this. I assume this change in documentation might help others too.