### PR TITLE
Remove custom WM_GETOBJECT handler

### DIFF
--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -84,20 +84,6 @@ bool NativeWindowViews::PreHandleMSG(
   NotifyWindowMessage(message, w_param, l_param);
 
   switch (message) {
-    // Screen readers send WM_GETOBJECT in order to get the accessibility
-    // object, so take this opportunity to push Chromium into accessible
-    // mode if it isn't already, always say we didn't handle the message
-    // because we still want Chromium to handle returning the actual
-    // accessibility object.
-    case WM_GETOBJECT: {
-      const DWORD obj_id = static_cast<DWORD>(l_param);
-      if (obj_id == OBJID_CLIENT) {
-        const auto axState = content::BrowserAccessibilityState::GetInstance();
-        if (axState && !axState->IsAccessibleBrowser())
-          axState->OnScreenReaderDetected();
-      }
-      return false;
-    }
     case WM_COMMAND:
       // Handle thumbar button click message.
       if (HIWORD(w_param) == THBN_CLICKED)


### PR DESCRIPTION
As of Chromium 47 this seems to be handled automatically, nvda still reports elements and the typing lag issue described in #4001 is fixed

/cc @ryanmolden to make sure I'm not missing anything