### PR TITLE
Add blinkFeatures option

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -34,10 +34,6 @@ FeaturePair kWebRuntimeFeatures[] = {
     switches::kExperimentalFeatures },
   { options::kExperimentalCanvasFeatures,
     switches::kExperimentalCanvasFeatures },
-  { options::kOverlayScrollbars,
-    switches::kOverlayScrollbars },
-  { options::kSharedWorker,
-    switches::kSharedWorker },
   { options::kPageVisibility,
     switches::kPageVisibility },
 };

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -10,6 +10,7 @@
 #include "atom/common/options_switches.h"
 #include "base/command_line.h"
 #include "base/strings/string_number_conversions.h"
+#include "content/public/common/content_switches.h"
 #include "content/public/common/web_preferences.h"
 #include "native_mate/dictionary.h"
 #include "net/base/filename_util.h"
@@ -21,22 +22,6 @@
 DEFINE_WEB_CONTENTS_USER_DATA_KEY(atom::WebContentsPreferences);
 
 namespace atom {
-
-namespace {
-
-// Array of available web runtime features.
-struct FeaturePair {
-  const char* name;
-  const char* cmd;
-};
-FeaturePair kWebRuntimeFeatures[] = {
-  { options::kExperimentalFeatures,
-    switches::kExperimentalFeatures },
-  { options::kExperimentalCanvasFeatures,
-    switches::kExperimentalCanvasFeatures },
-};
-
-}  // namespace
 
 WebContentsPreferences::WebContentsPreferences(
     content::WebContents* web_contents,
@@ -79,13 +64,12 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
   if (web_preferences.GetBoolean("plugins", &b) && b)
     command_line->AppendSwitch(switches::kEnablePlugins);
 
-  // This set of options are not availabe in WebPreferences, so we have to pass
-  // them via command line and enable them in renderer procss.
-  for (size_t i = 0; i < arraysize(kWebRuntimeFeatures); ++i) {
-    const auto& feature = kWebRuntimeFeatures[i];
-    if (web_preferences.GetBoolean(feature.name, &b))
-      command_line->AppendSwitchASCII(feature.cmd, b ? "true" : "false");
-  }
+  // Experimental flags.
+  if (web_preferences.GetBoolean(options::kExperimentalFeatures, &b) && b)
+    command_line->AppendSwitch(
+        ::switches::kEnableExperimentalWebPlatformFeatures);
+  if (web_preferences.GetBoolean(options::kExperimentalCanvasFeatures, &b) && b)
+    command_line->AppendSwitch(::switches::kEnableExperimentalCanvasFeatures);
 
   // Check if we have node integration specified.
   bool node_integration = true;

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -116,6 +116,12 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
   if (web_preferences.GetInteger(options::kOpenerID, &opener_id))
       command_line->AppendSwitchASCII(switches::kOpenerID,
                                       base::IntToString(opener_id));
+
+  // Enable blink features.
+  std::string blink_features;
+  if (web_preferences.GetString(options::kBlinkFeatures, &blink_features))
+      command_line->AppendSwitchASCII(::switches::kEnableBlinkFeatures,
+                                      blink_features);
 }
 
 // static

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -34,8 +34,6 @@ FeaturePair kWebRuntimeFeatures[] = {
     switches::kExperimentalFeatures },
   { options::kExperimentalCanvasFeatures,
     switches::kExperimentalCanvasFeatures },
-  { options::kPageVisibility,
-    switches::kPageVisibility },
 };
 
 }  // namespace

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -136,8 +136,6 @@ const char kPreloadScript[]              = "preload";
 const char kPreloadURL[]                 = "preload-url";
 const char kNodeIntegration[]            = "node-integration";
 const char kGuestInstanceID[]            = "guest-instance-id";
-const char kExperimentalFeatures[]       = "experimental-features";
-const char kExperimentalCanvasFeatures[] = "experimental-canvas-features";
 const char kOpenerID[]                   = "opener-id";
 
 // Widevine options

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -88,12 +88,15 @@ const char kGuestInstanceID[] = "guestInstanceId";
 // Enable DirectWrite on Windows.
 const char kDirectWrite[] = "directWrite";
 
-// Opener window's ID.
-const char kOpenerID[] = "openerId";
-
 // Web runtime features.
 const char kExperimentalFeatures[]       = "experimentalFeatures";
 const char kExperimentalCanvasFeatures[] = "experimentalCanvasFeatures";
+
+// Opener window's ID.
+const char kOpenerID[] = "openerId";
+
+// Enable blink features.
+const char kBlinkFeatures[] = "blinkFeatures";
 
 }  // namespace options
 

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -85,9 +85,6 @@ const char kNodeIntegration[] = "nodeIntegration";
 // Instancd ID of guest WebContents.
 const char kGuestInstanceID[] = "guestInstanceId";
 
-// Set page visiblity to always visible.
-const char kPageVisibility[] = "pageVisibility";
-
 // Enable DirectWrite on Windows.
 const char kDirectWrite[] = "directWrite";
 
@@ -141,7 +138,6 @@ const char kNodeIntegration[]            = "node-integration";
 const char kGuestInstanceID[]            = "guest-instance-id";
 const char kExperimentalFeatures[]       = "experimental-features";
 const char kExperimentalCanvasFeatures[] = "experimental-canvas-features";
-const char kPageVisibility[]             = "page-visiblity";
 const char kOpenerID[]                   = "opener-id";
 
 // Widevine options

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -97,8 +97,6 @@ const char kOpenerID[] = "openerId";
 // Web runtime features.
 const char kExperimentalFeatures[]       = "experimentalFeatures";
 const char kExperimentalCanvasFeatures[] = "experimentalCanvasFeatures";
-const char kOverlayScrollbars[]          = "overlayScrollbars";
-const char kSharedWorker[]               = "sharedWorker";
 
 }  // namespace options
 
@@ -143,8 +141,6 @@ const char kNodeIntegration[]            = "node-integration";
 const char kGuestInstanceID[]            = "guest-instance-id";
 const char kExperimentalFeatures[]       = "experimental-features";
 const char kExperimentalCanvasFeatures[] = "experimental-canvas-features";
-const char kOverlayScrollbars[]          = "overlay-scrollbars";
-const char kSharedWorker[]               = "shared-worker";
 const char kPageVisibility[]             = "page-visiblity";
 const char kOpenerID[]                   = "opener-id";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -49,7 +49,6 @@ extern const char kNodeIntegration[];
 extern const char kGuestInstanceID[];
 extern const char kExperimentalFeatures[];
 extern const char kExperimentalCanvasFeatures[];
-extern const char kPageVisibility[];
 extern const char kOpenerID[];
 
 }   // namespace options
@@ -77,7 +76,6 @@ extern const char kNodeIntegration[];
 extern const char kGuestInstanceID[];
 extern const char kExperimentalFeatures[];
 extern const char kExperimentalCanvasFeatures[];
-extern const char kPageVisibility[];
 extern const char kOpenerID[];
 
 extern const char kWidevineCdmPath[];

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -74,8 +74,6 @@ extern const char kPreloadScript[];
 extern const char kPreloadURL[];
 extern const char kNodeIntegration[];
 extern const char kGuestInstanceID[];
-extern const char kExperimentalFeatures[];
-extern const char kExperimentalCanvasFeatures[];
 extern const char kOpenerID[];
 
 extern const char kWidevineCdmPath[];

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -49,8 +49,6 @@ extern const char kNodeIntegration[];
 extern const char kGuestInstanceID[];
 extern const char kExperimentalFeatures[];
 extern const char kExperimentalCanvasFeatures[];
-extern const char kOverlayScrollbars[];
-extern const char kSharedWorker[];
 extern const char kPageVisibility[];
 extern const char kOpenerID[];
 
@@ -79,8 +77,6 @@ extern const char kNodeIntegration[];
 extern const char kGuestInstanceID[];
 extern const char kExperimentalFeatures[];
 extern const char kExperimentalCanvasFeatures[];
-extern const char kOverlayScrollbars[];
-extern const char kSharedWorker[];
 extern const char kPageVisibility[];
 extern const char kOpenerID[];
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -50,6 +50,7 @@ extern const char kGuestInstanceID[];
 extern const char kExperimentalFeatures[];
 extern const char kExperimentalCanvasFeatures[];
 extern const char kOpenerID[];
+extern const char kBlinkFeatures[];
 
 }   // namespace options
 

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -230,10 +230,6 @@ void AtomRendererClient::EnableWebRuntimeFeatures() {
     blink::WebRuntimeFeatures::enableExperimentalFeatures(true);
   if (IsSwitchEnabled(command_line, switches::kExperimentalCanvasFeatures))
     blink::WebRuntimeFeatures::enableExperimentalCanvasFeatures(true);
-  if (IsSwitchEnabled(command_line, switches::kOverlayScrollbars))
-    blink::WebRuntimeFeatures::enableOverlayScrollbars(true);
-  if (IsSwitchEnabled(command_line, switches::kSharedWorker))
-    blink::WebRuntimeFeatures::enableSharedWorker(true);
 }
 
 void AtomRendererClient::AddKeySystems(

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -41,11 +41,6 @@ namespace atom {
 
 namespace {
 
-bool IsSwitchEnabled(base::CommandLine* command_line,
-                     const char* switch_string) {
-  return command_line->GetSwitchValueASCII(switch_string) == "true";
-}
-
 // Helper class to forward the messages to the client.
 class AtomRenderFrameObserver : public content::RenderFrameObserver {
  public:
@@ -95,8 +90,6 @@ AtomRendererClient::~AtomRendererClient() {
 }
 
 void AtomRendererClient::WebKitInitialized() {
-  EnableWebRuntimeFeatures();
-
   blink::WebCustomElement::addEmbedderCustomElementName("webview");
   blink::WebCustomElement::addEmbedderCustomElementName("browserplugin");
 
@@ -208,15 +201,6 @@ content::BrowserPluginDelegate* AtomRendererClient::CreateBrowserPluginDelegate(
   } else {
     return nullptr;
   }
-}
-
-void AtomRendererClient::EnableWebRuntimeFeatures() {
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-
-  if (IsSwitchEnabled(command_line, switches::kExperimentalFeatures))
-    blink::WebRuntimeFeatures::enableExperimentalFeatures(true);
-  if (IsSwitchEnabled(command_line, switches::kExperimentalCanvasFeatures))
-    blink::WebRuntimeFeatures::enableExperimentalCanvasFeatures(true);
 }
 
 void AtomRendererClient::AddKeySystems(

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -210,19 +210,6 @@ content::BrowserPluginDelegate* AtomRendererClient::CreateBrowserPluginDelegate(
   }
 }
 
-bool AtomRendererClient::ShouldOverridePageVisibilityState(
-    const content::RenderFrame* render_frame,
-    blink::WebPageVisibilityState* override_state) {
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-
-  if (IsSwitchEnabled(command_line, switches::kPageVisibility)) {
-    *override_state = blink::WebPageVisibilityStateVisible;
-    return true;
-  }
-
-  return false;
-}
-
 void AtomRendererClient::EnableWebRuntimeFeatures() {
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
 

--- a/atom/renderer/atom_renderer_client.h
+++ b/atom/renderer/atom_renderer_client.h
@@ -56,9 +56,6 @@ class AtomRendererClient : public content::ContentRendererClient,
       content::RenderFrame* render_frame,
       const std::string& mime_type,
       const GURL& original_url) override;
-  bool ShouldOverridePageVisibilityState(
-      const content::RenderFrame* render_frame,
-      blink::WebPageVisibilityState* override_state) override;
   void AddKeySystems(std::vector<media::KeySystemInfo>* key_systems) override;
 
   void EnableWebRuntimeFeatures();

--- a/atom/renderer/atom_renderer_client.h
+++ b/atom/renderer/atom_renderer_client.h
@@ -58,8 +58,6 @@ class AtomRendererClient : public content::ContentRendererClient,
       const GURL& original_url) override;
   void AddKeySystems(std::vector<media::KeySystemInfo>* key_systems) override;
 
-  void EnableWebRuntimeFeatures();
-
   scoped_ptr<NodeBindings> node_bindings_;
   scoped_ptr<AtomBindings> atom_bindings_;
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -138,10 +138,6 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     canvas features. Default is `false`.
   * `directWrite` Boolean - Enables DirectWrite font rendering system on
      Windows. Default is `true`.
-  * `pageVisibility` Boolean - Page would be forced to be always in visible
-     or hidden state once set, instead of reflecting current window's
-     visibility. Users can set it to `true` to prevent throttling of DOM
-     timers. Default is `false`.
 
 ## Events
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -136,9 +136,6 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     Default is `false`.
   * `experimentalCanvasFeatures` Boolean - Enables Chromium's experimental
     canvas features. Default is `false`.
-  * `overlayScrollbars` Boolean - Enables overlay scrollbars. Default is
-    `false`.
-  * `sharedWorker` Boolean - Enables Shared Worker support. Default is `false`.
   * `directWrite` Boolean - Enables DirectWrite font rendering system on
      Windows. Default is `true`.
   * `pageVisibility` Boolean - Page would be forced to be always in visible

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -31,117 +31,127 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
 
 ### `new BrowserWindow([options])`
 
-`options` Object (optional), properties:
+* `options` Object
+  * `width` Integer - Window's width in pixels. Default is `800`.
+  * `height` Integer - Window's height in pixels. Default is `600`.
+  * `x` Integer - Window's left offset from screen. Default is to center the
+    window.
+  * `y` Integer - Window's top offset from screen. Default is to center the
+    window.
+  * `useContentSize` Boolean - The `width` and `height` would be used as web
+    page's size, which means the actual window's size will include window
+    frame's size and be slightly larger. Default is `false`.
+  * `center` Boolean - Show window in the center of the screen.
+  * `minWidth` Integer - Window's minimum width. Default is `0`.
+  * `minHeight` Integer - Window's minimum height. Default is `0`.
+  * `maxWidth` Integer - Window's maximum width. Default is no limit.
+  * `maxHeight` Integer - Window's maximum height. Default is no limit.
+  * `resizable` Boolean - Whether window is resizable. Default is `true`.
+  * `alwaysOnTop` Boolean - Whether the window should always stay on top of
+    other windows. Default is `false`.
+  * `fullscreen` Boolean - Whether the window should show in fullscreen. When
+    set to `false` the fullscreen button will be hidden or disabled on OS X.
+    Default is `false`.
+  * `skipTaskbar` Boolean - Whether to show the window in taskbar. Default is
+    `false`.
+  * `kiosk` Boolean - The kiosk mode. Default is `false`.
+  * `title` String - Default window title. Default is `"Electron"`.
+  * `icon` [NativeImage](native-image.md) - The window icon, when omitted on
+    Windows the executable's icon would be used as window icon.
+  * `show` Boolean - Whether window should be shown when created. Default is
+    `true`.
+  * `frame` Boolean - Specify `false` to create a
+    [Frameless Window](frameless-window.md). Default is `true`.
+  * `acceptFirstMouse` Boolean - Whether the web view accepts a single
+    mouse-down event that simultaneously activates the window. Default is `false`.
+  * `disableAutoHideCursor` Boolean - Whether to hide cursor when typing. Default
+    is `false`.
+  * `autoHideMenuBar` Boolean - Auto hide the menu bar unless the `Alt`
+    key is pressed. Default is `false`.
+  * `enableLargerThanScreen` Boolean - Enable the window to be resized larger
+    than screen. Default is `false`.
+  * `backgroundColor` String - Window's background color as Hexadecimal value,
+    like `#66CD00` or `#FFF`. This is only implemented on Linux and Windows.
+    Default is `#000` (black).
+  * `darkTheme` Boolean - Forces using dark theme for the window, only works on
+    some GTK+3 desktop environments. Default is `false`.
+  * `transparent` Boolean - Makes the window [transparent](frameless-window.md).
+    Default is `false`.
+  * `type` String - The type of window, default is normal window. See more about
+    this bellow.
+  * `titleBarStyle` String - The style of window title bar. See more about this
+    bellow.
+  * `webPreferences` Object - Settings of web page's features. See more about
+    this bellow.
 
-* `width` Integer - Window's width in pixels. Default is `800`.
-* `height` Integer - Window's height in pixels. Default is `600`.
-* `x` Integer - Window's left offset from screen. Default is to center the
-  window.
-* `y` Integer - Window's top offset from screen. Default is to center the
-  window.
-* `useContentSize` Boolean - The `width` and `height` would be used as web
-   page's size, which means the actual window's size will include window
-   frame's size and be slightly larger. Default is `false`.
-* `center` Boolean - Show window in the center of the screen.
-* `minWidth` Integer - Window's minimum width. Default is `0`.
-* `minHeight` Integer - Window's minimum height. Default is `0`.
-* `maxWidth` Integer - Window's maximum width. Default is no limit.
-* `maxHeight` Integer - Window's maximum height. Default is no limit.
-* `resizable` Boolean - Whether window is resizable. Default is `true`.
-* `alwaysOnTop` Boolean - Whether the window should always stay on top of
-   other windows. Default is `false`.
-* `fullscreen` Boolean - Whether the window should show in fullscreen. When
-  set to `false` the fullscreen button will be hidden or disabled on OS X.
-  Default is `false`.
-* `skipTaskbar` Boolean - Whether to show the window in taskbar. Default is
-  `false`.
-* `kiosk` Boolean - The kiosk mode. Default is `false`.
-* `title` String - Default window title. Default is `"Electron"`.
-* `icon` [NativeImage](native-image.md) - The window icon, when omitted on
-  Windows the executable's icon would be used as window icon.
-* `show` Boolean - Whether window should be shown when created. Default is
-  `true`.
-* `frame` Boolean - Specify `false` to create a
-  [Frameless Window](frameless-window.md). Default is `true`.
-* `acceptFirstMouse` Boolean - Whether the web view accepts a single
-  mouse-down event that simultaneously activates the window. Default is `false`.
-* `disableAutoHideCursor` Boolean - Whether to hide cursor when typing. Default
-  is `false`.
-* `autoHideMenuBar` Boolean - Auto hide the menu bar unless the `Alt`
-  key is pressed. Default is `false`.
-* `enableLargerThanScreen` Boolean - Enable the window to be resized larger
-  than screen. Default is `false`.
-* `backgroundColor` String - Window's background color as Hexadecimal value,
-  like `#66CD00` or `#FFF`. This is only implemented on Linux and Windows.
-  Default is `#000` (black).
-* `darkTheme` Boolean - Forces using dark theme for the window, only works on
-  some GTK+3 desktop environments. Default is `false`.
-* `transparent` Boolean - Makes the window [transparent](frameless-window.md).
-  Default is `false`.
-* `type` String - Specifies the type of the window, which applies
-  additional platform-specific properties. By default it's undefined and you'll
-  get a regular app window. Supported values:
-  * On Linux, possible types are `desktop`, `dock`, `toolbar`, `splash`,
-    `notification`.
-  * On OS X, possible types are `desktop`, `textured`. The `textured` type adds
-    metal gradient appearance (`NSTexturedBackgroundWindowMask`). The `desktop`
-    type places the window at the desktop background window level
+The possible values and behaviors of `type` option are platform dependent,
+supported values are:
+
+* On Linux, possible types are `desktop`, `dock`, `toolbar`, `splash`,
+  `notification`.
+* On OS X, possible types are `desktop`, `textured`.
+  * The `textured` type adds metal gradient appearance
+    (`NSTexturedBackgroundWindowMask`).
+  * The `desktop` type places the window at the desktop background window level
     (`kCGDesktopWindowLevel - 1`). Note that desktop window will not receive
     focus, keyboard or mouse events, but you can use `globalShortcut` to receive
     input sparingly.
-* `titleBarStyle` String, OS X - specifies the style of window title bar.
-  This option is supported on OS X 10.10 Yosemite and newer. There are three
-  possible values:
-  * `default` or not specified, results in the standard gray opaque Mac title
+
+The `titleBarStyle` option is only supported on OS X 10.10 Yosemite and newer.
+Possible values are:
+
+* `default` or not specified, results in the standard gray opaque Mac title
   bar.
-  * `hidden` results in a hidden title bar and a full size content window, yet
+* `hidden` results in a hidden title bar and a full size content window, yet
   the title bar still has the standard window controls ("traffic lights") in
   the top left.
-  * `hidden-inset` results in a hidden title bar with an alternative look
+* `hidden-inset` results in a hidden title bar with an alternative look
   where the traffic light buttons are slightly more inset from the window edge.
-* `webPreferences` Object - Settings of web page's features, properties:
-  * `nodeIntegration` Boolean - Whether node integration is enabled. Default
-    is `true`.
-  * `preload` String - Specifies a script that will be loaded before other
-    scripts run in the page. This script will always have access to node APIs
-    no matter whether node integration is turned on or off. The value should
-    be the absolute file path to the script.
-    When node integration is turned off, the preload script can reintroduce
-    Node global symbols back to the global scope. See example
-    [here](process.md#event-loaded).
-  * `partition` String - Sets the session used by the page. If `partition`
-    starts with `persist:`, the page will use a persistent session available to
-    all pages in the app with the same `partition`. if there is no `persist:`
-    prefix, the page will use an in-memory session. By assigning the same
-    `partition`, multiple pages can share the same session. If the `partition`
-    is unset then default session of the app will be used.
-  * `zoomFactor` Number - The default zoom factor of the page, `3.0` represents
-    `300%`. Default is `1.0`.
-  * `javascript` Boolean - Enables JavaScript support. Default is `true`.
-  * `webSecurity` Boolean - When setting `false`, it will disable the
-    same-origin policy (Usually using testing websites by people), and set
-    `allowDisplayingInsecureContent` and `allowRunningInsecureContent` to
-    `true` if these two options are not set by user. Default is `true`.
-  * `allowDisplayingInsecureContent` Boolean - Allow an https page to display
-    content like images from http URLs. Default is `false`.
-  * `allowRunningInsecureContent` Boolean - Allow a https page to run
-    JavaScript, CSS or plugins from http URLs. Default is `false`.
-  * `images` Boolean - Enables image support. Default is `true`.
-  * `textAreasAreResizable` Boolean - Make TextArea elements resizable. Default
-    is `true`.
-  * `webgl` Boolean - Enables WebGL support. Default is `true`.
-  * `webaudio` Boolean - Enables WebAudio support. Default is `true`.
-  * `plugins` Boolean - Whether plugins should be enabled. Default is `false`.
-  * `experimentalFeatures` Boolean - Enables Chromium's experimental features.
-    Default is `false`.
-  * `experimentalCanvasFeatures` Boolean - Enables Chromium's experimental
-    canvas features. Default is `false`.
-  * `directWrite` Boolean - Enables DirectWrite font rendering system on
-     Windows. Default is `true`.
-  * `blinkFeatures` String - A list of feature strings separated by `,`, like
-    `CSSVariables,KeyboardEventKey`. The full list of supported feature strings
-    can be found in the [setFeatureEnabledFromString][blink-feature-string]
-    function.
+
+The `webPreferences` option is an object that can have following properties:
+
+* `nodeIntegration` Boolean - Whether node integration is enabled. Default
+  is `true`.
+* `preload` String - Specifies a script that will be loaded before other
+  scripts run in the page. This script will always have access to node APIs
+  no matter whether node integration is turned on or off. The value should
+  be the absolute file path to the script.
+  When node integration is turned off, the preload script can reintroduce
+  Node global symbols back to the global scope. See example
+  [here](process.md#event-loaded).
+* `partition` String - Sets the session used by the page. If `partition`
+  starts with `persist:`, the page will use a persistent session available to
+  all pages in the app with the same `partition`. if there is no `persist:`
+  prefix, the page will use an in-memory session. By assigning the same
+  `partition`, multiple pages can share the same session. If the `partition`
+  is unset then default session of the app will be used.
+* `zoomFactor` Number - The default zoom factor of the page, `3.0` represents
+  `300%`. Default is `1.0`.
+* `javascript` Boolean - Enables JavaScript support. Default is `true`.
+* `webSecurity` Boolean - When setting `false`, it will disable the
+  same-origin policy (Usually using testing websites by people), and set
+  `allowDisplayingInsecureContent` and `allowRunningInsecureContent` to
+  `true` if these two options are not set by user. Default is `true`.
+* `allowDisplayingInsecureContent` Boolean - Allow an https page to display
+  content like images from http URLs. Default is `false`.
+* `allowRunningInsecureContent` Boolean - Allow a https page to run
+  JavaScript, CSS or plugins from http URLs. Default is `false`.
+* `images` Boolean - Enables image support. Default is `true`.
+* `textAreasAreResizable` Boolean - Make TextArea elements resizable. Default
+  is `true`.
+* `webgl` Boolean - Enables WebGL support. Default is `true`.
+* `webaudio` Boolean - Enables WebAudio support. Default is `true`.
+* `plugins` Boolean - Whether plugins should be enabled. Default is `false`.
+* `experimentalFeatures` Boolean - Enables Chromium's experimental features.
+  Default is `false`.
+* `experimentalCanvasFeatures` Boolean - Enables Chromium's experimental
+  canvas features. Default is `false`.
+* `directWrite` Boolean - Enables DirectWrite font rendering system on
+  Windows. Default is `true`.
+* `blinkFeatures` String - A list of feature strings separated by `,`, like
+  `CSSVariables,KeyboardEventKey`. The full list of supported feature strings
+  can be found in the [setFeatureEnabledFromString][blink-feature-string]
+  function.
 
 ## Events
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -138,6 +138,10 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     canvas features. Default is `false`.
   * `directWrite` Boolean - Enables DirectWrite font rendering system on
      Windows. Default is `true`.
+  * `blinkFeatures` String - A list of feature strings separated by `,`, like
+    `CSSVariables,KeyboardEventKey`. The full list of supported feature strings
+    can be found in the [setFeatureEnabledFromString][blink-feature-string]
+    function.
 
 ## Events
 
@@ -750,3 +754,5 @@ Returns whether the window is visible on all workspaces.
 * `ignore` Boolean
 
 Ignore all moused events that happened in the window.
+
+[blink-feature-string]: https://code.google.com/p/chromium/codesearch#chromium/src/out/Debug/gen/blink/platform/RuntimeEnabledFeatures.cpp&sq=package:chromium&type=cs&l=527

--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -94,10 +94,6 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
-
 ## --ignore-certificate-errors
 
 Ignores certificate related errors.
@@ -121,7 +117,16 @@ fallback will accept.
 
 ## --cipher-suite-blacklist=`cipher_suites`
 
-Specify comma-separated list of SSL cipher suites to disable.
+Specifies comma-separated list of SSL cipher suites to disable.
+
+## --disable-renderer-backgrounding
+
+Prevents Chromium from lowering the priority of invisible pages' renderer
+processes.
+
+This flag is global to all renderer processes, if you only want to disable
+throttling in one window, you can take the hack of
+[playing silent audio][play-silent-audio].
 
 ## --enable-logging
 
@@ -149,3 +154,8 @@ whole pathname and not just the module. E.g. `*/foo/bar/*=2` would change the
 logging level for all code in the source files under a `foo/bar` directory.
 
 This switch only works when `--enable-logging` is also passed.
+
+[app]: app.md
+[append-switch]: app.md#appcommandlineappendswitchswitch-value
+[ready]: app.md#event-ready
+[play-silent-audio]: https://github.com/atom/atom/pull/9485/files


### PR DESCRIPTION
This PR introduces `blinkFeatures` option, which is a far more flexible way to enable blink features, so we don't have to add an option for every blink feature.

For example, to enable `KeyboardEvent.key`, use:

```javascript
webPreferences: {
  blinkFeatures: 'KeyboardEventCode,KeyboardEventKey'
}
```

Refs #2310.