### PR TITLE
update faq link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ select the tag that matches your version.
 There are questions that are asked quite often, check this out before creating
 an issue:
 
-* [Electron FAQ](faq/api-faq.md)
+* [Electron FAQ](faq/electron-faq.md)
 
 ## Guides
 


### PR DESCRIPTION
just a tiny fix for the broken link, pointing to electron faq