### PR TITLE
Added getNativeWindowHandle method

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -594,6 +594,11 @@ void Window::SetAspectRatio(double aspect_ratio, mate::Arguments* args) {
   window_->SetAspectRatio(aspect_ratio, extra_size);
 }
 
+v8::Local<v8::Value> Window::GetNativeWindowHandle() {
+  gfx::AcceleratedWidget handle = window_->GetAcceleratedWidget();
+  return ToBuffer(isolate(), static_cast<void*>(&handle), sizeof(gfx::AcceleratedWidget));
+}
+
 void Window::SetVisibleOnAllWorkspaces(bool visible) {
   return window_->SetVisibleOnAllWorkspaces(visible);
 }
@@ -634,6 +639,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setFullScreen", &Window::SetFullScreen)
       .SetMethod("isFullScreen", &Window::IsFullscreen)
       .SetMethod("setAspectRatio", &Window::SetAspectRatio)
+      .SetMethod("getNativeWindowHandle", &Window::GetNativeWindowHandle)
       .SetMethod("getBounds", &Window::GetBounds)
       .SetMethod("setBounds", &Window::SetBounds)
       .SetMethod("getSize", &Window::GetSize)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -107,7 +107,6 @@ void TranslateOldOptions(v8::Isolate* isolate, v8::Local<v8::Object> options) {
   }
 }
 
-#if defined(OS_WIN)
 // Converts binary data to Buffer.
 v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
   auto buffer = node::Buffer::New(isolate, static_cast<char*>(val), size);
@@ -116,7 +115,6 @@ v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
   else
     return buffer.ToLocalChecked();
 }
-#endif
 
 }  // namespace
 
@@ -596,7 +594,9 @@ void Window::SetAspectRatio(double aspect_ratio, mate::Arguments* args) {
 
 v8::Local<v8::Value> Window::GetNativeWindowHandle() {
   gfx::AcceleratedWidget handle = window_->GetAcceleratedWidget();
-  return ToBuffer(isolate(), static_cast<void*>(&handle), sizeof(gfx::AcceleratedWidget));
+  return ToBuffer(isolate(),
+    static_cast<void*>(&handle),
+    sizeof(gfx::AcceleratedWidget));
 }
 
 void Window::SetVisibleOnAllWorkspaces(bool visible) {

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -137,6 +137,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetMenuBarVisibility(bool visible);
   bool IsMenuBarVisible();
   void SetAspectRatio(double aspect_ratio, mate::Arguments* args);
+  v8::Local<v8::Value> GetNativeWindowHandle();
 
 #if defined(OS_WIN)
   typedef base::Callback<void(v8::Local<v8::Value>,

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -143,6 +143,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetMenu(ui::MenuModel* menu);
   virtual bool HasModalDialog();
   virtual gfx::NativeWindow GetNativeWindow() = 0;
+  virtual gfx::AcceleratedWidget GetAcceleratedWidget() = 0;
 
   // Taskbar/Dock APIs.
   virtual void SetProgressBar(double progress) = 0;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -65,6 +65,7 @@ class NativeWindowMac : public NativeWindow {
   void SetIgnoreMouseEvents(bool ignore) override;
   bool HasModalDialog() override;
   gfx::NativeWindow GetNativeWindow() override;
+  gfx::AcceleratedWidget GetAcceleratedWidget() override;
   void SetProgressBar(double progress) override;
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -731,6 +731,10 @@ gfx::NativeWindow NativeWindowMac::GetNativeWindow() {
   return window_;
 }
 
+gfx::AcceleratedWidget NativeWindowMac::GetAcceleratedWidget() {
+  return window_;
+}
+
 void NativeWindowMac::SetProgressBar(double progress) {
   NSDockTile* dock_tile = [NSApp dockTile];
 

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -732,7 +732,7 @@ gfx::NativeWindow NativeWindowMac::GetNativeWindow() {
 }
 
 gfx::AcceleratedWidget NativeWindowMac::GetAcceleratedWidget() {
-  return window_;
+  return inspectable_web_contents()->GetView()->GetNativeView();
 }
 
 void NativeWindowMac::SetProgressBar(double progress) {

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -90,7 +90,7 @@ class NativeWindowViews : public NativeWindow,
   void SetVisibleOnAllWorkspaces(bool visible) override;
   bool IsVisibleOnAllWorkspaces() override;
 
-  gfx::AcceleratedWidget GetAcceleratedWidget();
+  gfx::AcceleratedWidget GetAcceleratedWidget() override;
 
   views::Widget* widget() const { return window_.get(); }
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -573,7 +573,9 @@ Returns whether the window is in kiosk mode.
 
 ### `win.getNativeWindowHandle()`
 
-Returns the OS window handle in a buffer.
+Returns the platform-specific handle of the window in a buffer.
+Cast it to the appropriate type, such as HWND for Windows, NSView* for OS X or unsigned long for Linux.
+Used for OS's Native API's for windows.
 
 ### `win.hookWindowMessage(message, callback)` _Windows_
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -571,6 +571,10 @@ Enters or leaves the kiosk mode.
 
 Returns whether the window is in kiosk mode.
 
+### `win.getNativeWindowHandle()`
+
+Returns the OS window handle in a buffer.
+
 ### `win.hookWindowMessage(message, callback)` _Windows_
 
 * `message` Integer


### PR DESCRIPTION
As discussed here https://github.com/atom/electron/issues/3219
Returns the native OS window handle in a buffer.
Not sure about the Mac implementation, if someone could double-check me.