### PR TITLE
session: allow user to isolate pac script and proxy bypass rules

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -115,14 +115,27 @@ struct Converter<net::ProxyConfig> {
                      v8::Local<v8::Value> val,
                      net::ProxyConfig* out) {
     mate::Dictionary options;
-    if (!ConvertFromV8(isolate, val, &options))
-      return false;
+    if (!ConvertFromV8(isolate, val, &options)) {
+      // Fallback to previous api (https://git.io/vuhjj).
+      std::string proxy;
+      if (!ConvertFromV8(isolate, val, &proxy))
+        return false;
+      auto pac_url = GURL(proxy);
+      if (pac_url.is_valid()) {
+        out->set_pac_url(pac_url);
+      } else {
+        out->proxy_rules().ParseFromString(proxy);
+      }
+      return true;
+    }
+
     GURL pac_url;
     std::string rules;
-    if (options.Get("pacScript", &pac_url))
+    if (options.Get("pacScript", &pac_url)) {
       out->set_pac_url(pac_url);
-    else if (options.Get("proxyRules", &rules))
+    } else if (options.Get("proxyRules", &rules)) {
       out->proxy_rules().ParseFromString(rules);
+    }
     return true;
   }
 };

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -114,15 +114,15 @@ struct Converter<net::ProxyConfig> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      net::ProxyConfig* out) {
-    std::string proxy;
-    if (!ConvertFromV8(isolate, val, &proxy))
+    mate::Dictionary options;
+    if (!ConvertFromV8(isolate, val, &options))
       return false;
-    auto pac_url = GURL(proxy);
-    if (pac_url.is_valid()) {
+    GURL pac_url;
+    std::string rules;
+    if (options.Get("pacScript", &pac_url))
       out->set_pac_url(pac_url);
-    } else {
-      out->proxy_rules().ParseFromString(proxy);
-    }
+    else if (options.Get("proxyRules", &rules))
+      out->proxy_rules().ParseFromString(rules);
     return true;
   }
 };

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -186,6 +186,9 @@ Clears the data of web storages.
   * `proxyRules` String - Rules indicating which proxies to use.
 * `callback` Function - Called when operation is done.
 
+When `pacScript` and `proxyRules` are provided together, the `proxyRules`
+option is ignored and `pacScript` configuration is applied.
+
 ```
 proxyRules = scheme-proxies[";"<scheme-proxies>]
 scheme-proxies = [<url-scheme>"="]<proxy-uri-list>

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -181,15 +181,13 @@ Clears the data of web storages.
 
 #### `ses.setProxy(config, callback)`
 
-* `config` String
+* `config` Object
+  * `pacScript` String - The URL associated with the PAC file.
+  * `proxyRules` String - Rules indicating which proxies to use.
 * `callback` Function - Called when operation is done.
 
-If `config` is a PAC url, it is used directly otherwise
-`config` is parsed based on the following rules indicating which
-proxies to use for the session.
-
 ```
-config = scheme-proxies[";"<scheme-proxies>]
+proxyRules = scheme-proxies[";"<scheme-proxies>]
 scheme-proxies = [<url-scheme>"="]<proxy-uri-list>
 url-scheme = "http" | "https" | "ftp" | "socks"
 proxy-uri-list = <proxy-uri>[","<proxy-uri-list>]


### PR DESCRIPTION
Fixes #4032 

Previously single proxy types where considered as PAC urls. Since there is no way to differentiate where a single proxy rule is a pac url or a proxy rule, we require the user to specify them now.