### PR TITLE
Change brightray's PATH_START to 11000

### DIFF
--- a/chromium_src/chrome/common/chrome_paths.h
+++ b/chromium_src/chrome/common/chrome_paths.h
@@ -17,7 +17,7 @@ class FilePath;
 namespace chrome {
 
 enum {
-  PATH_START = 2000,
+  PATH_START = 1000,
 
   DIR_APP = PATH_START,         // Directory where dlls and data reside.
   DIR_LOGS,                     // Directory where logs should be written.


### PR DESCRIPTION
Modifying the value in `chrome_paths.h` is not the right fix for #3709, the same value is used by `gfx_paths.h` and we will meet another conflict finally. This PR changes brightray's `PATH_START` to 11000, which is a very safe value.

Refs https://github.com/atom/electron/pull/3732.

