### PR TITLE
Return null for no focused window when calling BrowserWindow.getFocusedWindow

### DIFF
--- a/atom/browser/api/lib/browser-window.coffee
+++ b/atom/browser/api/lib/browser-window.coffee
@@ -66,6 +66,7 @@ BrowserWindow::_init = ->
 BrowserWindow.getFocusedWindow = ->
   windows = BrowserWindow.getAllWindows()
   return window for window in windows when window.isFocused()
+  null
 
 BrowserWindow.fromWebContents = (webContents) ->
   windows = BrowserWindow.getAllWindows()

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -287,7 +287,7 @@ Returns an array of all opened browser windows.
 
 ### `BrowserWindow.getFocusedWindow()`
 
-Returns the window that is focused in this application.
+Returns the window that is focused in this application, otherwise returns `null`.
 
 ### `BrowserWindow.fromWebContents(webContents)`
 


### PR DESCRIPTION
##### Problem
if we run the below code when there is no focused window, electron throws an error.
```js
dialog.showMessageBox(BrowserWindow.getFocusedWindow(), options)
```

![image](https://cloud.githubusercontent.com/assets/1622515/12228581/8a494d86-b863-11e5-9e31-fe8553d9fa6c.png)

###### Solution

When there is no focused window, return `null` when calling `BrowserWindow.getFocusedWindow()`.
It helps to use with `dialog` methods like `showOpenDialog`, `showSaveDialog` and `showMessageBox` which expects `null` to represent no window.
