### PR TITLE
Pass --touch-devices to chromium contents under X11

### DIFF
--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -21,6 +21,7 @@
 
 #if defined(USE_X11)
 #include "chrome/browser/ui/libgtk2ui/gtk2_util.h"
+#include "ui/events/devices/x11/touch_factory_x11.h"
 #endif
 
 namespace atom {
@@ -115,6 +116,10 @@ void AtomBrowserMainParts::PreMainMessageLoopRun() {
   // a chance to setup everything.
   node_bindings_->PrepareMessageLoop();
   node_bindings_->RunMessageLoop();
+
+#if defined(USE_X11)
+  ui::TouchFactory::SetTouchDeviceListFromCommandLine();
+#endif
 
   // Start idle gc.
   gc_timer_.Start(


### PR DESCRIPTION
The --touch-devices will not work under X11 systems (tested under Linux) because ui::TouchFactory does not have a chance to see the command line. This is done in ash::shell::ShellBrowserMainParts::PreMainMessageLoopStart in Chromium but somehow it is not called in atom::AtomBrowserMainParts::PreMainMessageLoopRun() in Electron.