### PR TITLE
Clean up comments from CoffeeScript migration

### DIFF
--- a/atom/browser/api/lib/app.js
+++ b/atom/browser/api/lib/app.js
@@ -54,7 +54,7 @@ app.getAppPath = function() {
 };
 
 
-/* Routes the events to webContents. */
+// Routes the events to webContents.
 
 ref1 = ['login', 'certificate-error', 'select-client-certificate'];
 fn = function(name) {
@@ -70,7 +70,7 @@ for (i = 0, len = ref1.length; i < len; i++) {
 }
 
 
-/* Deprecated. */
+// Deprecated.
 
 app.getHomeDir = deprecate('app.getHomeDir', 'app.getPath', function() {
   return this.getPath('home');
@@ -92,7 +92,7 @@ deprecate.rename(app, 'terminate', 'quit');
 
 deprecate.event(app, 'finish-launching', 'ready', function() {
 
-  /* give default app a chance to setup default menu. */
+  // give default app a chance to setup default menu.
   return setImmediate((function(_this) {
     return function() {
       return _this.emit('finish-launching');
@@ -109,14 +109,14 @@ deprecate.event(app, 'activate-with-no-open-windows', 'activate', function(event
 deprecate.event(app, 'select-certificate', 'select-client-certificate');
 
 
-/* Wrappers for native classes. */
+// Wrappers for native classes.
 
 wrapDownloadItem = function(downloadItem) {
 
-  /* downloadItem is an EventEmitter. */
+  // downloadItem is an EventEmitter.
   downloadItem.__proto__ = EventEmitter.prototype;
 
-  /* Deprecated. */
+  // Deprecated.
   deprecate.property(downloadItem, 'url', 'getURL');
   deprecate.property(downloadItem, 'filename', 'getFilename');
   deprecate.property(downloadItem, 'mimeType', 'getMimeType');
@@ -126,6 +126,6 @@ wrapDownloadItem = function(downloadItem) {
 downloadItemBindings._setWrapDownloadItem(wrapDownloadItem);
 
 
-/* Only one App object pemitted. */
+// Only one App object pemitted.
 
 module.exports = app;

--- a/atom/browser/api/lib/app.js
+++ b/atom/browser/api/lib/app.js
@@ -53,9 +53,7 @@ app.getAppPath = function() {
   return appPath;
 };
 
-
 // Routes the events to webContents.
-
 ref1 = ['login', 'certificate-error', 'select-client-certificate'];
 fn = function(name) {
   return app.on(name, function() {
@@ -68,7 +66,6 @@ for (i = 0, len = ref1.length; i < len; i++) {
   name = ref1[i];
   fn(name);
 }
-
 
 // Deprecated.
 
@@ -108,9 +105,7 @@ deprecate.event(app, 'activate-with-no-open-windows', 'activate', function(event
 
 deprecate.event(app, 'select-certificate', 'select-client-certificate');
 
-
 // Wrappers for native classes.
-
 wrapDownloadItem = function(downloadItem) {
 
   // downloadItem is an EventEmitter.
@@ -125,7 +120,5 @@ wrapDownloadItem = function(downloadItem) {
 
 downloadItemBindings._setWrapDownloadItem(wrapDownloadItem);
 
-
 // Only one App object pemitted.
-
 module.exports = app;

--- a/atom/browser/api/lib/auto-updater.js
+++ b/atom/browser/api/lib/auto-updater.js
@@ -4,11 +4,7 @@ deprecate = require('electron').deprecate;
 
 autoUpdater = process.platform === 'win32' ? require('./auto-updater/auto-updater-win') : require('./auto-updater/auto-updater-native');
 
-
 // Deprecated.
-
 deprecate.rename(autoUpdater, 'setFeedUrl', 'setFeedURL');
-
-
 
 module.exports = autoUpdater;

--- a/atom/browser/api/lib/auto-updater.js
+++ b/atom/browser/api/lib/auto-updater.js
@@ -5,7 +5,7 @@ deprecate = require('electron').deprecate;
 autoUpdater = process.platform === 'win32' ? require('./auto-updater/auto-updater-win') : require('./auto-updater/auto-updater-native');
 
 
-/* Deprecated. */
+// Deprecated.
 
 deprecate.rename(autoUpdater, 'setFeedUrl', 'setFeedURL');
 

--- a/atom/browser/api/lib/auto-updater/auto-updater-win.js
+++ b/atom/browser/api/lib/auto-updater/auto-updater-win.js
@@ -50,7 +50,7 @@ AutoUpdater = (function(superClass) {
           }
           releaseNotes = update.releaseNotes, version = update.version;
 
-          /* Following information is not available on Windows, so fake them. */
+          // Following information is not available on Windows, so fake them.
           date = new Date;
           url = _this.updateURL;
           return _this.emit('update-downloaded', {}, releaseNotes, version, date, url, function() {

--- a/atom/browser/api/lib/auto-updater/auto-updater-win.js
+++ b/atom/browser/api/lib/auto-updater/auto-updater-win.js
@@ -62,11 +62,8 @@ AutoUpdater = (function(superClass) {
   };
 
 
-  /*
-    Private: Emit both error object and message, this is to keep compatibility
-    with Old APIs.
-   */
-
+  // Private: Emit both error object and message, this is to keep compatibility
+  // with Old APIs.
   AutoUpdater.prototype.emitError = function(message) {
     return this.emit('error', new Error(message), message);
   };

--- a/atom/browser/api/lib/auto-updater/squirrel-update-win.js
+++ b/atom/browser/api/lib/auto-updater/squirrel-update-win.js
@@ -6,24 +6,16 @@ path = require('path');
 
 spawn = require('child_process').spawn;
 
-
 // i.e. my-app/app-0.1.13/
-
 appFolder = path.dirname(process.execPath);
 
-
 // i.e. my-app/Update.exe
-
 updateExe = path.resolve(appFolder, '..', 'Update.exe');
 
 exeName = path.basename(process.execPath);
 
-
-/*
-  Spawn a command and invoke the callback when it completes with an error
-  and the output from standard out.
- */
-
+// Spawn a command and invoke the callback when it completes with an error
+// and the output from standard out.
 spawnUpdate = function(args, detached, callback) {
   var error, error1, errorEmitted, spawnedProcess, stderr, stdout;
   try {

--- a/atom/browser/api/lib/auto-updater/squirrel-update-win.js
+++ b/atom/browser/api/lib/auto-updater/squirrel-update-win.js
@@ -7,12 +7,12 @@ path = require('path');
 spawn = require('child_process').spawn;
 
 
-/* i.e. my-app/app-0.1.13/ */
+// i.e. my-app/app-0.1.13/
 
 appFolder = path.dirname(process.execPath);
 
 
-/* i.e. my-app/Update.exe */
+// i.e. my-app/Update.exe
 
 updateExe = path.resolve(appFolder, '..', 'Update.exe');
 
@@ -33,7 +33,7 @@ spawnUpdate = function(args, detached, callback) {
   } catch (error1) {
     error = error1;
 
-    /* Shouldn't happen, but still guard it. */
+    // Shouldn't happen, but still guard it.
     process.nextTick(function() {
       return callback(error);
     });
@@ -54,30 +54,30 @@ spawnUpdate = function(args, detached, callback) {
   });
   return spawnedProcess.on('exit', function(code, signal) {
 
-    /* We may have already emitted an error. */
+    // We may have already emitted an error.
     if (errorEmitted) {
       return;
     }
 
-    /* Process terminated with error. */
+    // Process terminated with error.
     if (code !== 0) {
       return callback("Command failed: " + (signal != null ? signal : code) + "\n" + stderr);
     }
 
-    /* Success. */
+    // Success.
     return callback(null, stdout);
   });
 };
 
 
-/* Start an instance of the installed app. */
+// Start an instance of the installed app.
 
 exports.processStart = function(callback) {
   return spawnUpdate(['--processStart', exeName], true, function() {});
 };
 
 
-/* Download the releases specified by the URL and write new results to stdout. */
+// Download the releases specified by the URL and write new results to stdout.
 
 exports.download = function(updateURL, callback) {
   return spawnUpdate(['--download', updateURL], false, function(error, stdout) {
@@ -87,7 +87,7 @@ exports.download = function(updateURL, callback) {
     }
     try {
 
-      /* Last line of output is the JSON details about the releases */
+      // Last line of output is the JSON details about the releases
       json = stdout.trim().split('\n').pop();
       update = (ref = JSON.parse(json)) != null ? (ref1 = ref.releasesToApply) != null ? typeof ref1.pop === "function" ? ref1.pop() : void 0 : void 0 : void 0;
     } catch (error1) {
@@ -98,14 +98,14 @@ exports.download = function(updateURL, callback) {
 };
 
 
-/* Update the application to the latest remote version specified by URL. */
+// Update the application to the latest remote version specified by URL.
 
 exports.update = function(updateURL, callback) {
   return spawnUpdate(['--update', updateURL], false, callback);
 };
 
 
-/* Is the Update.exe installed with the current application? */
+// Is the Update.exe installed with the current application?
 
 exports.supported = function() {
   var error1;

--- a/atom/browser/api/lib/auto-updater/squirrel-update-win.js
+++ b/atom/browser/api/lib/auto-updater/squirrel-update-win.js
@@ -61,16 +61,12 @@ spawnUpdate = function(args, detached, callback) {
   });
 };
 
-
 // Start an instance of the installed app.
-
 exports.processStart = function(callback) {
   return spawnUpdate(['--processStart', exeName], true, function() {});
 };
 
-
 // Download the releases specified by the URL and write new results to stdout.
-
 exports.download = function(updateURL, callback) {
   return spawnUpdate(['--download', updateURL], false, function(error, stdout) {
     var error1, json, ref, ref1, update;
@@ -91,14 +87,12 @@ exports.download = function(updateURL, callback) {
 
 
 // Update the application to the latest remote version specified by URL.
-
 exports.update = function(updateURL, callback) {
   return spawnUpdate(['--update', updateURL], false, callback);
 };
 
 
 // Is the Update.exe installed with the current application?
-
 exports.supported = function() {
   var error1;
   try {

--- a/atom/browser/api/lib/browser-window.js
+++ b/atom/browser/api/lib/browser-window.js
@@ -33,10 +33,8 @@ BrowserWindow.prototype._init = function() {
     return ipcMain.emit('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPEN', event, url, frameName, options);
   });
 
-  /*
-    window.resizeTo(...)
-    window.moveTo(...)
-   */
+  // window.resizeTo(...)
+  // window.moveTo(...)
   this.webContents.on('move', (function(_this) {
     return function(event, size) {
       return _this.setBounds(size);
@@ -69,14 +67,12 @@ BrowserWindow.prototype._init = function() {
     };
   })(this));
 
-  /*
-    Sometimes the webContents doesn't get focus when window is shown, so we have
-    to force focusing on webContents in this case. The safest way is to focus it
-    when we first start to load URL, if we do it earlier it won't have effect,
-    if we do it later we might move focus in the page.
-    Though this hack is only needed on OS X when the app is launched from
-    Finder, we still do it on all platforms in case of other bugs we don't know.
-   */
+  // Sometimes the webContents doesn't get focus when window is shown, so we have
+  // to force focusing on webContents in this case. The safest way is to focus it
+  // when we first start to load URL, if we do it earlier it won't have effect,
+  // if we do it later we might move focus in the page.
+  // Though this hack is only needed on OS X when the app is launched from
+  // Finder, we still do it on all platforms in case of other bugs we don't know.
   this.webContents.once('load-url', function() {
     return this.focus();
   });

--- a/atom/browser/api/lib/browser-window.js
+++ b/atom/browser/api/lib/browser-window.js
@@ -151,7 +151,6 @@ BrowserWindow.fromDevToolsWebContents = function(webContents) {
   }
 };
 
-
 // Helpers.
 
 BrowserWindow.prototype.loadURL = function() {
@@ -197,7 +196,6 @@ BrowserWindow.prototype.inspectElement = function() {
 BrowserWindow.prototype.inspectServiceWorker = function() {
   return this.webContents.inspectServiceWorker();
 };
-
 
 // Deprecated.
 

--- a/atom/browser/api/lib/browser-window.js
+++ b/atom/browser/api/lib/browser-window.js
@@ -10,11 +10,11 @@ BrowserWindow.prototype.__proto__ = EventEmitter.prototype;
 
 BrowserWindow.prototype._init = function() {
 
-  /* avoid recursive require. */
+  // avoid recursive require.
   var app, menu;
   app = require('electron').app;
 
-  /* Simulate the application menu on platforms other than OS X. */
+  // Simulate the application menu on platforms other than OS X.
   if (process.platform !== 'darwin') {
     menu = app.getApplicationMenu();
     if (menu != null) {
@@ -22,7 +22,7 @@ BrowserWindow.prototype._init = function() {
     }
   }
 
-  /* Make new windows requested by links behave like "window.open" */
+  // Make new windows requested by links behave like "window.open"
   this.webContents.on('-new-window', function(event, url, frameName) {
     var options;
     options = {
@@ -43,7 +43,7 @@ BrowserWindow.prototype._init = function() {
     };
   })(this));
 
-  /* Hide the auto-hide menu when webContents is focused. */
+  // Hide the auto-hide menu when webContents is focused.
   this.webContents.on('activate', (function(_this) {
     return function() {
       if (process.platform !== 'darwin' && _this.isMenuBarAutoHide() && _this.isMenuBarVisible()) {
@@ -52,14 +52,14 @@ BrowserWindow.prototype._init = function() {
     };
   })(this));
 
-  /* Forward the crashed event. */
+  // Forward the crashed event.
   this.webContents.on('crashed', (function(_this) {
     return function() {
       return _this.emit('crashed');
     };
   })(this));
 
-  /* Change window title to page title. */
+  // Change window title to page title.
   this.webContents.on('page-title-updated', (function(_this) {
     return function(event, title, explicitSet) {
       _this.emit('page-title-updated', event, title);
@@ -81,7 +81,7 @@ BrowserWindow.prototype._init = function() {
     return this.focus();
   });
 
-  /* Redirect focus/blur event to app instance too. */
+  // Redirect focus/blur event to app instance too.
   this.on('blur', (function(_this) {
     return function(event) {
       return app.emit('browser-window-blur', event, _this);
@@ -93,10 +93,10 @@ BrowserWindow.prototype._init = function() {
     };
   })(this));
 
-  /* Notify the creation of the window. */
+  // Notify the creation of the window.
   app.emit('browser-window-created', {}, this);
 
-  /* Be compatible with old APIs. */
+  // Be compatible with old APIs.
   this.webContents.on('devtools-focused', (function(_this) {
     return function() {
       return _this.emit('devtools-focused');
@@ -156,7 +156,7 @@ BrowserWindow.fromDevToolsWebContents = function(webContents) {
 };
 
 
-/* Helpers. */
+// Helpers.
 
 BrowserWindow.prototype.loadURL = function() {
   return this.webContents.loadURL.apply(this.webContents, arguments);
@@ -203,7 +203,7 @@ BrowserWindow.prototype.inspectServiceWorker = function() {
 };
 
 
-/* Deprecated. */
+// Deprecated.
 
 deprecate.member(BrowserWindow, 'undo', 'webContents');
 

--- a/atom/browser/api/lib/dialog.js
+++ b/atom/browser/api/lib/dialog.js
@@ -23,14 +23,12 @@ messageBoxOptions = {
 
 parseArgs = function(window, options, callback) {
   if (!(window === null || (window != null ? window.constructor : void 0) === BrowserWindow)) {
-
     // Shift.
     callback = options;
     options = window;
     window = null;
   }
   if ((callback == null) && typeof options === 'function') {
-
     // Shift.
     callback = options;
     options = null;
@@ -165,9 +163,7 @@ module.exports = {
   }
 };
 
-
 // Mark standard asynchronous functions.
-
 ref1 = ['showMessageBox', 'showOpenDialog', 'showSaveDialog'];
 for (j = 0, len = ref1.length; j < len; j++) {
   api = ref1[j];

--- a/atom/browser/api/lib/dialog.js
+++ b/atom/browser/api/lib/dialog.js
@@ -24,14 +24,14 @@ messageBoxOptions = {
 parseArgs = function(window, options, callback) {
   if (!(window === null || (window != null ? window.constructor : void 0) === BrowserWindow)) {
 
-    /* Shift. */
+    // Shift.
     callback = options;
     options = window;
     window = null;
   }
   if ((callback == null) && typeof options === 'function') {
 
-    /* Shift. */
+    // Shift.
     callback = options;
     options = null;
   }
@@ -143,7 +143,7 @@ module.exports = {
       options.defaultId = -1;
     }
 
-    /* Choose a default button to get selected when dialog is cancelled. */
+    // Choose a default button to get selected when dialog is cancelled.
     if (options.cancelId == null) {
       options.cancelId = 0;
       ref2 = options.buttons;
@@ -166,7 +166,7 @@ module.exports = {
 };
 
 
-/* Mark standard asynchronous functions. */
+// Mark standard asynchronous functions.
 
 ref1 = ['showMessageBox', 'showOpenDialog', 'showSaveDialog'];
 for (j = 0, len = ref1.length; j < len; j++) {

--- a/atom/browser/api/lib/exports/electron.js
+++ b/atom/browser/api/lib/exports/electron.js
@@ -3,13 +3,13 @@ var common;
 common = require('../../../../common/api/lib/exports/electron');
 
 
-/* Import common modules. */
+// Import common modules.
 
 common.defineProperties(exports);
 
 Object.defineProperties(exports, {
 
-  /* Browser side modules, please sort with alphabet order. */
+  // Browser side modules, please sort with alphabet order.
   app: {
     enumerable: true,
     get: function() {
@@ -101,7 +101,7 @@ Object.defineProperties(exports, {
     }
   },
 
-  /* The internal modules, invisible unless you know their names. */
+  // The internal modules, invisible unless you know their names.
   NavigationController: {
     get: function() {
       return require('../navigation-controller');

--- a/atom/browser/api/lib/exports/electron.js
+++ b/atom/browser/api/lib/exports/electron.js
@@ -4,7 +4,6 @@ common = require('../../../../common/api/lib/exports/electron');
 
 
 // Import common modules.
-
 common.defineProperties(exports);
 
 Object.defineProperties(exports, {

--- a/atom/browser/api/lib/ipc.js
+++ b/atom/browser/api/lib/ipc.js
@@ -3,7 +3,7 @@ var deprecate, ipcMain, ref;
 ref = require('electron'), deprecate = ref.deprecate, ipcMain = ref.ipcMain;
 
 
-/* This module is deprecated, we mirror everything from ipcMain. */
+// This module is deprecated, we mirror everything from ipcMain.
 
 deprecate.warn('ipc module', 'require("electron").ipcMain');
 

--- a/atom/browser/api/lib/ipc.js
+++ b/atom/browser/api/lib/ipc.js
@@ -2,9 +2,7 @@ var deprecate, ipcMain, ref;
 
 ref = require('electron'), deprecate = ref.deprecate, ipcMain = ref.ipcMain;
 
-
 // This module is deprecated, we mirror everything from ipcMain.
-
 deprecate.warn('ipc module', 'require("electron").ipcMain');
 
 module.exports = ipcMain;

--- a/atom/browser/api/lib/menu-item.js
+++ b/atom/browser/api/lib/menu-item.js
@@ -4,9 +4,7 @@ v8Util = process.atomBinding('v8_util');
 
 nextCommandId = 0;
 
-
 // Maps role to methods of webContents
-
 rolesMap = {
   undo: 'undo',
   redo: 'redo',
@@ -18,9 +16,7 @@ rolesMap = {
   close: 'close'
 };
 
-
 // Maps methods that should be called directly on the BrowserWindow instance
-
 methodInBrowserWindow = {
   minimize: true,
   close: true

--- a/atom/browser/api/lib/menu-item.js
+++ b/atom/browser/api/lib/menu-item.js
@@ -5,7 +5,7 @@ v8Util = process.atomBinding('v8_util');
 nextCommandId = 0;
 
 
-/* Maps role to methods of webContents */
+// Maps role to methods of webContents
 
 rolesMap = {
   undo: 'undo',
@@ -19,7 +19,7 @@ rolesMap = {
 };
 
 
-/* Maps methods that should be called directly on the BrowserWindow instance */
+// Maps methods that should be called directly on the BrowserWindow instance
 
 methodInBrowserWindow = {
   minimize: true,
@@ -59,7 +59,7 @@ MenuItem = (function() {
     this.click = (function(_this) {
       return function(focusedWindow) {
 
-        /* Manually flip the checked flags when clicked. */
+        // Manually flip the checked flags when clicked.
         var methodName, ref1, ref2;
         if ((ref1 = _this.type) === 'checkbox' || ref1 === 'radio') {
           _this.checked = !_this.checked;

--- a/atom/browser/api/lib/menu.js
+++ b/atom/browser/api/lib/menu.js
@@ -9,15 +9,15 @@ v8Util = process.atomBinding('v8_util');
 bindings = process.atomBinding('menu');
 
 
-/* Automatically generated radio menu item's group id. */
+// Automatically generated radio menu item's group id.
 
 nextGroupId = 0;
 
 
-/* Search between seperators to find a radio menu item and return its group id, */
+// Search between seperators to find a radio menu item and return its group id,
 
 
-/* otherwise generate a group id. */
+// otherwise generate a group id.
 
 generateGroupId = function(items, pos) {
   var i, item, j, k, ref1, ref2, ref3;
@@ -46,7 +46,7 @@ generateGroupId = function(items, pos) {
 };
 
 
-/* Returns the index of item according to |id|. */
+// Returns the index of item according to |id|.
 
 indexOfItemById = function(items, id) {
   var i, item, j, len;
@@ -60,7 +60,7 @@ indexOfItemById = function(items, id) {
 };
 
 
-/* Returns the index of where to insert the item according to |position|. */
+// Returns the index of where to insert the item according to |position|.
 
 indexToInsertByPosition = function(items, position) {
   var id, insertIndex, query, ref1;
@@ -79,7 +79,7 @@ indexToInsertByPosition = function(items, position) {
       break;
     case 'endof':
 
-      /* If the |id| doesn't exist, then create a new group with the |id|. */
+      // If the |id| doesn't exist, then create a new group with the |id|.
       if (insertIndex === -1) {
         items.push({
           id: id,
@@ -88,7 +88,7 @@ indexToInsertByPosition = function(items, position) {
         insertIndex = items.length - 1;
       }
 
-      /* Find the end of the group. */
+      // Find the end of the group.
       insertIndex++;
       while (insertIndex < items.length && items[insertIndex].type !== 'separator') {
         insertIndex++;
@@ -145,7 +145,7 @@ Menu.prototype._init = function() {
     menuWillShow: (function(_this) {
       return function() {
 
-        /* Make sure radio groups have at least one menu item seleted. */
+        // Make sure radio groups have at least one menu item seleted.
         var checked, group, id, j, len, radioItem, ref1, results;
         ref1 = _this.groupsMap;
         results = [];
@@ -175,7 +175,7 @@ Menu.prototype._init = function() {
 Menu.prototype.popup = function(window, x, y) {
   if ((window != null ? window.constructor : void 0) !== BrowserWindow) {
 
-    /* Shift. */
+    // Shift.
     y = x;
     x = window;
     window = BrowserWindow.getFocusedWindow();
@@ -211,14 +211,14 @@ Menu.prototype.insert = function(pos, item) {
       break;
     case 'radio':
 
-      /* Grouping radio menu items. */
+      // Grouping radio menu items.
       item.overrideReadOnlyProperty('groupId', generateGroupId(this.items, pos));
       if ((base = this.groupsMap)[name = item.groupId] == null) {
         base[name] = [];
       }
       this.groupsMap[item.groupId].push(item);
 
-      /* Setting a radio menu item should flip other items in the group. */
+      // Setting a radio menu item should flip other items in the group.
       v8Util.setHiddenValue(item, 'checked', item.checked);
       Object.defineProperty(item, 'checked', {
         enumerable: true,
@@ -251,16 +251,16 @@ Menu.prototype.insert = function(pos, item) {
     this.setRole(pos, item.role);
   }
 
-  /* Make menu accessable to items. */
+  // Make menu accessable to items.
   item.overrideReadOnlyProperty('menu', this);
 
-  /* Remember the items. */
+  // Remember the items.
   this.items.splice(pos, 0, item);
   return this.commandsMap[item.commandId] = item;
 };
 
 
-/* Force menuWillShow to be called */
+// Force menuWillShow to be called
 
 Menu.prototype._callMenuWillShow = function() {
   var item, j, len, ref1, ref2, results;
@@ -286,7 +286,7 @@ Menu.setApplicationMenu = function(menu) {
     throw new TypeError('Invalid menu');
   }
 
-  /* Keep a reference. */
+  // Keep a reference.
   applicationMenu = menu;
   if (process.platform === 'darwin') {
     if (menu === null) {
@@ -324,7 +324,7 @@ Menu.buildFromTemplate = function(template) {
       insertIndex = indexToInsertByPosition(positionedTemplate, item.position);
     } else {
 
-      /* If no |position| is specified, insert after last item. */
+      // If no |position| is specified, insert after last item.
       insertIndex++;
     }
     positionedTemplate.splice(insertIndex, 0, item);

--- a/atom/browser/api/lib/menu.js
+++ b/atom/browser/api/lib/menu.js
@@ -8,17 +8,11 @@ v8Util = process.atomBinding('v8_util');
 
 bindings = process.atomBinding('menu');
 
-
 // Automatically generated radio menu item's group id.
-
 nextGroupId = 0;
 
-
 // Search between seperators to find a radio menu item and return its group id,
-
-
 // otherwise generate a group id.
-
 generateGroupId = function(items, pos) {
   var i, item, j, k, ref1, ref2, ref3;
   if (pos > 0) {
@@ -45,9 +39,7 @@ generateGroupId = function(items, pos) {
   return ++nextGroupId;
 };
 
-
 // Returns the index of item according to |id|.
-
 indexOfItemById = function(items, id) {
   var i, item, j, len;
   for (i = j = 0, len = items.length; j < len; i = ++j) {
@@ -59,9 +51,7 @@ indexOfItemById = function(items, id) {
   return -1;
 };
 
-
 // Returns the index of where to insert the item according to |position|.
-
 indexToInsertByPosition = function(items, position) {
   var id, insertIndex, query, ref1;
   if (!position) {
@@ -174,7 +164,6 @@ Menu.prototype._init = function() {
 
 Menu.prototype.popup = function(window, x, y) {
   if ((window != null ? window.constructor : void 0) !== BrowserWindow) {
-
     // Shift.
     y = x;
     x = window;
@@ -210,7 +199,6 @@ Menu.prototype.insert = function(pos, item) {
       this.insertSubMenu(pos, item.commandId, item.label, item.submenu);
       break;
     case 'radio':
-
       // Grouping radio menu items.
       item.overrideReadOnlyProperty('groupId', generateGroupId(this.items, pos));
       if ((base = this.groupsMap)[name = item.groupId] == null) {
@@ -261,7 +249,6 @@ Menu.prototype.insert = function(pos, item) {
 
 
 // Force menuWillShow to be called
-
 Menu.prototype._callMenuWillShow = function() {
   var item, j, len, ref1, ref2, results;
   if ((ref1 = this.delegate) != null) {
@@ -323,7 +310,6 @@ Menu.buildFromTemplate = function(template) {
     if (item.position) {
       insertIndex = indexToInsertByPosition(positionedTemplate, item.position);
     } else {
-
       // If no |position| is specified, insert after last item.
       insertIndex++;
     }

--- a/atom/browser/api/lib/navigation-controller.js
+++ b/atom/browser/api/lib/navigation-controller.js
@@ -4,7 +4,7 @@ var NavigationController, ipcMain,
 ipcMain = require('electron').ipcMain;
 
 
-/* The history operation in renderer is redirected to browser. */
+// The history operation in renderer is redirected to browser.
 
 ipcMain.on('ATOM_SHELL_NAVIGATION_CONTROLLER', function() {
   var args, event, method, ref;
@@ -32,7 +32,7 @@ NavigationController = (function() {
     this.webContents = webContents;
     this.clearHistory();
 
-    /* webContents may have already navigated to a page. */
+    // webContents may have already navigated to a page.
     if (this.webContents._getURL()) {
       this.currentIndex++;
       this.history.push(this.webContents._getURL());
@@ -42,26 +42,26 @@ NavigationController = (function() {
         var currentEntry;
         if (_this.inPageIndex > -1 && !inPage) {
 
-          /* Navigated to a new page, clear in-page mark. */
+          // Navigated to a new page, clear in-page mark.
           _this.inPageIndex = -1;
         } else if (_this.inPageIndex === -1 && inPage) {
 
-          /* Started in-page navigations. */
+          // Started in-page navigations.
           _this.inPageIndex = _this.currentIndex;
         }
         if (_this.pendingIndex >= 0) {
 
-          /* Go to index. */
+          // Go to index.
           _this.currentIndex = _this.pendingIndex;
           _this.pendingIndex = -1;
           return _this.history[_this.currentIndex] = url;
         } else if (replaceEntry) {
 
-          /* Non-user initialized navigation. */
+          // Non-user initialized navigation.
           return _this.history[_this.currentIndex] = url;
         } else {
 
-          /* Normal navigation. Clear history. */
+          // Normal navigation. Clear history.
           _this.history = _this.history.slice(0, _this.currentIndex + 1);
           currentEntry = _this.history[_this.currentIndex];
           if ((currentEntry != null ? currentEntry.url : void 0) !== url) {

--- a/atom/browser/api/lib/navigation-controller.js
+++ b/atom/browser/api/lib/navigation-controller.js
@@ -18,15 +18,11 @@ ipcMain.on('ATOM_SHELL_SYNC_NAVIGATION_CONTROLLER', function() {
   return event.returnValue = (ref = event.sender)[method].apply(ref, args);
 });
 
-
-/*
-  JavaScript implementation of Chromium's NavigationController.
-  Instead of relying on Chromium for history control, we compeletely do history
-  control on user land, and only rely on WebContents.loadURL for navigation.
-  This helps us avoid Chromium's various optimizations so we can ensure renderer
-  process is restarted everytime.
- */
-
+// JavaScript implementation of Chromium's NavigationController.
+// Instead of relying on Chromium for history control, we compeletely do history
+// control on user land, and only rely on WebContents.loadURL for navigation.
+// This helps us avoid Chromium's various optimizations so we can ensure renderer
+// process is restarted everytime.
 NavigationController = (function() {
   function NavigationController(webContents) {
     this.webContents = webContents;

--- a/atom/browser/api/lib/navigation-controller.js
+++ b/atom/browser/api/lib/navigation-controller.js
@@ -3,9 +3,7 @@ var NavigationController, ipcMain,
 
 ipcMain = require('electron').ipcMain;
 
-
 // The history operation in renderer is redirected to browser.
-
 ipcMain.on('ATOM_SHELL_NAVIGATION_CONTROLLER', function() {
   var args, event, method, ref;
   event = arguments[0], method = arguments[1], args = 3 <= arguments.length ? slice.call(arguments, 2) : [];

--- a/atom/browser/api/lib/protocol.js
+++ b/atom/browser/api/lib/protocol.js
@@ -8,9 +8,7 @@ if (!app.isReady()) {
 
 protocol = process.atomBinding('protocol').protocol;
 
-
 // Warn about removed APIs.
-
 logAndThrow = function(callback, message) {
   console.error(message);
   if (callback) {

--- a/atom/browser/api/lib/protocol.js
+++ b/atom/browser/api/lib/protocol.js
@@ -9,7 +9,7 @@ if (!app.isReady()) {
 protocol = process.atomBinding('protocol').protocol;
 
 
-/* Warn about removed APIs. */
+// Warn about removed APIs.
 
 logAndThrow = function(callback, message) {
   console.error(message);

--- a/atom/browser/api/lib/session.js
+++ b/atom/browser/api/lib/session.js
@@ -7,7 +7,7 @@ bindings = process.atomBinding('session');
 PERSIST_PERFIX = 'persist:';
 
 
-/* Returns the Session from |partition| string. */
+// Returns the Session from |partition| string.
 
 exports.fromPartition = function(partition) {
   if (partition == null) {
@@ -24,7 +24,7 @@ exports.fromPartition = function(partition) {
 };
 
 
-/* Returns the default session. */
+// Returns the default session.
 
 Object.defineProperty(exports, 'defaultSession', {
   enumerable: true,
@@ -35,7 +35,7 @@ Object.defineProperty(exports, 'defaultSession', {
 
 wrapSession = function(session) {
 
-  /* session is an EventEmitter. */
+  // session is an EventEmitter.
   return session.__proto__ = EventEmitter.prototype;
 };
 

--- a/atom/browser/api/lib/session.js
+++ b/atom/browser/api/lib/session.js
@@ -6,9 +6,7 @@ bindings = process.atomBinding('session');
 
 PERSIST_PERFIX = 'persist:';
 
-
 // Returns the Session from |partition| string.
-
 exports.fromPartition = function(partition) {
   if (partition == null) {
     partition = '';
@@ -23,9 +21,7 @@ exports.fromPartition = function(partition) {
   }
 };
 
-
 // Returns the default session.
-
 Object.defineProperty(exports, 'defaultSession', {
   enumerable: true,
   get: function() {
@@ -34,7 +30,6 @@ Object.defineProperty(exports, 'defaultSession', {
 });
 
 wrapSession = function(session) {
-
   // session is an EventEmitter.
   return session.__proto__ = EventEmitter.prototype;
 };

--- a/atom/browser/api/lib/tray.js
+++ b/atom/browser/api/lib/tray.js
@@ -9,7 +9,6 @@ Tray = process.atomBinding('tray').Tray;
 Tray.prototype.__proto__ = EventEmitter.prototype;
 
 Tray.prototype._init = function() {
-
   // Deprecated.
   deprecate.rename(this, 'popContextMenu', 'popUpContextMenu');
   deprecate.event(this, 'clicked', 'click');

--- a/atom/browser/api/lib/tray.js
+++ b/atom/browser/api/lib/tray.js
@@ -10,7 +10,7 @@ Tray.prototype.__proto__ = EventEmitter.prototype;
 
 Tray.prototype._init = function() {
 
-  /* Deprecated. */
+  // Deprecated.
   deprecate.rename(this, 'popContextMenu', 'popUpContextMenu');
   deprecate.event(this, 'clicked', 'click');
   deprecate.event(this, 'double-clicked', 'double-click');
@@ -21,7 +21,7 @@ Tray.prototype._init = function() {
 Tray.prototype.setContextMenu = function(menu) {
   this._setContextMenu(menu);
 
-  /* Keep a strong reference of menu. */
+  // Keep a strong reference of menu.
   return this.menu = menu;
 };
 

--- a/atom/browser/api/lib/web-contents.js
+++ b/atom/browser/api/lib/web-contents.js
@@ -65,7 +65,6 @@ const webFrameMethods = [
 ];
 
 wrapWebContents = function(webContents) {
-
   // webContents is an EventEmitter.
   var controller, method, name, ref1;
   webContents.__proto__ = EventEmitter.prototype;

--- a/atom/browser/api/lib/web-contents.js
+++ b/atom/browser/api/lib/web-contents.js
@@ -66,18 +66,18 @@ const webFrameMethods = [
 
 wrapWebContents = function(webContents) {
 
-  /* webContents is an EventEmitter. */
+  // webContents is an EventEmitter.
   var controller, method, name, ref1;
   webContents.__proto__ = EventEmitter.prototype;
 
-  /* WebContents::send(channel, args..) */
+  // WebContents::send(channel, args..)
   webContents.send = function() {
     var args, channel;
     channel = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
     return this._send(channel, slice.call(args));
   };
 
-  /* The navigation controller. */
+  // The navigation controller.
   controller = new NavigationController(webContents);
   ref1 = NavigationController.prototype;
   for (name in ref1) {
@@ -109,7 +109,7 @@ wrapWebContents = function(webContents) {
       return this.once('did-finish-load', executeJavaScript.bind(this, code, hasUserGesture));
   };
 
-  /* Dispatch IPC messages to the ipc module. */
+  // Dispatch IPC messages to the ipc module.
   webContents.on('ipc-message', function(event, packed) {
     var args, channel;
     channel = packed[0], args = 2 <= packed.length ? slice.call(packed, 1) : [];
@@ -126,14 +126,14 @@ wrapWebContents = function(webContents) {
     return ipcMain.emit.apply(ipcMain, [channel, event].concat(slice.call(args)));
   });
 
-  /* Handle context menu action request from pepper plugin. */
+  // Handle context menu action request from pepper plugin.
   webContents.on('pepper-context-menu', function(event, params) {
     var menu;
     menu = Menu.buildFromTemplate(params.menu);
     return menu.popup(params.x, params.y);
   });
 
-  /* This error occurs when host could not be found. */
+  // This error occurs when host could not be found.
   webContents.on('did-fail-provisional-load', function() {
     var args;
     args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
@@ -149,7 +149,7 @@ wrapWebContents = function(webContents) {
     })(this));
   });
 
-  /* Delays the page-title-updated event to next tick. */
+  // Delays the page-title-updated event to next tick.
   webContents.on('-page-title-updated', function() {
     var args;
     args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
@@ -160,7 +160,7 @@ wrapWebContents = function(webContents) {
     })(this));
   });
 
-  /* Deprecated. */
+  // Deprecated.
   deprecate.rename(webContents, 'loadUrl', 'loadURL');
   deprecate.rename(webContents, 'getUrl', 'getURL');
   deprecate.event(webContents, 'page-title-set', 'page-title-updated', function() {

--- a/atom/browser/api/lib/web-contents.js
+++ b/atom/browser/api/lib/web-contents.js
@@ -138,10 +138,8 @@ wrapWebContents = function(webContents) {
     var args;
     args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
 
-    /*
-      Calling loadURL during this event might cause crash, so delay the event
-      until next tick.
-     */
+    // Calling loadURL during this event might cause crash, so delay the event
+    // until next tick.
     return setImmediate((function(_this) {
       return function() {
         return _this.emit.apply(_this, ['did-fail-load'].concat(slice.call(args)));

--- a/atom/browser/lib/chrome-extension.js
+++ b/atom/browser/lib/chrome-extension.js
@@ -36,10 +36,8 @@ getExtensionInfoFromPath = function(srcDirectory) {
   manifest = JSON.parse(fs.readFileSync(path.join(srcDirectory, 'manifest.json')));
   if (extensionInfoMap[manifest.name] == null) {
 
-    /*
-      We can not use 'file://' directly because all resources in the extension
-      will be treated as relative to the root in Chrome.
-     */
+    // We can not use 'file://' directly because all resources in the extension
+    // will be treated as relative to the root in Chrome.
     page = url.format({
       protocol: 'chrome-extension',
       slashes: true,

--- a/atom/browser/lib/chrome-extension.js
+++ b/atom/browser/lib/chrome-extension.js
@@ -9,7 +9,7 @@ path = require('path');
 url = require('url');
 
 
-/* Mapping between hostname and file path. */
+// Mapping between hostname and file path.
 
 hostPathMap = {};
 
@@ -27,7 +27,7 @@ getPathForHost = function(host) {
 };
 
 
-/* Cache extensionInfo. */
+// Cache extensionInfo.
 
 extensionInfoMap = {};
 
@@ -57,14 +57,14 @@ getExtensionInfoFromPath = function(srcDirectory) {
 };
 
 
-/* The loaded extensions cache and its persistent path. */
+// The loaded extensions cache and its persistent path.
 
 loadedExtensions = null;
 
 loadedExtensionsPath = null;
 
 
-/* Persistent loaded extensions. */
+// Persistent loaded extensions.
 
 app = electron.app;
 
@@ -86,13 +86,13 @@ app.on('will-quit', function() {
 });
 
 
-/* We can not use protocol or BrowserWindow until app is ready. */
+// We can not use protocol or BrowserWindow until app is ready.
 
 app.once('ready', function() {
   var BrowserWindow, chromeExtensionHandler, e, error1, i, init, len, protocol, srcDirectory;
   protocol = electron.protocol, BrowserWindow = electron.BrowserWindow;
 
-  /* Load persistented extensions. */
+  // Load persistented extensions.
   loadedExtensionsPath = path.join(app.getPath('userData'), 'DevTools Extensions');
   try {
     loadedExtensions = JSON.parse(fs.readFileSync(loadedExtensionsPath));
@@ -100,7 +100,7 @@ app.once('ready', function() {
       loadedExtensions = [];
     }
 
-    /* Preheat the extensionInfo cache. */
+    // Preheat the extensionInfo cache.
     for (i = 0, len = loadedExtensions.length; i < len; i++) {
       srcDirectory = loadedExtensions[i];
       getExtensionInfoFromPath(srcDirectory);
@@ -109,7 +109,7 @@ app.once('ready', function() {
     e = error1;
   }
 
-  /* The chrome-extension: can map a extension URL request to real file path. */
+  // The chrome-extension: can map a extension URL request to real file path.
   chromeExtensionHandler = function(request, callback) {
     var directory, parsed;
     parsed = url.parse(request.url);
@@ -150,7 +150,7 @@ app.once('ready', function() {
     return delete extensionInfoMap[name];
   };
 
-  /* Load persistented extensions when devtools is opened. */
+  // Load persistented extensions when devtools is opened.
   init = BrowserWindow.prototype._init;
   return BrowserWindow.prototype._init = function() {
     init.call(this);

--- a/atom/browser/lib/chrome-extension.js
+++ b/atom/browser/lib/chrome-extension.js
@@ -8,9 +8,7 @@ path = require('path');
 
 url = require('url');
 
-
 // Mapping between hostname and file path.
-
 hostPathMap = {};
 
 hostPathMapNextKey = 0;
@@ -26,9 +24,7 @@ getPathForHost = function(host) {
   return hostPathMap[host];
 };
 
-
 // Cache extensionInfo.
-
 extensionInfoMap = {};
 
 getExtensionInfoFromPath = function(srcDirectory) {
@@ -54,16 +50,11 @@ getExtensionInfoFromPath = function(srcDirectory) {
   }
 };
 
-
 // The loaded extensions cache and its persistent path.
-
 loadedExtensions = null;
-
 loadedExtensionsPath = null;
 
-
 // Persistent loaded extensions.
-
 app = electron.app;
 
 app.on('will-quit', function() {
@@ -83,9 +74,7 @@ app.on('will-quit', function() {
   }
 });
 
-
 // We can not use protocol or BrowserWindow until app is ready.
-
 app.once('ready', function() {
   var BrowserWindow, chromeExtensionHandler, e, error1, i, init, len, protocol, srcDirectory;
   protocol = electron.protocol, BrowserWindow = electron.BrowserWindow;

--- a/atom/browser/lib/desktop-capturer.js
+++ b/atom/browser/lib/desktop-capturer.js
@@ -8,9 +8,7 @@ deepEqual = function(opt1, opt2) {
   return JSON.stringify(opt1) === JSON.stringify(opt2);
 };
 
-
 // A queue for holding all requests from renderer process.
-
 requestsQueue = [];
 
 ipcMain.on('ATOM_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', function(event, captureWindow, captureScreen, thumbnailSize, id) {
@@ -37,7 +35,6 @@ ipcMain.on('ATOM_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', function(event, captureW
 });
 
 desktopCapturer.emit = function(event, name, sources) {
-
   // Receiving sources result from main process, now send them back to renderer.
   var captureScreen, captureWindow, handledRequest, i, len, ref, ref1, ref2, request, result, source, thumbnailSize, unhandledRequestsQueue;
   handledRequest = requestsQueue.shift(0);

--- a/atom/browser/lib/desktop-capturer.js
+++ b/atom/browser/lib/desktop-capturer.js
@@ -29,10 +29,8 @@ ipcMain.on('ATOM_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', function(event, captureW
     desktopCapturer.startHandling(captureWindow, captureScreen, thumbnailSize);
   }
 
-  /*
-    If the WebContents is destroyed before receiving result, just remove the
-    reference from requestsQueue to make the module not send the result to it.
-   */
+  // If the WebContents is destroyed before receiving result, just remove the
+  // reference from requestsQueue to make the module not send the result to it.
   return event.sender.once('destroyed', function() {
     return request.webContents = null;
   });
@@ -60,10 +58,8 @@ desktopCapturer.emit = function(event, name, sources) {
     ref.send("ATOM_RENDERER_DESKTOP_CAPTURER_RESULT_" + handledRequest.id, result);
   }
 
-  /*
-    Check the queue to see whether there is other same request. If has, handle
-    it for reducing redunplicated `desktopCaptuer.startHandling` calls.
-   */
+  // Check the queue to see whether there is other same request. If has, handle
+  // it for reducing redunplicated `desktopCaptuer.startHandling` calls.
   unhandledRequestsQueue = [];
   for (i = 0, len = requestsQueue.length; i < len; i++) {
     request = requestsQueue[i];

--- a/atom/browser/lib/desktop-capturer.js
+++ b/atom/browser/lib/desktop-capturer.js
@@ -9,7 +9,7 @@ deepEqual = function(opt1, opt2) {
 };
 
 
-/* A queue for holding all requests from renderer process. */
+// A queue for holding all requests from renderer process.
 
 requestsQueue = [];
 
@@ -40,7 +40,7 @@ ipcMain.on('ATOM_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', function(event, captureW
 
 desktopCapturer.emit = function(event, name, sources) {
 
-  /* Receiving sources result from main process, now send them back to renderer. */
+  // Receiving sources result from main process, now send them back to renderer.
   var captureScreen, captureWindow, handledRequest, i, len, ref, ref1, ref2, request, result, source, thumbnailSize, unhandledRequestsQueue;
   handledRequest = requestsQueue.shift(0);
   result = (function() {
@@ -77,7 +77,7 @@ desktopCapturer.emit = function(event, name, sources) {
   }
   requestsQueue = unhandledRequestsQueue;
 
-  /* If the requestsQueue is not empty, start a new request handling. */
+  // If the requestsQueue is not empty, start a new request handling.
   if (requestsQueue.length > 0) {
     ref2 = requestsQueue[0].options, captureWindow = ref2.captureWindow, captureScreen = ref2.captureScreen, thumbnailSize = ref2.thumbnailSize;
     return desktopCapturer.startHandling(captureWindow, captureScreen, thumbnailSize);

--- a/atom/browser/lib/guest-view-manager.js
+++ b/atom/browser/lib/guest-view-manager.js
@@ -62,11 +62,9 @@ createGuest = function(embedder, params) {
     event = destroyEvents[i];
     embedder.once(event, destroy);
 
-    /*
-      Users might also listen to the crashed event, so We must ensure the guest
-      is destroyed before users' listener gets called. It is done by moving our
-      listener to the first one in queue.
-     */
+    // Users might also listen to the crashed event, so We must ensure the guest
+    // is destroyed before users' listener gets called. It is done by moving our
+    // listener to the first one in queue.
     listeners = embedder._events[event];
     if (Array.isArray(listeners)) {
       moveLastToFirst(listeners);

--- a/atom/browser/lib/guest-view-manager.js
+++ b/atom/browser/lib/guest-view-manager.js
@@ -4,7 +4,7 @@ var attachGuest, createGuest, destroyGuest, embedderElementsMap, getNextInstance
 ref = require('electron'), ipcMain = ref.ipcMain, webContents = ref.webContents;
 
 
-/* Doesn't exist in early initialization. */
+// Doesn't exist in early initialization.
 
 webViewManager = null;
 
@@ -19,21 +19,21 @@ embedderElementsMap = {};
 reverseEmbedderElementsMap = {};
 
 
-/* Moves the last element of array to the first one. */
+// Moves the last element of array to the first one.
 
 moveLastToFirst = function(list) {
   return list.unshift(list.pop());
 };
 
 
-/* Generate guestInstanceId. */
+// Generate guestInstanceId.
 
 getNextInstanceId = function(webContents) {
   return ++nextInstanceId;
 };
 
 
-/* Create a new guest instance. */
+// Create a new guest instance.
 
 createGuest = function(embedder, params) {
   var destroy, destroyEvents, event, fn, guest, i, id, j, len, len1, listeners;
@@ -51,7 +51,7 @@ createGuest = function(embedder, params) {
     embedder: embedder
   };
 
-  /* Destroy guest when the embedder is gone or navigated. */
+  // Destroy guest when the embedder is gone or navigated.
   destroyEvents = ['will-destroy', 'crashed', 'did-navigate'];
   destroy = function() {
     if (guestInstances[id] != null) {
@@ -82,7 +82,7 @@ createGuest = function(embedder, params) {
     return results;
   });
 
-  /* Init guest web view after attached. */
+  // Init guest web view after attached.
   guest.once('did-attach', function() {
     var opts;
     params = this.attachParams;
@@ -119,7 +119,7 @@ createGuest = function(embedder, params) {
     return guest.allowPopups = params.allowpopups;
   });
 
-  /* Dispatch events to embedder. */
+  // Dispatch events to embedder.
   fn = function(event) {
     return guest.on(event, function() {
       var _, args;
@@ -132,14 +132,14 @@ createGuest = function(embedder, params) {
     fn(event);
   }
 
-  /* Dispatch guest's IPC messages to embedder. */
+  // Dispatch guest's IPC messages to embedder.
   guest.on('ipc-message-host', function(_, packed) {
     var args, channel;
     channel = packed[0], args = 2 <= packed.length ? slice.call(packed, 1) : [];
     return embedder.send.apply(embedder, ["ATOM_SHELL_GUEST_VIEW_INTERNAL_IPC_MESSAGE-" + guest.viewInstanceId, channel].concat(slice.call(args)));
   });
 
-  /* Autosize. */
+  // Autosize.
   guest.on('size-changed', function() {
     var _, args;
     _ = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
@@ -149,18 +149,18 @@ createGuest = function(embedder, params) {
 };
 
 
-/* Attach the guest to an element of embedder. */
+// Attach the guest to an element of embedder.
 
 attachGuest = function(embedder, elementInstanceId, guestInstanceId, params) {
   var guest, key, oldGuestInstanceId, ref1, webPreferences;
   guest = guestInstances[guestInstanceId].guest;
 
-  /* Destroy the old guest when attaching. */
+  // Destroy the old guest when attaching.
   key = (embedder.getId()) + "-" + elementInstanceId;
   oldGuestInstanceId = embedderElementsMap[key];
   if (oldGuestInstanceId != null) {
 
-    /* Reattachment to the same guest is not currently supported. */
+    // Reattachment to the same guest is not currently supported.
     if (oldGuestInstanceId === guestInstanceId) {
       return;
     }
@@ -185,7 +185,7 @@ attachGuest = function(embedder, elementInstanceId, guestInstanceId, params) {
 };
 
 
-/* Destroy an existing guest instance. */
+// Destroy an existing guest instance.
 
 destroyGuest = function(embedder, id) {
   var key;
@@ -222,7 +222,7 @@ ipcMain.on('ATOM_SHELL_GUEST_VIEW_MANAGER_SET_ALLOW_TRANSPARENCY', function(even
 });
 
 
-/* Returns WebContents from its guest id. */
+// Returns WebContents from its guest id.
 
 exports.getGuest = function(id) {
   var ref1;
@@ -230,7 +230,7 @@ exports.getGuest = function(id) {
 };
 
 
-/* Returns the embedder of the guest. */
+// Returns the embedder of the guest.
 
 exports.getEmbedder = function(id) {
   var ref1;

--- a/atom/browser/lib/guest-view-manager.js
+++ b/atom/browser/lib/guest-view-manager.js
@@ -3,9 +3,7 @@ var attachGuest, createGuest, destroyGuest, embedderElementsMap, getNextInstance
 
 ref = require('electron'), ipcMain = ref.ipcMain, webContents = ref.webContents;
 
-
 // Doesn't exist in early initialization.
-
 webViewManager = null;
 
 supportedWebViewEvents = ['load-commit', 'did-finish-load', 'did-fail-load', 'did-frame-finish-load', 'did-start-loading', 'did-stop-loading', 'did-get-response-details', 'did-get-redirect-request', 'dom-ready', 'console-message', 'devtools-opened', 'devtools-closed', 'devtools-focused', 'new-window', 'will-navigate', 'did-navigate', 'did-navigate-in-page', 'close', 'crashed', 'gpu-crashed', 'plugin-crashed', 'destroyed', 'page-title-updated', 'page-favicon-updated', 'enter-html-full-screen', 'leave-html-full-screen', 'media-started-playing', 'media-paused', 'found-in-page', 'did-change-theme-color'];
@@ -18,23 +16,17 @@ embedderElementsMap = {};
 
 reverseEmbedderElementsMap = {};
 
-
 // Moves the last element of array to the first one.
-
 moveLastToFirst = function(list) {
   return list.unshift(list.pop());
 };
 
-
 // Generate guestInstanceId.
-
 getNextInstanceId = function(webContents) {
   return ++nextInstanceId;
 };
 
-
 // Create a new guest instance.
-
 createGuest = function(embedder, params) {
   var destroy, destroyEvents, event, fn, guest, i, id, j, len, len1, listeners;
   if (webViewManager == null) {
@@ -146,9 +138,7 @@ createGuest = function(embedder, params) {
   return id;
 };
 
-
 // Attach the guest to an element of embedder.
-
 attachGuest = function(embedder, elementInstanceId, guestInstanceId, params) {
   var guest, key, oldGuestInstanceId, ref1, webPreferences;
   guest = guestInstances[guestInstanceId].guest;
@@ -182,9 +172,7 @@ attachGuest = function(embedder, elementInstanceId, guestInstanceId, params) {
   return reverseEmbedderElementsMap[guestInstanceId] = key;
 };
 
-
 // Destroy an existing guest instance.
-
 destroyGuest = function(embedder, id) {
   var key;
   webViewManager.removeGuest(embedder, id);
@@ -219,17 +207,13 @@ ipcMain.on('ATOM_SHELL_GUEST_VIEW_MANAGER_SET_ALLOW_TRANSPARENCY', function(even
   return (ref1 = guestInstances[id]) != null ? ref1.guest.setAllowTransparency(allowtransparency) : void 0;
 });
 
-
 // Returns WebContents from its guest id.
-
 exports.getGuest = function(id) {
   var ref1;
   return (ref1 = guestInstances[id]) != null ? ref1.guest : void 0;
 };
 
-
 // Returns the embedder of the guest.
-
 exports.getEmbedder = function(id) {
   var ref1;
   return (ref1 = guestInstances[id]) != null ? ref1.embedder : void 0;

--- a/atom/browser/lib/guest-window-manager.js
+++ b/atom/browser/lib/guest-window-manager.js
@@ -8,9 +8,7 @@ v8Util = process.atomBinding('v8_util');
 
 frameToGuest = {};
 
-
 // Copy attribute of |parent| to |child| if it is not defined in |child|.
-
 mergeOptions = function(child, parent) {
   var key, value;
   for (key in parent) {
@@ -27,9 +25,7 @@ mergeOptions = function(child, parent) {
   return child;
 };
 
-
 // Merge |options| with the |embedder|'s window's options.
-
 mergeBrowserWindowOptions = function(embedder, options) {
   if (embedder.browserWindowOptions != null) {
 
@@ -46,9 +42,7 @@ mergeBrowserWindowOptions = function(embedder, options) {
   return options;
 };
 
-
 // Create a new guest created by |embedder| with |options|.
-
 createGuest = function(embedder, url, frameName, options) {
   var closedByEmbedder, closedByUser, guest, guestId, ref1;
   guest = frameToGuest[frameName];
@@ -89,9 +83,7 @@ createGuest = function(embedder, url, frameName, options) {
   return guest.id;
 };
 
-
 // Routed window.open messages.
-
 ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPEN', function() {
   var args, event, frameName, options, url;
   event = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];

--- a/atom/browser/lib/guest-window-manager.js
+++ b/atom/browser/lib/guest-window-manager.js
@@ -9,7 +9,7 @@ v8Util = process.atomBinding('v8_util');
 frameToGuest = {};
 
 
-/* Copy attribute of |parent| to |child| if it is not defined in |child|. */
+// Copy attribute of |parent| to |child| if it is not defined in |child|.
 
 mergeOptions = function(child, parent) {
   var key, value;
@@ -28,16 +28,16 @@ mergeOptions = function(child, parent) {
 };
 
 
-/* Merge |options| with the |embedder|'s window's options. */
+// Merge |options| with the |embedder|'s window's options.
 
 mergeBrowserWindowOptions = function(embedder, options) {
   if (embedder.browserWindowOptions != null) {
 
-    /* Inherit the original options if it is a BrowserWindow. */
+    // Inherit the original options if it is a BrowserWindow.
     mergeOptions(options, embedder.browserWindowOptions);
   } else {
 
-    /* Or only inherit web-preferences if it is a webview. */
+    // Or only inherit web-preferences if it is a webview.
     if (options.webPreferences == null) {
       options.webPreferences = {};
     }
@@ -47,7 +47,7 @@ mergeBrowserWindowOptions = function(embedder, options) {
 };
 
 
-/* Create a new guest created by |embedder| with |options|. */
+// Create a new guest created by |embedder| with |options|.
 
 createGuest = function(embedder, url, frameName, options) {
   var closedByEmbedder, closedByUser, guest, guestId, ref1;
@@ -57,7 +57,7 @@ createGuest = function(embedder, url, frameName, options) {
     return guest.id;
   }
 
-  /* Remember the embedder window's id. */
+  // Remember the embedder window's id.
   if (options.webPreferences == null) {
     options.webPreferences = {};
   }
@@ -92,7 +92,7 @@ createGuest = function(embedder, url, frameName, options) {
 };
 
 
-/* Routed window.open messages. */
+// Routed window.open messages.
 
 ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPEN', function() {
   var args, event, frameName, options, url;

--- a/atom/browser/lib/guest-window-manager.js
+++ b/atom/browser/lib/guest-window-manager.js
@@ -65,11 +65,9 @@ createGuest = function(embedder, url, frameName, options) {
   guest = new BrowserWindow(options);
   guest.loadURL(url);
 
-  /*
-    When |embedder| is destroyed we should also destroy attached guest, and if
-    guest is closed by user then we should prevent |embedder| from double
-    closing guest.
-   */
+  // When |embedder| is destroyed we should also destroy attached guest, and if
+  // guest is closed by user then we should prevent |embedder| from double
+  // closing guest.
   guestId = guest.id;
   closedByEmbedder = function() {
     guest.removeListener('closed', closedByUser);

--- a/atom/browser/lib/init.js
+++ b/atom/browser/lib/init.js
@@ -9,12 +9,8 @@ util = require('util');
 
 Module = require('module');
 
-
 // We modified the original process.argv to let node.js load the atom.js,
-
-
 // we need to restore it here.
-
 process.argv.splice(1, 1);
 
 // Clear search paths.
@@ -62,9 +58,7 @@ if (process.platform === 'win32') {
   });
 }
 
-
 // Don't quit on fatal error.
-
 process.on('uncaughtException', function(error) {
 
   // Do nothing if the user has a custom uncaught exception handler.
@@ -80,35 +74,26 @@ process.on('uncaughtException', function(error) {
   return dialog.showErrorBox('A JavaScript error occurred in the main process', message);
 });
 
-
 // Emit 'exit' event on quit.
-
 app = require('electron').app;
 
 app.on('quit', function(event, exitCode) {
   return process.emit('exit', exitCode);
 });
 
-
 // Map process.exit to app.exit, which quits gracefully.
-
 process.exit = app.exit;
 
-
 // Load the RPC server.
-
 require('./rpc-server');
 
-
 // Load the guest view manager.
-
 require('./guest-view-manager');
 
 require('./guest-window-manager');
 
 
 // Now we try to load app's package.json.
-
 packageJson = null;
 
 searchPaths = ['app', 'app.asar', 'default_app'];
@@ -132,61 +117,43 @@ if (packageJson == null) {
   throw new Error("Unable to find a valid app");
 }
 
-
 // Set application's version.
-
 if (packageJson.version != null) {
   app.setVersion(packageJson.version);
 }
 
-
 // Set application's name.
-
 if (packageJson.productName != null) {
   app.setName(packageJson.productName);
 } else if (packageJson.name != null) {
   app.setName(packageJson.name);
 }
 
-
 // Set application's desktop name.
-
 if (packageJson.desktopName != null) {
   app.setDesktopName(packageJson.desktopName);
 } else {
   app.setDesktopName((app.getName()) + ".desktop");
 }
 
-
 // Chrome 42 disables NPAPI plugins by default, reenable them here
-
 app.commandLine.appendSwitch('enable-npapi');
 
-
 // Set the user path according to application's name.
-
 app.setPath('userData', path.join(app.getPath('appData'), app.getName()));
 
 app.setPath('userCache', path.join(app.getPath('cache'), app.getName()));
 
 app.setAppPath(packagePath);
 
-
 // Load the chrome extension support.
-
 require('./chrome-extension');
 
-
 // Load internal desktop-capturer module.
-
 require('./desktop-capturer');
 
-
 // Set main startup script of the app.
-
 mainStartupScript = packageJson.main || 'index.js';
 
-
 // Finally load app's main.js and transfer control to C++.
-
 Module._load(path.join(packagePath, mainStartupScript), Module, true);

--- a/atom/browser/lib/init.js
+++ b/atom/browser/lib/init.js
@@ -17,14 +17,10 @@ Module = require('module');
 
 process.argv.splice(1, 1);
 
-
 // Clear search paths.
-
 require(path.resolve(__dirname, '..', '..', 'common', 'lib', 'reset-search-paths'));
 
-
 // Import common settings.
-
 require(path.resolve(__dirname, '..', '..', 'common', 'lib', 'init'));
 
 globalPaths = Module.globalPaths;
@@ -33,17 +29,12 @@ if (!process.env.ELECTRON_HIDE_INTERNAL_MODULES) {
   globalPaths.push(path.resolve(__dirname, '..', 'api', 'lib'));
 }
 
-
 // Expose public APIs.
-
 globalPaths.push(path.resolve(__dirname, '..', 'api', 'lib', 'exports'));
 
 if (process.platform === 'win32') {
-
-  /*
-    Redirect node's console to use our own implementations, since node can not
-    handle console output when running as GUI program.
-   */
+  // Redirect node's console to use our own implementations, since node can not
+  // handle console output when running as GUI program.
   consoleLog = function() {
     var args;
     args = 1 <= arguments.length ? slice.call(arguments, 0) : [];

--- a/atom/browser/lib/init.js
+++ b/atom/browser/lib/init.js
@@ -10,20 +10,20 @@ util = require('util');
 Module = require('module');
 
 
-/* We modified the original process.argv to let node.js load the atom.js, */
+// We modified the original process.argv to let node.js load the atom.js,
 
 
-/* we need to restore it here. */
+// we need to restore it here.
 
 process.argv.splice(1, 1);
 
 
-/* Clear search paths. */
+// Clear search paths.
 
 require(path.resolve(__dirname, '..', '..', 'common', 'lib', 'reset-search-paths'));
 
 
-/* Import common settings. */
+// Import common settings.
 
 require(path.resolve(__dirname, '..', '..', 'common', 'lib', 'init'));
 
@@ -34,7 +34,7 @@ if (!process.env.ELECTRON_HIDE_INTERNAL_MODULES) {
 }
 
 
-/* Expose public APIs. */
+// Expose public APIs.
 
 globalPaths.push(path.resolve(__dirname, '..', 'api', 'lib', 'exports'));
 
@@ -62,7 +62,7 @@ if (process.platform === 'win32') {
   console.log = console.error = console.warn = consoleLog;
   process.stdout.write = process.stderr.write = streamWrite;
 
-  /* Always returns EOF for stdin stream. */
+  // Always returns EOF for stdin stream.
   Readable = require('stream').Readable;
   stdin = new Readable;
   stdin.push(null);
@@ -72,17 +72,17 @@ if (process.platform === 'win32') {
 }
 
 
-/* Don't quit on fatal error. */
+// Don't quit on fatal error.
 
 process.on('uncaughtException', function(error) {
 
-  /* Do nothing if the user has a custom uncaught exception handler. */
+  // Do nothing if the user has a custom uncaught exception handler.
   var dialog, message, ref, stack;
   if (process.listeners('uncaughtException').length > 1) {
     return;
   }
 
-  /* Show error in GUI. */
+  // Show error in GUI.
   dialog = require('electron').dialog;
   stack = (ref = error.stack) != null ? ref : error.name + ": " + error.message;
   message = "Uncaught Exception:\n" + stack;
@@ -90,7 +90,7 @@ process.on('uncaughtException', function(error) {
 });
 
 
-/* Emit 'exit' event on quit. */
+// Emit 'exit' event on quit.
 
 app = require('electron').app;
 
@@ -99,24 +99,24 @@ app.on('quit', function(event, exitCode) {
 });
 
 
-/* Map process.exit to app.exit, which quits gracefully. */
+// Map process.exit to app.exit, which quits gracefully.
 
 process.exit = app.exit;
 
 
-/* Load the RPC server. */
+// Load the RPC server.
 
 require('./rpc-server');
 
 
-/* Load the guest view manager. */
+// Load the guest view manager.
 
 require('./guest-view-manager');
 
 require('./guest-window-manager');
 
 
-/* Now we try to load app's package.json. */
+// Now we try to load app's package.json.
 
 packageJson = null;
 
@@ -142,14 +142,14 @@ if (packageJson == null) {
 }
 
 
-/* Set application's version. */
+// Set application's version.
 
 if (packageJson.version != null) {
   app.setVersion(packageJson.version);
 }
 
 
-/* Set application's name. */
+// Set application's name.
 
 if (packageJson.productName != null) {
   app.setName(packageJson.productName);
@@ -158,7 +158,7 @@ if (packageJson.productName != null) {
 }
 
 
-/* Set application's desktop name. */
+// Set application's desktop name.
 
 if (packageJson.desktopName != null) {
   app.setDesktopName(packageJson.desktopName);
@@ -167,12 +167,12 @@ if (packageJson.desktopName != null) {
 }
 
 
-/* Chrome 42 disables NPAPI plugins by default, reenable them here */
+// Chrome 42 disables NPAPI plugins by default, reenable them here
 
 app.commandLine.appendSwitch('enable-npapi');
 
 
-/* Set the user path according to application's name. */
+// Set the user path according to application's name.
 
 app.setPath('userData', path.join(app.getPath('appData'), app.getName()));
 
@@ -181,21 +181,21 @@ app.setPath('userCache', path.join(app.getPath('cache'), app.getName()));
 app.setAppPath(packagePath);
 
 
-/* Load the chrome extension support. */
+// Load the chrome extension support.
 
 require('./chrome-extension');
 
 
-/* Load internal desktop-capturer module. */
+// Load internal desktop-capturer module.
 
 require('./desktop-capturer');
 
 
-/* Set main startup script of the app. */
+// Set main startup script of the app.
 
 mainStartupScript = packageJson.main || 'index.js';
 
 
-/* Finally load app's main.js and transfer control to C++. */
+// Finally load app's main.js and transfer control to C++.
 
 Module._load(path.join(packagePath, mainStartupScript), Module, true);

--- a/atom/browser/lib/objects-registry.js
+++ b/atom/browser/lib/objects-registry.js
@@ -36,7 +36,7 @@ ObjectsRegistry = (function(superClass) {
     var base, base1, id;
     id = this.saveToStorage(obj);
 
-    /* Remember the owner. */
+    // Remember the owner.
     if ((base = this.owners)[webContentsId] == null) {
       base[webContentsId] = {};
     }
@@ -45,12 +45,12 @@ ObjectsRegistry = (function(superClass) {
     }
     this.owners[webContentsId][id]++;
 
-    /* Returns object's id */
+    // Returns object's id
     return id;
   };
 
 
-  /* Get an object according to its ID. */
+  // Get an object according to its ID.
 
   ObjectsRegistry.prototype.get = function(id) {
     var ref;
@@ -58,13 +58,13 @@ ObjectsRegistry = (function(superClass) {
   };
 
 
-  /* Dereference an object according to its ID. */
+  // Dereference an object according to its ID.
 
   ObjectsRegistry.prototype.remove = function(webContentsId, id) {
     var pointer;
     this.dereference(id, 1);
 
-    /* Also reduce the count in owner. */
+    // Also reduce the count in owner.
     pointer = this.owners[webContentsId];
     if (pointer == null) {
       return;
@@ -76,7 +76,7 @@ ObjectsRegistry = (function(superClass) {
   };
 
 
-  /* Clear all references to objects refrenced by the WebContents. */
+  // Clear all references to objects refrenced by the WebContents.
 
   ObjectsRegistry.prototype.clear = function(webContentsId) {
     var count, id, ref;
@@ -93,7 +93,7 @@ ObjectsRegistry = (function(superClass) {
   };
 
 
-  /* Private: Saves the object into storage and assigns an ID for it. */
+  // Private: Saves the object into storage and assigns an ID for it.
 
   ObjectsRegistry.prototype.saveToStorage = function(object) {
     var id;
@@ -111,7 +111,7 @@ ObjectsRegistry = (function(superClass) {
   };
 
 
-  /* Private: Dereference the object from store. */
+  // Private: Dereference the object from store.
 
   ObjectsRegistry.prototype.dereference = function(id, count) {
     var pointer;

--- a/atom/browser/lib/objects-registry.js
+++ b/atom/browser/lib/objects-registry.js
@@ -65,7 +65,6 @@ ObjectsRegistry = (function(superClass) {
     }
   };
 
-
   // Clear all references to objects refrenced by the WebContents.
   ObjectsRegistry.prototype.clear = function(webContentsId) {
     var count, id, ref;
@@ -80,7 +79,6 @@ ObjectsRegistry = (function(superClass) {
     }
     return delete this.owners[webContentsId];
   };
-
 
   // Private: Saves the object into storage and assigns an ID for it.
   ObjectsRegistry.prototype.saveToStorage = function(object) {
@@ -97,7 +95,6 @@ ObjectsRegistry = (function(superClass) {
     ++this.storage[id].count;
     return id;
   };
-
 
   // Private: Dereference the object from store.
   ObjectsRegistry.prototype.dereference = function(id, count) {

--- a/atom/browser/lib/objects-registry.js
+++ b/atom/browser/lib/objects-registry.js
@@ -13,25 +13,17 @@ ObjectsRegistry = (function(superClass) {
     this.setMaxListeners(Number.MAX_VALUE);
     this.nextId = 0;
 
-    /*
-      Stores all objects by ref-counting.
-      (id) => {object, count}
-     */
+    // Stores all objects by ref-counting.
+    // (id) => {object, count}
     this.storage = {};
 
-    /*
-      Stores the IDs of objects referenced by WebContents.
-      (webContentsId) => {(id) => (count)}
-     */
+    // Stores the IDs of objects referenced by WebContents.
+    // (webContentsId) => {(id) => (count)}
     this.owners = {};
   }
 
-
-  /*
-    Register a new object, the object would be kept referenced until you release
-    it explicitly.
-   */
-
+  // Register a new object, the object would be kept referenced until you release
+  // it explicitly.
   ObjectsRegistry.prototype.add = function(webContentsId, obj) {
     var base, base1, id;
     id = this.saveToStorage(obj);
@@ -51,7 +43,6 @@ ObjectsRegistry = (function(superClass) {
 
 
   // Get an object according to its ID.
-
   ObjectsRegistry.prototype.get = function(id) {
     var ref;
     return (ref = this.storage[id]) != null ? ref.object : void 0;
@@ -59,7 +50,6 @@ ObjectsRegistry = (function(superClass) {
 
 
   // Dereference an object according to its ID.
-
   ObjectsRegistry.prototype.remove = function(webContentsId, id) {
     var pointer;
     this.dereference(id, 1);
@@ -77,7 +67,6 @@ ObjectsRegistry = (function(superClass) {
 
 
   // Clear all references to objects refrenced by the WebContents.
-
   ObjectsRegistry.prototype.clear = function(webContentsId) {
     var count, id, ref;
     this.emit("clear-" + webContentsId);
@@ -94,7 +83,6 @@ ObjectsRegistry = (function(superClass) {
 
 
   // Private: Saves the object into storage and assigns an ID for it.
-
   ObjectsRegistry.prototype.saveToStorage = function(object) {
     var id;
     id = v8Util.getHiddenValue(object, 'atomId');
@@ -112,7 +100,6 @@ ObjectsRegistry = (function(superClass) {
 
 
   // Private: Dereference the object from store.
-
   ObjectsRegistry.prototype.dereference = function(id, count) {
     var pointer;
     pointer = this.storage[id];

--- a/atom/browser/lib/rpc-server.js
+++ b/atom/browser/lib/rpc-server.js
@@ -14,7 +14,7 @@ v8Util = process.atomBinding('v8_util');
 IDWeakMap = process.atomBinding('id_weak_map').IDWeakMap;
 
 
-/* Convert a real value into meta data. */
+// Convert a real value into meta data.
 
 valueToMeta = function(sender, value, optimizeSimpleObject) {
   var el, field, i, len, meta, name;
@@ -43,12 +43,12 @@ valueToMeta = function(sender, value, optimizeSimpleObject) {
     meta.type = 'promise';
   }
 
-  /* Treat simple objects as value. */
+  // Treat simple objects as value.
   if (optimizeSimpleObject && meta.type === 'object' && v8Util.getHiddenValue(value, 'simple')) {
     meta.type = 'value';
   }
 
-  /* Treat the arguments object as array. */
+  // Treat the arguments object as array.
   if (meta.type === 'object' && (value.callee != null) && (value.length != null)) {
     meta.type = 'array';
   }
@@ -86,7 +86,7 @@ valueToMeta = function(sender, value, optimizeSimpleObject) {
   } else if (meta.type === 'error') {
     meta.members = plainObjectToMeta(value);
 
-    /* Error.name is not part of own properties. */
+    // Error.name is not part of own properties.
     meta.members.push({
       name: 'name',
       value: value.name
@@ -101,7 +101,7 @@ valueToMeta = function(sender, value, optimizeSimpleObject) {
 };
 
 
-/* Convert object to meta by value. */
+// Convert object to meta by value.
 
 plainObjectToMeta = function(obj) {
   return Object.getOwnPropertyNames(obj).map(function(name) {
@@ -113,7 +113,7 @@ plainObjectToMeta = function(obj) {
 };
 
 
-/* Convert Error into meta data. */
+// Convert Error into meta data.
 
 exceptionToMeta = function(error) {
   return {
@@ -124,7 +124,7 @@ exceptionToMeta = function(error) {
 };
 
 
-/* Convert array of meta data from renderer into array of real values. */
+// Convert array of meta data from renderer into array of real values.
 
 unwrapArgs = function(sender, args) {
   var metaToValue;
@@ -160,7 +160,7 @@ unwrapArgs = function(sender, args) {
         };
       case 'function':
 
-        /* Cache the callbacks in renderer. */
+        // Cache the callbacks in renderer.
         if (!sender.callbacks) {
           sender.callbacks = new IDWeakMap;
           sender.on('render-view-deleted', function() {
@@ -230,7 +230,7 @@ callFunction = function(event, func, caller, args) {
 };
 
 
-/* Send by BrowserWindow when its render view is deleted. */
+// Send by BrowserWindow when its render view is deleted.
 
 process.on('ATOM_BROWSER_RELEASE_RENDER_VIEW', function(id) {
   return objectsRegistry.clear(id);
@@ -316,7 +316,7 @@ ipcMain.on('ATOM_BROWSER_MEMBER_CONSTRUCTOR', function(event, id, method, args) 
     args = unwrapArgs(event.sender, args);
     constructor = objectsRegistry.get(id)[method];
 
-    /* Call new with array of arguments. */
+    // Call new with array of arguments.
     obj = new (Function.prototype.bind.apply(constructor, [null].concat(args)));
     return event.returnValue = valueToMeta(event.sender, obj);
   } catch (error1) {

--- a/atom/browser/lib/rpc-server.js
+++ b/atom/browser/lib/rpc-server.js
@@ -61,11 +61,9 @@ valueToMeta = function(sender, value, optimizeSimpleObject) {
   } else if (meta.type === 'object' || meta.type === 'function') {
     meta.name = value.constructor.name;
 
-    /*
-      Reference the original value if it's an object, because when it's
-      passed to renderer we would assume the renderer keeps a reference of
-      it.
-     */
+    // Reference the original value if it's an object, because when it's
+    // passed to renderer we would assume the renderer keeps a reference of
+    // it.
     meta.id = objectsRegistry.add(sender.getId(), value);
     meta.members = (function() {
       var results;
@@ -196,12 +194,8 @@ unwrapArgs = function(sender, args) {
   return args.map(metaToValue);
 };
 
-
-/*
-  Call a function and send reply asynchronously if it's a an asynchronous
-  style function and the caller didn't pass a callback.
- */
-
+// Call a function and send reply asynchronously if it's a an asynchronous
+// style function and the caller didn't pass a callback.
 callFunction = function(event, func, caller, args) {
   var e, error1, funcMarkedAsync, funcName, funcPassedCallback, ref, ret;
   funcMarkedAsync = v8Util.getHiddenValue(func, 'asynchronous');
@@ -219,11 +213,9 @@ callFunction = function(event, func, caller, args) {
   } catch (error1) {
     e = error1;
 
-    /*
-      Catch functions thrown further down in function invocation and wrap
-      them with the function name so it's easier to trace things like
-      `Error processing argument -1.`
-     */
+    // Catch functions thrown further down in function invocation and wrap
+    // them with the function name so it's easier to trace things like
+    // `Error processing argument -1.`
     funcName = (ref = func.name) != null ? ref : "anonymous";
     throw new Error("Could not call remote function `" + funcName + "`. Check that the function signature is correct. Underlying error: " + e.message);
   }
@@ -231,7 +223,6 @@ callFunction = function(event, func, caller, args) {
 
 
 // Send by BrowserWindow when its render view is deleted.
-
 process.on('ATOM_BROWSER_RELEASE_RENDER_VIEW', function(id) {
   return objectsRegistry.clear(id);
 });
@@ -286,10 +277,8 @@ ipcMain.on('ATOM_BROWSER_CONSTRUCTOR', function(event, id, args) {
     args = unwrapArgs(event.sender, args);
     constructor = objectsRegistry.get(id);
 
-    /*
-      Call new with array of arguments.
-      http://stackoverflow.com/questions/1606797/use-of-apply-with-new-operator-is-this-possible
-     */
+    // Call new with array of arguments.
+    // http://stackoverflow.com/questions/1606797/use-of-apply-with-new-operator-is-this-possible
     obj = new (Function.prototype.bind.apply(constructor, [null].concat(args)));
     return event.returnValue = valueToMeta(event.sender, obj);
   } catch (error1) {

--- a/atom/browser/lib/rpc-server.js
+++ b/atom/browser/lib/rpc-server.js
@@ -13,9 +13,7 @@ v8Util = process.atomBinding('v8_util');
 
 IDWeakMap = process.atomBinding('id_weak_map').IDWeakMap;
 
-
 // Convert a real value into meta data.
-
 valueToMeta = function(sender, value, optimizeSimpleObject) {
   var el, field, i, len, meta, name;
   if (optimizeSimpleObject == null) {
@@ -98,9 +96,7 @@ valueToMeta = function(sender, value, optimizeSimpleObject) {
   return meta;
 };
 
-
 // Convert object to meta by value.
-
 plainObjectToMeta = function(obj) {
   return Object.getOwnPropertyNames(obj).map(function(name) {
     return {
@@ -110,9 +106,7 @@ plainObjectToMeta = function(obj) {
   });
 };
 
-
 // Convert Error into meta data.
-
 exceptionToMeta = function(error) {
   return {
     type: 'exception',
@@ -121,9 +115,7 @@ exceptionToMeta = function(error) {
   };
 };
 
-
 // Convert array of meta data from renderer into array of real values.
-
 unwrapArgs = function(sender, args) {
   var metaToValue;
   metaToValue = function(meta) {
@@ -157,7 +149,6 @@ unwrapArgs = function(sender, args) {
           return returnValue;
         };
       case 'function':
-
         // Cache the callbacks in renderer.
         if (!sender.callbacks) {
           sender.callbacks = new IDWeakMap;
@@ -220,7 +211,6 @@ callFunction = function(event, func, caller, args) {
     throw new Error("Could not call remote function `" + funcName + "`. Check that the function signature is correct. Underlying error: " + e.message);
   }
 };
-
 
 // Send by BrowserWindow when its render view is deleted.
 process.on('ATOM_BROWSER_RELEASE_RENDER_VIEW', function(id) {

--- a/atom/common/api/lib/callbacks-registry.js
+++ b/atom/common/api/lib/callbacks-registry.js
@@ -11,7 +11,7 @@ module.exports = CallbacksRegistry = (function() {
 
   CallbacksRegistry.prototype.add = function(callback) {
 
-    /* The callback is already added. */
+    // The callback is already added.
     var filenameAndLine, id, location, match, ref, regexp, stackString, x;
     id = v8Util.getHiddenValue(callback, 'callbackId');
     if (id != null) {

--- a/atom/common/api/lib/callbacks-registry.js
+++ b/atom/common/api/lib/callbacks-registry.js
@@ -10,7 +10,6 @@ module.exports = CallbacksRegistry = (function() {
   }
 
   CallbacksRegistry.prototype.add = function(callback) {
-
     // The callback is already added.
     var filenameAndLine, id, location, match, ref, regexp, stackString, x;
     id = v8Util.getHiddenValue(callback, 'callbackId');

--- a/atom/common/api/lib/callbacks-registry.js
+++ b/atom/common/api/lib/callbacks-registry.js
@@ -19,10 +19,8 @@ module.exports = CallbacksRegistry = (function() {
     }
     id = ++this.nextId;
 
-    /*
-      Capture the location of the function and put it in the ID string,
-      so that release errors can be tracked down easily.
-     */
+    // Capture the location of the function and put it in the ID string,
+    // so that release errors can be tracked down easily.
     regexp = /at (.*)/gi;
     stackString = (new Error).stack;
     while ((match = regexp.exec(stackString)) !== null) {

--- a/atom/common/api/lib/clipboard.js
+++ b/atom/common/api/lib/clipboard.js
@@ -1,6 +1,6 @@
 if (process.platform === 'linux' && process.type === 'renderer') {
 
-  /* On Linux we could not access clipboard in renderer process. */
+  // On Linux we could not access clipboard in renderer process.
   module.exports = require('electron').remote.clipboard;
 } else {
   module.exports = process.atomBinding('clipboard');

--- a/atom/common/api/lib/clipboard.js
+++ b/atom/common/api/lib/clipboard.js
@@ -1,5 +1,4 @@
 if (process.platform === 'linux' && process.type === 'renderer') {
-
   // On Linux we could not access clipboard in renderer process.
   module.exports = require('electron').remote.clipboard;
 } else {

--- a/atom/common/api/lib/crash-reporter.js
+++ b/atom/common/api/lib/crash-reporter.js
@@ -22,7 +22,7 @@ CrashReporter = (function() {
     }
     this.productName = options.productName, companyName = options.companyName, submitURL = options.submitURL, autoSubmit = options.autoSubmit, ignoreSystemCrashHandler = options.ignoreSystemCrashHandler, extra = options.extra;
 
-    /* Deprecated. */
+    // Deprecated.
     deprecate = electron.deprecate;
     if (options.submitUrl) {
       if (submitURL == null) {

--- a/atom/common/api/lib/deprecate.js
+++ b/atom/common/api/lib/deprecate.js
@@ -1,5 +1,5 @@
 
-/* Deprecate a method. */
+// Deprecate a method.
 var deprecate,
   slice = [].slice;
 
@@ -16,7 +16,7 @@ deprecate = function(oldName, newName, fn) {
 };
 
 
-/* The method is renamed. */
+// The method is renamed.
 
 deprecate.rename = function(object, oldName, newName) {
   var newMethod, warned;
@@ -36,7 +36,7 @@ deprecate.rename = function(object, oldName, newName) {
 };
 
 
-/* Forward the method to member. */
+// Forward the method to member.
 
 deprecate.member = function(object, method, member) {
   var warned;
@@ -51,7 +51,7 @@ deprecate.member = function(object, method, member) {
 };
 
 
-/* Deprecate a property. */
+// Deprecate a property.
 
 deprecate.property = function(object, property, method) {
   return Object.defineProperty(object, property, {
@@ -68,7 +68,7 @@ deprecate.property = function(object, property, method) {
 };
 
 
-/* Deprecate an event. */
+// Deprecate an event.
 
 deprecate.event = function(emitter, oldName, newName, fn) {
   var warned;
@@ -77,7 +77,7 @@ deprecate.event = function(emitter, oldName, newName, fn) {
     var args;
     args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
 
-    /* there is listeners for old API. */
+    // there is listeners for old API.
     if (this.listenerCount(oldName) > 0) {
       if (!(warned || process.noDeprecation)) {
         warned = true;
@@ -93,14 +93,14 @@ deprecate.event = function(emitter, oldName, newName, fn) {
 };
 
 
-/* Print deprecation warning. */
+// Print deprecation warning.
 
 deprecate.warn = function(oldName, newName) {
   return deprecate.log(oldName + " is deprecated. Use " + newName + " instead.");
 };
 
 
-/* Print deprecation message. */
+// Print deprecation message.
 
 deprecate.log = function(message) {
   if (process.throwDeprecation) {

--- a/atom/common/api/lib/deprecate.js
+++ b/atom/common/api/lib/deprecate.js
@@ -1,4 +1,3 @@
-
 // Deprecate a method.
 var deprecate,
   slice = [].slice;
@@ -15,9 +14,7 @@ deprecate = function(oldName, newName, fn) {
   };
 };
 
-
 // The method is renamed.
-
 deprecate.rename = function(object, oldName, newName) {
   var newMethod, warned;
   warned = false;
@@ -35,9 +32,7 @@ deprecate.rename = function(object, oldName, newName) {
   }
 };
 
-
 // Forward the method to member.
-
 deprecate.member = function(object, method, member) {
   var warned;
   warned = false;
@@ -50,9 +45,7 @@ deprecate.member = function(object, method, member) {
   };
 };
 
-
 // Deprecate a property.
-
 deprecate.property = function(object, property, method) {
   return Object.defineProperty(object, property, {
     get: function() {
@@ -67,9 +60,7 @@ deprecate.property = function(object, property, method) {
   });
 };
 
-
 // Deprecate an event.
-
 deprecate.event = function(emitter, oldName, newName, fn) {
   var warned;
   warned = false;
@@ -92,16 +83,12 @@ deprecate.event = function(emitter, oldName, newName, fn) {
   });
 };
 
-
 // Print deprecation warning.
-
 deprecate.warn = function(oldName, newName) {
   return deprecate.log(oldName + " is deprecated. Use " + newName + " instead.");
 };
 
-
 // Print deprecation message.
-
 deprecate.log = function(message) {
   if (process.throwDeprecation) {
     throw new Error(message);

--- a/atom/common/api/lib/exports/electron.js
+++ b/atom/common/api/lib/exports/electron.js
@@ -1,25 +1,25 @@
 
-/* Do not expose the internal modules to `require`. */
+// Do not expose the internal modules to `require`.
 exports.hideInternalModules = function() {
   var globalPaths;
   globalPaths = require('module').globalPaths;
   if (globalPaths.length === 3) {
 
-    /* Remove the "common/api/lib" and "browser-or-renderer/api/lib". */
+    // Remove the "common/api/lib" and "browser-or-renderer/api/lib".
     return globalPaths.splice(0, 2);
   }
 };
 
 
-/* Attaches properties to |exports|. */
+// Attaches properties to |exports|.
 
 exports.defineProperties = function(exports) {
   return Object.defineProperties(exports, {
 
-    /* Common modules, please sort with alphabet order. */
+    // Common modules, please sort with alphabet order.
     clipboard: {
 
-      /* Must be enumerable, otherwise it woulde be invisible to remote module. */
+      // Must be enumerable, otherwise it woulde be invisible to remote module.
       enumerable: true,
       get: function() {
         return require('../clipboard');
@@ -44,7 +44,7 @@ exports.defineProperties = function(exports) {
       }
     },
 
-    /* The internal modules, invisible unless you know their names. */
+    // The internal modules, invisible unless you know their names.
     CallbacksRegistry: {
       get: function() {
         return require('../callbacks-registry');

--- a/atom/common/api/lib/exports/electron.js
+++ b/atom/common/api/lib/exports/electron.js
@@ -1,4 +1,3 @@
-
 // Do not expose the internal modules to `require`.
 exports.hideInternalModules = function() {
   var globalPaths;
@@ -10,9 +9,7 @@ exports.hideInternalModules = function() {
   }
 };
 
-
 // Attaches properties to |exports|.
-
 exports.defineProperties = function(exports) {
   return Object.defineProperties(exports, {
 

--- a/atom/common/api/lib/native-image.js
+++ b/atom/common/api/lib/native-image.js
@@ -5,7 +5,7 @@ deprecate = require('electron').deprecate;
 nativeImage = process.atomBinding('native_image');
 
 
-/* Deprecated. */
+// Deprecated.
 
 deprecate.rename(nativeImage, 'createFromDataUrl', 'createFromDataURL');
 

--- a/atom/common/api/lib/native-image.js
+++ b/atom/common/api/lib/native-image.js
@@ -4,9 +4,7 @@ deprecate = require('electron').deprecate;
 
 nativeImage = process.atomBinding('native_image');
 
-
 // Deprecated.
-
 deprecate.rename(nativeImage, 'createFromDataUrl', 'createFromDataURL');
 
 module.exports = nativeImage;

--- a/atom/common/lib/asar.js
+++ b/atom/common/lib/asar.js
@@ -10,9 +10,7 @@ path = require('path');
 
 util = require('util');
 
-
 // Cache asar archive objects.
-
 cachedArchives = {};
 
 getOrCreateArchive = function(p) {
@@ -28,9 +26,7 @@ getOrCreateArchive = function(p) {
   return cachedArchives[p] = archive;
 };
 
-
 // Clean cache on quit.
-
 process.on('exit', function() {
   var archive, p, results;
   results = [];
@@ -42,9 +38,7 @@ process.on('exit', function() {
   return results;
 });
 
-
 // Separate asar package's path from full path.
-
 splitPath = function(p) {
 
   // shortcut to disable asar.
@@ -66,9 +60,7 @@ splitPath = function(p) {
   return [true, p.substr(0, index + 5), p.substr(index + 6)];
 };
 
-
 // Convert asar archive's Stats object to fs's Stats object.
-
 nextInode = 0;
 
 uid = process.getuid != null ? process.getuid() : 0;
@@ -115,9 +107,7 @@ asarStatsToFsStats = function(stats) {
   };
 };
 
-
 // Create a ENOENT error.
-
 notFoundError = function(asarPath, filePath, callback) {
   var error;
   error = new Error("ENOENT, " + filePath + " not found in " + asarPath);
@@ -131,9 +121,7 @@ notFoundError = function(asarPath, filePath, callback) {
   });
 };
 
-
 // Create a ENOTDIR error.
-
 notDirError = function(callback) {
   var error;
   error = new Error('ENOTDIR, not a directory');
@@ -147,9 +135,7 @@ notDirError = function(callback) {
   });
 };
 
-
 // Create invalid archive error.
-
 invalidArchiveError = function(asarPath, callback) {
   var error;
   error = new Error("Invalid package " + asarPath);
@@ -161,9 +147,7 @@ invalidArchiveError = function(asarPath, callback) {
   });
 };
 
-
 // Override APIs that rely on passing file path instead of content to C++.
-
 overrideAPISync = function(module, name, arg) {
   var old;
   if (arg == null) {
@@ -220,9 +204,7 @@ overrideAPI = function(module, name, arg) {
   };
 };
 
-
 // Override fs APIs.
-
 exports.wrapFsWithAsar = function(fs) {
   var exists, existsSync, internalModuleReadFile, internalModuleStat, lstat, lstatSync, mkdir, mkdirSync, open, openSync, readFile, readFileSync, readdir, readdirSync, realpath, realpathSync, stat, statSync, statSyncNoException;
   lstatSync = fs.lstatSync;

--- a/atom/common/lib/asar.js
+++ b/atom/common/lib/asar.js
@@ -571,12 +571,10 @@ exports.wrapFsWithAsar = function(fs) {
     }
   };
 
-  /*
-    Calling mkdir for directory inside asar archive should throw ENOTDIR
-    error, but on Windows it throws ENOENT.
-    This is to work around the recursive looping bug of mkdirp since it is
-    widely used.
-   */
+  // Calling mkdir for directory inside asar archive should throw ENOTDIR
+  // error, but on Windows it throws ENOENT.
+  // This is to work around the recursive looping bug of mkdirp since it is
+  // widely used.
   if (process.platform === 'win32') {
     mkdir = fs.mkdir;
     fs.mkdir = function(p, mode, callback) {

--- a/atom/common/lib/asar.js
+++ b/atom/common/lib/asar.js
@@ -11,7 +11,7 @@ path = require('path');
 util = require('util');
 
 
-/* Cache asar archive objects. */
+// Cache asar archive objects.
 
 cachedArchives = {};
 
@@ -29,7 +29,7 @@ getOrCreateArchive = function(p) {
 };
 
 
-/* Clean cache on quit. */
+// Clean cache on quit.
 
 process.on('exit', function() {
   var archive, p, results;
@@ -43,11 +43,11 @@ process.on('exit', function() {
 });
 
 
-/* Separate asar package's path from full path. */
+// Separate asar package's path from full path.
 
 splitPath = function(p) {
 
-  /* shortcut to disable asar. */
+  // shortcut to disable asar.
   var index;
   if (process.noAsar) {
     return [false];
@@ -67,7 +67,7 @@ splitPath = function(p) {
 };
 
 
-/* Convert asar archive's Stats object to fs's Stats object. */
+// Convert asar archive's Stats object to fs's Stats object.
 
 nextInode = 0;
 
@@ -116,7 +116,7 @@ asarStatsToFsStats = function(stats) {
 };
 
 
-/* Create a ENOENT error. */
+// Create a ENOENT error.
 
 notFoundError = function(asarPath, filePath, callback) {
   var error;
@@ -132,7 +132,7 @@ notFoundError = function(asarPath, filePath, callback) {
 };
 
 
-/* Create a ENOTDIR error. */
+// Create a ENOTDIR error.
 
 notDirError = function(callback) {
   var error;
@@ -148,7 +148,7 @@ notDirError = function(callback) {
 };
 
 
-/* Create invalid archive error. */
+// Create invalid archive error.
 
 invalidArchiveError = function(asarPath, callback) {
   var error;
@@ -162,7 +162,7 @@ invalidArchiveError = function(asarPath, callback) {
 };
 
 
-/* Override APIs that rely on passing file path instead of content to C++. */
+// Override APIs that rely on passing file path instead of content to C++.
 
 overrideAPISync = function(module, name, arg) {
   var old;
@@ -221,7 +221,7 @@ overrideAPI = function(module, name, arg) {
 };
 
 
-/* Override fs APIs. */
+// Override fs APIs.
 
 exports.wrapFsWithAsar = function(fs) {
   var exists, existsSync, internalModuleReadFile, internalModuleStat, lstat, lstatSync, mkdir, mkdirSync, open, openSync, readFile, readFileSync, readdir, readdirSync, realpath, realpathSync, stat, statSync, statSyncNoException;
@@ -269,7 +269,7 @@ exports.wrapFsWithAsar = function(fs) {
       return statSync(p);
     }
 
-    /* Do not distinguish links for now. */
+    // Do not distinguish links for now.
     return fs.lstatSync(p);
   };
   stat = fs.stat;
@@ -280,7 +280,7 @@ exports.wrapFsWithAsar = function(fs) {
       return stat(p, callback);
     }
 
-    /* Do not distinguish links for now. */
+    // Do not distinguish links for now.
     return process.nextTick(function() {
       return fs.lstat(p, callback);
     });
@@ -427,7 +427,7 @@ exports.wrapFsWithAsar = function(fs) {
   readFileSync = fs.readFileSync;
   fs.readFileSync = function(p, opts) {
 
-    /* this allows v8 to optimize this function */
+    // this allows v8 to optimize this function
     var archive, asarPath, buffer, encoding, fd, filePath, info, isAsar, options, realPath, ref;
     options = opts;
     ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
@@ -554,13 +554,13 @@ exports.wrapFsWithAsar = function(fs) {
     }
     archive = getOrCreateArchive(asarPath);
 
-    /* -ENOENT */
+    // -ENOENT
     if (!archive) {
       return -34;
     }
     stats = archive.stat(filePath);
 
-    /* -ENOENT */
+    // -ENOENT
     if (!stats) {
       return -34;
     }

--- a/atom/common/lib/asar_init.js
+++ b/atom/common/lib/asar_init.js
@@ -3,13 +3,13 @@ return function(process, require, asarSource) {
   var createArchive, source;
   createArchive = process.binding('atom_common_asar').createArchive;
 
-  /* Make asar.coffee accessible via "require". */
+  // Make asar.coffee accessible via "require".
   process.binding('natives').ATOM_SHELL_ASAR = asarSource;
 
-  /* Monkey-patch the fs module. */
+  // Monkey-patch the fs module.
   require('ATOM_SHELL_ASAR').wrapFsWithAsar(require('fs'));
 
-  /* Make graceful-fs work with asar. */
+  // Make graceful-fs work with asar.
   source = process.binding('natives');
   source['original-fs'] = source.fs;
   return source['fs'] = "var src = '(function (exports, require, module, __filename, __dirname) { ' +\n          process.binding('natives')['original-fs'] +\n          ' });';\nvar vm = require('vm');\nvar fn = vm.runInThisContext(src, { filename: 'fs.js' });\nfn(exports, require, module);\nvar asar = require('ATOM_SHELL_ASAR');\nasar.wrapFsWithAsar(exports);";

--- a/atom/common/lib/init.js
+++ b/atom/common/lib/init.js
@@ -27,15 +27,12 @@ if (!process.env.ELECTRON_HIDE_INTERNAL_MODULES) {
 }
 
 
-/*
-  setImmediate and process.nextTick makes use of uv_check and uv_prepare to
-  run the callbacks, however since we only run uv loop on requests, the
-  callbacks wouldn't be called until something else activated the uv loop,
-  which would delay the callbacks for arbitrary long time. So we should
-  initiatively activate the uv loop once setImmediate and process.nextTick is
-  called.
- */
-
+// setImmediate and process.nextTick makes use of uv_check and uv_prepare to
+// run the callbacks, however since we only run uv loop on requests, the
+// callbacks wouldn't be called until something else activated the uv loop,
+// which would delay the callbacks for arbitrary long time. So we should
+// initiatively activate the uv loop once setImmediate and process.nextTick is
+// called.
 wrapWithActivateUvLoop = function(func) {
   return function() {
     process.activateUvLoop();
@@ -51,12 +48,10 @@ global.clearImmediate = timers.clearImmediate;
 
 if (process.type === 'browser') {
 
-  /*
-    setTimeout needs to update the polling timeout of the event loop, when
-    called under Chromium's event loop the node's event loop won't get a chance
-    to update the timeout, so we have to force the node's event loop to
-    recalculate the timeout in browser process.
-   */
+  // setTimeout needs to update the polling timeout of the event loop, when
+  // called under Chromium's event loop the node's event loop won't get a chance
+  // to update the timeout, so we have to force the node's event loop to
+  // recalculate the timeout in browser process.
   global.setTimeout = wrapWithActivateUvLoop(timers.setTimeout);
   global.setInterval = wrapWithActivateUvLoop(timers.setInterval);
 }

--- a/atom/common/lib/init.js
+++ b/atom/common/lib/init.js
@@ -21,7 +21,6 @@ process.atomBinding = function(name) {
 };
 
 if (!process.env.ELECTRON_HIDE_INTERNAL_MODULES) {
-
   // Add common/api/lib to module search paths.
   Module.globalPaths.push(path.resolve(__dirname, '..', 'api', 'lib'));
 }
@@ -47,7 +46,6 @@ global.setImmediate = wrapWithActivateUvLoop(timers.setImmediate);
 global.clearImmediate = timers.clearImmediate;
 
 if (process.type === 'browser') {
-
   // setTimeout needs to update the polling timeout of the event loop, when
   // called under Chromium's event loop the node's event loop won't get a chance
   // to update the timeout, so we have to force the node's event loop to

--- a/atom/common/lib/init.js
+++ b/atom/common/lib/init.js
@@ -22,7 +22,7 @@ process.atomBinding = function(name) {
 
 if (!process.env.ELECTRON_HIDE_INTERNAL_MODULES) {
 
-  /* Add common/api/lib to module search paths. */
+  // Add common/api/lib to module search paths.
   Module.globalPaths.push(path.resolve(__dirname, '..', 'api', 'lib'));
 }
 

--- a/atom/common/lib/reset-search-paths.js
+++ b/atom/common/lib/reset-search-paths.js
@@ -5,28 +5,28 @@ path = require('path');
 Module = require('module');
 
 
-/* Clear Node's global search paths. */
+// Clear Node's global search paths.
 
 Module.globalPaths.length = 0;
 
 
-/* Clear current and parent(init.coffee)'s search paths. */
+// Clear current and parent(init.coffee)'s search paths.
 
 module.paths = [];
 
 module.parent.paths = [];
 
 
-/* Prevent Node from adding paths outside this app to search paths. */
+// Prevent Node from adding paths outside this app to search paths.
 
 Module._nodeModulePaths = function(from) {
   var dir, i, part, parts, paths, skipOutsidePaths, splitRe, tip;
   from = path.resolve(from);
 
-  /* If "from" is outside the app then we do nothing. */
+  // If "from" is outside the app then we do nothing.
   skipOutsidePaths = from.startsWith(process.resourcesPath);
 
-  /* Following logoic is copied from module.js. */
+  // Following logoic is copied from module.js.
   splitRe = process.platform === 'win32' ? /[\/\\]/ : /\//;
   paths = [];
   parts = from.split(splitRe);

--- a/atom/common/lib/reset-search-paths.js
+++ b/atom/common/lib/reset-search-paths.js
@@ -4,21 +4,15 @@ path = require('path');
 
 Module = require('module');
 
-
 // Clear Node's global search paths.
-
 Module.globalPaths.length = 0;
 
-
 // Clear current and parent(init.coffee)'s search paths.
-
 module.paths = [];
 
 module.parent.paths = [];
 
-
 // Prevent Node from adding paths outside this app to search paths.
-
 Module._nodeModulePaths = function(from) {
   var dir, i, part, parts, paths, skipOutsidePaths, splitRe, tip;
   from = path.resolve(from);

--- a/atom/renderer/api/lib/desktop-capturer.js
+++ b/atom/renderer/api/lib/desktop-capturer.js
@@ -10,7 +10,7 @@ getNextId = function() {
 };
 
 
-/* |options.type| can not be empty and has to include 'window' or 'screen'. */
+// |options.type| can not be empty and has to include 'window' or 'screen'.
 
 isValid = function(options) {
   return ((options != null ? options.types : void 0) != null) && Array.isArray(options.types);

--- a/atom/renderer/api/lib/desktop-capturer.js
+++ b/atom/renderer/api/lib/desktop-capturer.js
@@ -9,9 +9,7 @@ getNextId = function() {
   return ++nextId;
 };
 
-
 // |options.type| can not be empty and has to include 'window' or 'screen'.
-
 isValid = function(options) {
   return ((options != null ? options.types : void 0) != null) && Array.isArray(options.types);
 };

--- a/atom/renderer/api/lib/exports/electron.js
+++ b/atom/renderer/api/lib/exports/electron.js
@@ -2,13 +2,10 @@ var common;
 
 common = require('../../../../common/api/lib/exports/electron');
 
-
 // Import common modules.
-
 common.defineProperties(exports);
 
 Object.defineProperties(exports, {
-
   // Renderer side modules, please sort with alphabet order.
   desktopCapturer: {
     enumerable: true,

--- a/atom/renderer/api/lib/exports/electron.js
+++ b/atom/renderer/api/lib/exports/electron.js
@@ -3,13 +3,13 @@ var common;
 common = require('../../../../common/api/lib/exports/electron');
 
 
-/* Import common modules. */
+// Import common modules.
 
 common.defineProperties(exports);
 
 Object.defineProperties(exports, {
 
-  /* Renderer side modules, please sort with alphabet order. */
+  // Renderer side modules, please sort with alphabet order.
   desktopCapturer: {
     enumerable: true,
     get: function() {

--- a/atom/renderer/api/lib/ipc-renderer.js
+++ b/atom/renderer/api/lib/ipc-renderer.js
@@ -7,9 +7,7 @@ binding = process.atomBinding('ipc');
 
 v8Util = process.atomBinding('v8_util');
 
-
 // Created by init.coffee.
-
 ipcRenderer = v8Util.getHiddenValue(global, 'ipc');
 
 ipcRenderer.send = function() {

--- a/atom/renderer/api/lib/ipc-renderer.js
+++ b/atom/renderer/api/lib/ipc-renderer.js
@@ -8,7 +8,7 @@ binding = process.atomBinding('ipc');
 v8Util = process.atomBinding('v8_util');
 
 
-/* Created by init.coffee. */
+// Created by init.coffee.
 
 ipcRenderer = v8Util.getHiddenValue(global, 'ipc');
 

--- a/atom/renderer/api/lib/ipc.js
+++ b/atom/renderer/api/lib/ipc.js
@@ -5,14 +5,10 @@ ref = require('electron'), ipcRenderer = ref.ipcRenderer, deprecate = ref.deprec
 
 EventEmitter = require('events').EventEmitter;
 
-
 // This module is deprecated, we mirror everything from ipcRenderer.
-
 deprecate.warn('ipc module', 'require("electron").ipcRenderer');
 
-
 // Routes events of ipcRenderer.
-
 ipc = new EventEmitter;
 
 ipcRenderer.emit = function() {
@@ -22,9 +18,7 @@ ipcRenderer.emit = function() {
   return EventEmitter.prototype.emit.apply(ipcRenderer, arguments);
 };
 
-
 // Deprecated.
-
 for (method in ipcRenderer) {
   if (method.startsWith('send')) {
     ipc[method] = ipcRenderer[method];

--- a/atom/renderer/api/lib/ipc.js
+++ b/atom/renderer/api/lib/ipc.js
@@ -6,12 +6,12 @@ ref = require('electron'), ipcRenderer = ref.ipcRenderer, deprecate = ref.deprec
 EventEmitter = require('events').EventEmitter;
 
 
-/* This module is deprecated, we mirror everything from ipcRenderer. */
+// This module is deprecated, we mirror everything from ipcRenderer.
 
 deprecate.warn('ipc module', 'require("electron").ipcRenderer');
 
 
-/* Routes events of ipcRenderer. */
+// Routes events of ipcRenderer.
 
 ipc = new EventEmitter;
 
@@ -23,7 +23,7 @@ ipcRenderer.emit = function() {
 };
 
 
-/* Deprecated. */
+// Deprecated.
 
 for (method in ipcRenderer) {
   if (method.startsWith('send')) {

--- a/atom/renderer/api/lib/remote.js
+++ b/atom/renderer/api/lib/remote.js
@@ -8,7 +8,7 @@ v8Util = process.atomBinding('v8_util');
 callbacksRegistry = new CallbacksRegistry;
 
 
-/* Check for circular reference. */
+// Check for circular reference.
 
 isCircular = function(field, visited) {
   if (typeof field === 'object') {
@@ -21,7 +21,7 @@ isCircular = function(field, visited) {
 };
 
 
-/* Convert the arguments object into an array of meta data. */
+// Convert the arguments object into an array of meta data.
 
 wrapArgs = function(args, visited) {
   var valueToMeta;
@@ -91,7 +91,7 @@ wrapArgs = function(args, visited) {
 };
 
 
-/* Convert meta data from browser into real value. */
+// Convert meta data from browser into real value.
 
 metaToValue = function(meta) {
   var RemoteFunction, el, i, j, len, len1, member, ref1, ref2, results, ret;
@@ -122,13 +122,13 @@ metaToValue = function(meta) {
     default:
       if (meta.type === 'function') {
 
-        /* A shadow class to represent the remote function object. */
+        // A shadow class to represent the remote function object.
         ret = RemoteFunction = (function() {
           function RemoteFunction() {
             var obj;
             if (this.constructor === RemoteFunction) {
 
-              /* Constructor call. */
+              // Constructor call.
               obj = ipcRenderer.sendSync('ATOM_BROWSER_CONSTRUCTOR', meta.id, wrapArgs(arguments));
 
               /*
@@ -139,7 +139,7 @@ metaToValue = function(meta) {
               return metaToValue(obj);
             } else {
 
-              /* Function call. */
+              // Function call.
               obj = ipcRenderer.sendSync('ATOM_BROWSER_FUNCTION_CALL', meta.id, wrapArgs(arguments));
               return metaToValue(obj);
             }
@@ -152,7 +152,7 @@ metaToValue = function(meta) {
         ret = v8Util.createObjectWithName(meta.name);
       }
 
-      /* Polulate delegate members. */
+      // Polulate delegate members.
       ref2 = meta.members;
       for (j = 0, len1 = ref2.length; j < len1; j++) {
         member = ref2[j];
@@ -171,14 +171,14 @@ metaToValue = function(meta) {
         return ipcRenderer.send('ATOM_BROWSER_DEREFERENCE', meta.id);
       });
 
-      /* Remember object's id. */
+      // Remember object's id.
       v8Util.setHiddenValue(ret, 'atomId', meta.id);
       return ret;
   }
 };
 
 
-/* Construct a plain object from the meta. */
+// Construct a plain object from the meta.
 
 metaToPlainObject = function(meta) {
   var i, len, name, obj, ref1, ref2, value;
@@ -212,12 +212,12 @@ createRemoteMemberFunction = function(metaId, name) {
       var ret;
       if (this.constructor === RemoteMemberFunction) {
 
-        /* Constructor call. */
+        // Constructor call.
         ret = ipcRenderer.sendSync('ATOM_BROWSER_MEMBER_CONSTRUCTOR', metaId, name, wrapArgs(arguments));
         return metaToValue(ret);
       } else {
 
-        /* Call member function. */
+        // Call member function.
         ret = ipcRenderer.sendSync('ATOM_BROWSER_MEMBER_CALL', metaId, name, wrapArgs(arguments));
         return metaToValue(ret);
       }
@@ -241,39 +241,39 @@ createRemoteMemberProperty = function(metaId, name) {
     configurable: false,
     set: function(value) {
 
-      /* Set member data. */
+      // Set member data.
       ipcRenderer.sendSync('ATOM_BROWSER_MEMBER_SET', metaId, name, value);
       return value;
     },
     get: function() {
 
-      /* Get member data. */
+      // Get member data.
       return metaToValue(ipcRenderer.sendSync('ATOM_BROWSER_MEMBER_GET', metaId, name));
     }
   };
 };
 
 
-/* Browser calls a callback in renderer. */
+// Browser calls a callback in renderer.
 
 ipcRenderer.on('ATOM_RENDERER_CALLBACK', function(event, id, args) {
   return callbacksRegistry.apply(id, metaToValue(args));
 });
 
 
-/* A callback in browser is released. */
+// A callback in browser is released.
 
 ipcRenderer.on('ATOM_RENDERER_RELEASE_CALLBACK', function(event, id) {
   return callbacksRegistry.remove(id);
 });
 
 
-/* List all built-in modules in browser process. */
+// List all built-in modules in browser process.
 
 browserModules = require('../../../browser/api/lib/exports/electron');
 
 
-/* And add a helper receiver for each one. */
+// And add a helper receiver for each one.
 
 fn = function(name) {
   return Object.defineProperty(exports, name, {
@@ -305,12 +305,12 @@ exports.require = function(module) {
 };
 
 
-/* Optimize require('electron'). */
+// Optimize require('electron').
 
 moduleCache.electron = exports;
 
 
-/* Alias to remote.require('electron').xxx. */
+// Alias to remote.require('electron').xxx.
 
 builtinCache = {};
 
@@ -324,7 +324,7 @@ exports.getBuiltin = function(module) {
 };
 
 
-/* Get current BrowserWindow object. */
+// Get current BrowserWindow object.
 
 windowCache = null;
 
@@ -338,7 +338,7 @@ exports.getCurrentWindow = function() {
 };
 
 
-/* Get current WebContents object. */
+// Get current WebContents object.
 
 webContentsCache = null;
 
@@ -352,7 +352,7 @@ exports.getCurrentWebContents = function() {
 };
 
 
-/* Get a global object in browser. */
+// Get a global object in browser.
 
 exports.getGlobal = function(name) {
   var meta;
@@ -361,7 +361,7 @@ exports.getGlobal = function(name) {
 };
 
 
-/* Get the process object in browser. */
+// Get the process object in browser.
 
 processCache = null;
 
@@ -373,7 +373,7 @@ exports.__defineGetter__('process', function() {
 });
 
 
-/* Create a funtion that will return the specifed value when called in browser. */
+// Create a funtion that will return the specifed value when called in browser.
 
 exports.createFunctionWithReturnValue = function(returnValue) {
   var func;
@@ -385,7 +385,7 @@ exports.createFunctionWithReturnValue = function(returnValue) {
 };
 
 
-/* Get the guest WebContents from guestInstanceId. */
+// Get the guest WebContents from guestInstanceId.
 
 exports.getGuestWebContents = function(guestInstanceId) {
   var meta;

--- a/atom/renderer/api/lib/remote.js
+++ b/atom/renderer/api/lib/remote.js
@@ -7,9 +7,7 @@ v8Util = process.atomBinding('v8_util');
 
 callbacksRegistry = new CallbacksRegistry;
 
-
 // Check for circular reference.
-
 isCircular = function(field, visited) {
   if (typeof field === 'object') {
     if (indexOf.call(visited, field) >= 0) {
@@ -20,9 +18,7 @@ isCircular = function(field, visited) {
   return false;
 };
 
-
 // Convert the arguments object into an array of meta data.
-
 wrapArgs = function(args, visited) {
   var valueToMeta;
   if (visited == null) {
@@ -90,9 +86,7 @@ wrapArgs = function(args, visited) {
   return Array.prototype.slice.call(args).map(valueToMeta);
 };
 
-
 // Convert meta data from browser into real value.
-
 metaToValue = function(meta) {
   var RemoteFunction, el, i, j, len, len1, member, ref1, ref2, results, ret;
   switch (meta.type) {
@@ -121,7 +115,6 @@ metaToValue = function(meta) {
       break;
     default:
       if (meta.type === 'function') {
-
         // A shadow class to represent the remote function object.
         ret = RemoteFunction = (function() {
           function RemoteFunction() {
@@ -163,10 +156,8 @@ metaToValue = function(meta) {
         }
       }
 
-      /*
-        Track delegate object's life time, and tell the browser to clean up
-        when the object is GCed.
-       */
+      // Track delegate object's life time, and tell the browser to clean up
+      // when the object is GCed.
       v8Util.setDestructor(ret, function() {
         return ipcRenderer.send('ATOM_BROWSER_DEREFERENCE', meta.id);
       });
@@ -177,9 +168,7 @@ metaToValue = function(meta) {
   }
 };
 
-
 // Construct a plain object from the meta.
-
 metaToPlainObject = function(meta) {
   var i, len, name, obj, ref1, ref2, value;
   obj = (function() {
@@ -198,13 +187,9 @@ metaToPlainObject = function(meta) {
   return obj;
 };
 
-
-/*
-  Create a RemoteMemberFunction instance.
-  This function's content should not be inlined into metaToValue, otherwise V8
-  may consider it circular reference.
- */
-
+// Create a RemoteMemberFunction instance.
+// This function's content should not be inlined into metaToValue, otherwise V8
+// may consider it circular reference.
 createRemoteMemberFunction = function(metaId, name) {
   var RemoteMemberFunction;
   return RemoteMemberFunction = (function() {
@@ -228,13 +213,9 @@ createRemoteMemberFunction = function(metaId, name) {
   })();
 };
 
-
-/*
-  Create configuration for defineProperty.
-  This function's content should not be inlined into metaToValue, otherwise V8
-  may consider it circular reference.
- */
-
+// Create configuration for defineProperty.
+// This function's content should not be inlined into metaToValue, otherwise V8
+// may consider it circular reference.
 createRemoteMemberProperty = function(metaId, name) {
   return {
     enumerable: true,
@@ -253,28 +234,20 @@ createRemoteMemberProperty = function(metaId, name) {
   };
 };
 
-
 // Browser calls a callback in renderer.
-
 ipcRenderer.on('ATOM_RENDERER_CALLBACK', function(event, id, args) {
   return callbacksRegistry.apply(id, metaToValue(args));
 });
 
-
 // A callback in browser is released.
-
 ipcRenderer.on('ATOM_RENDERER_RELEASE_CALLBACK', function(event, id) {
   return callbacksRegistry.remove(id);
 });
 
-
 // List all built-in modules in browser process.
-
 browserModules = require('../../../browser/api/lib/exports/electron');
 
-
 // And add a helper receiver for each one.
-
 fn = function(name) {
   return Object.defineProperty(exports, name, {
     get: function() {
@@ -287,12 +260,9 @@ for (name in browserModules) {
 }
 
 
-/*
-  Get remote module.
-  (Just like node's require, the modules are cached permanently, note that this
-  is safe leak since the object is not expected to get freed in browser)
- */
-
+// Get remote module.
+// (Just like node's require, the modules are cached permanently, note that this
+// is safe leak since the object is not expected to get freed in browser)
 moduleCache = {};
 
 exports.require = function(module) {
@@ -306,12 +276,10 @@ exports.require = function(module) {
 
 
 // Optimize require('electron').
-
 moduleCache.electron = exports;
 
 
 // Alias to remote.require('electron').xxx.
-
 builtinCache = {};
 
 exports.getBuiltin = function(module) {
@@ -323,9 +291,7 @@ exports.getBuiltin = function(module) {
   return builtinCache[module] = metaToValue(meta);
 };
 
-
 // Get current BrowserWindow object.
-
 windowCache = null;
 
 exports.getCurrentWindow = function() {
@@ -337,9 +303,7 @@ exports.getCurrentWindow = function() {
   return windowCache = metaToValue(meta);
 };
 
-
 // Get current WebContents object.
-
 webContentsCache = null;
 
 exports.getCurrentWebContents = function() {
@@ -351,18 +315,14 @@ exports.getCurrentWebContents = function() {
   return webContentsCache = metaToValue(meta);
 };
 
-
 // Get a global object in browser.
-
 exports.getGlobal = function(name) {
   var meta;
   meta = ipcRenderer.sendSync('ATOM_BROWSER_GLOBAL', name);
   return metaToValue(meta);
 };
 
-
 // Get the process object in browser.
-
 processCache = null;
 
 exports.__defineGetter__('process', function() {
@@ -372,9 +332,7 @@ exports.__defineGetter__('process', function() {
   return processCache;
 });
 
-
 // Create a funtion that will return the specifed value when called in browser.
-
 exports.createFunctionWithReturnValue = function(returnValue) {
   var func;
   func = function() {
@@ -384,9 +342,7 @@ exports.createFunctionWithReturnValue = function(returnValue) {
   return func;
 };
 
-
 // Get the guest WebContents from guestInstanceId.
-
 exports.getGuestWebContents = function(guestInstanceId) {
   var meta;
   meta = ipcRenderer.sendSync('ATOM_BROWSER_GUEST_WEB_CONTENTS', guestInstanceId);

--- a/atom/renderer/lib/init.js
+++ b/atom/renderer/lib/init.js
@@ -11,21 +11,16 @@ url = require('url');
 Module = require('module');
 
 
-/*
-  We modified the original process.argv to let node.js load the
-  atom-renderer.js, we need to restore it here.
- */
-
+// We modified the original process.argv to let node.js load the
+// atom-renderer.js, we need to restore it here.
 process.argv.splice(1, 1);
 
 
 // Clear search paths.
-
 require(path.resolve(__dirname, '..', '..', 'common', 'lib', 'reset-search-paths'));
 
 
 // Import common settings.
-
 require(path.resolve(__dirname, '..', '..', 'common', 'lib', 'init'));
 
 globalPaths = Module.globalPaths;
@@ -34,14 +29,10 @@ if (!process.env.ELECTRON_HIDE_INTERNAL_MODULES) {
   globalPaths.push(path.resolve(__dirname, '..', 'api', 'lib'));
 }
 
-
 // Expose public APIs.
-
 globalPaths.push(path.resolve(__dirname, '..', 'api', 'lib', 'exports'));
 
-
 // The global variable will be used by ipc for event dispatching
-
 v8Util = process.atomBinding('v8_util');
 
 v8Util.setHiddenValue(global, 'ipc', new events.EventEmitter);
@@ -55,18 +46,15 @@ electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', (event, m
 });
 
 // Process command line arguments.
-
 nodeIntegration = 'false';
 
 ref = process.argv;
 for (i = 0, len = ref.length; i < len; i++) {
   arg = ref[i];
   if (arg.indexOf('--guest-instance-id=') === 0) {
-
     // This is a guest web view.
     process.guestInstanceId = parseInt(arg.substr(arg.indexOf('=') + 1));
   } else if (arg.indexOf('--opener-id=') === 0) {
-
     // This is a guest BrowserWindow.
     process.openerId = parseInt(arg.substr(arg.indexOf('=') + 1));
   } else if (arg.indexOf('--node-integration=') === 0) {
@@ -77,17 +65,14 @@ for (i = 0, len = ref.length; i < len; i++) {
 }
 
 if (location.protocol === 'chrome-devtools:') {
-
   // Override some inspector APIs.
   require('./inspector');
   nodeIntegration = 'true';
 } else if (location.protocol === 'chrome-extension:') {
-
   // Add implementations of chrome API.
   require('./chrome-api');
   nodeIntegration = 'true';
 } else {
-
   // Override default web functions.
   require('./override');
 
@@ -99,7 +84,6 @@ if (location.protocol === 'chrome-devtools:') {
 }
 
 if (nodeIntegration === 'true' || nodeIntegration === 'all' || nodeIntegration === 'except-iframe' || nodeIntegration === 'manual-enable-iframe') {
-
   // Export node bindings to global.
   global.require = require;
   global.module = module;
@@ -135,7 +119,6 @@ if (nodeIntegration === 'true' || nodeIntegration === 'all' || nodeIntegration =
     return process.emit('exit');
   });
 } else {
-
   // Delete Node's symbols after the Environment has been loaded.
   process.once('loaded', function() {
     delete global.process;
@@ -145,9 +128,7 @@ if (nodeIntegration === 'true' || nodeIntegration === 'all' || nodeIntegration =
   });
 }
 
-
 // Load the script specfied by the "preload" attribute.
-
 if (preloadScript) {
   try {
     require(preloadScript);

--- a/atom/renderer/lib/init.js
+++ b/atom/renderer/lib/init.js
@@ -19,12 +19,12 @@ Module = require('module');
 process.argv.splice(1, 1);
 
 
-/* Clear search paths. */
+// Clear search paths.
 
 require(path.resolve(__dirname, '..', '..', 'common', 'lib', 'reset-search-paths'));
 
 
-/* Import common settings. */
+// Import common settings.
 
 require(path.resolve(__dirname, '..', '..', 'common', 'lib', 'init'));
 
@@ -35,12 +35,12 @@ if (!process.env.ELECTRON_HIDE_INTERNAL_MODULES) {
 }
 
 
-/* Expose public APIs. */
+// Expose public APIs.
 
 globalPaths.push(path.resolve(__dirname, '..', 'api', 'lib', 'exports'));
 
 
-/* The global variable will be used by ipc for event dispatching */
+// The global variable will be used by ipc for event dispatching
 
 v8Util = process.atomBinding('v8_util');
 
@@ -54,7 +54,7 @@ electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', (event, m
   electron.webFrame[method].apply(electron.webFrame, args);
 });
 
-/* Process command line arguments. */
+// Process command line arguments.
 
 nodeIntegration = 'false';
 
@@ -63,11 +63,11 @@ for (i = 0, len = ref.length; i < len; i++) {
   arg = ref[i];
   if (arg.indexOf('--guest-instance-id=') === 0) {
 
-    /* This is a guest web view. */
+    // This is a guest web view.
     process.guestInstanceId = parseInt(arg.substr(arg.indexOf('=') + 1));
   } else if (arg.indexOf('--opener-id=') === 0) {
 
-    /* This is a guest BrowserWindow. */
+    // This is a guest BrowserWindow.
     process.openerId = parseInt(arg.substr(arg.indexOf('=') + 1));
   } else if (arg.indexOf('--node-integration=') === 0) {
     nodeIntegration = arg.substr(arg.indexOf('=') + 1);
@@ -78,20 +78,20 @@ for (i = 0, len = ref.length; i < len; i++) {
 
 if (location.protocol === 'chrome-devtools:') {
 
-  /* Override some inspector APIs. */
+  // Override some inspector APIs.
   require('./inspector');
   nodeIntegration = 'true';
 } else if (location.protocol === 'chrome-extension:') {
 
-  /* Add implementations of chrome API. */
+  // Add implementations of chrome API.
   require('./chrome-api');
   nodeIntegration = 'true';
 } else {
 
-  /* Override default web functions. */
+  // Override default web functions.
   require('./override');
 
-  /* Load webview tag implementation. */
+  // Load webview tag implementation.
   if (process.guestInstanceId == null) {
     require('./web-view/web-view');
     require('./web-view/web-view-attributes');
@@ -100,27 +100,27 @@ if (location.protocol === 'chrome-devtools:') {
 
 if (nodeIntegration === 'true' || nodeIntegration === 'all' || nodeIntegration === 'except-iframe' || nodeIntegration === 'manual-enable-iframe') {
 
-  /* Export node bindings to global. */
+  // Export node bindings to global.
   global.require = require;
   global.module = module;
 
-  /* Set the __filename to the path of html file if it is file: protocol. */
+  // Set the __filename to the path of html file if it is file: protocol.
   if (window.location.protocol === 'file:') {
     pathname = process.platform === 'win32' && window.location.pathname[0] === '/' ? window.location.pathname.substr(1) : window.location.pathname;
     global.__filename = path.normalize(decodeURIComponent(pathname));
     global.__dirname = path.dirname(global.__filename);
 
-    /* Set module's filename so relative require can work as expected. */
+    // Set module's filename so relative require can work as expected.
     module.filename = global.__filename;
 
-    /* Also search for module under the html file. */
+    // Also search for module under the html file.
     module.paths = module.paths.concat(Module._nodeModulePaths(global.__dirname));
   } else {
     global.__filename = __filename;
     global.__dirname = __dirname;
   }
 
-  /* Redirect window.onerror to uncaughtException. */
+  // Redirect window.onerror to uncaughtException.
   window.onerror = function(message, filename, lineno, colno, error) {
     if (global.process.listeners('uncaughtException').length > 0) {
       global.process.emit('uncaughtException', error);
@@ -130,13 +130,13 @@ if (nodeIntegration === 'true' || nodeIntegration === 'all' || nodeIntegration =
     }
   };
 
-  /* Emit the 'exit' event when page is unloading. */
+  // Emit the 'exit' event when page is unloading.
   window.addEventListener('unload', function() {
     return process.emit('exit');
   });
 } else {
 
-  /* Delete Node's symbols after the Environment has been loaded. */
+  // Delete Node's symbols after the Environment has been loaded.
   process.once('loaded', function() {
     delete global.process;
     delete global.setImmediate;
@@ -146,7 +146,7 @@ if (nodeIntegration === 'true' || nodeIntegration === 'all' || nodeIntegration =
 }
 
 
-/* Load the script specfied by the "preload" attribute. */
+// Load the script specfied by the "preload" attribute.
 
 if (preloadScript) {
   try {

--- a/atom/renderer/lib/inspector.js
+++ b/atom/renderer/lib/inspector.js
@@ -1,7 +1,6 @@
 var convertToMenuTemplate, createFileSelectorElement, createMenu, pathToHtml5FileObject, showFileChooserDialog;
 
 window.onload = function() {
-
   // Use menu API to show context menu.
   InspectorFrontendHost.showContextMenuAtPoint = createMenu;
 

--- a/atom/renderer/lib/inspector.js
+++ b/atom/renderer/lib/inspector.js
@@ -2,10 +2,10 @@ var convertToMenuTemplate, createFileSelectorElement, createMenu, pathToHtml5Fil
 
 window.onload = function() {
 
-  /* Use menu API to show context menu. */
+  // Use menu API to show context menu.
   InspectorFrontendHost.showContextMenuAtPoint = createMenu;
 
-  /* Use dialog API to override file chooser dialog. */
+  // Use dialog API to override file chooser dialog.
   return WebInspector.createFileSelectorElement = createFileSelectorElement;
 };
 
@@ -52,7 +52,7 @@ createMenu = function(x, y, items, document) {
   Menu = remote.Menu;
   menu = Menu.buildFromTemplate(convertToMenuTemplate(items));
 
-  /* The menu is expected to show asynchronously. */
+  // The menu is expected to show asynchronously.
   return setTimeout(function() {
     return menu.popup(remote.getCurrentWindow());
   });

--- a/atom/renderer/lib/override.js
+++ b/atom/renderer/lib/override.js
@@ -4,7 +4,7 @@ var BrowserWindowProxy, a, getHistoryOperation, ipcRenderer, ref, remote, resolv
 ref = require('electron'), ipcRenderer = ref.ipcRenderer, remote = ref.remote;
 
 
-/* Helper function to resolve relative url. */
+// Helper function to resolve relative url.
 
 a = window.top.document.createElement('a');
 
@@ -14,7 +14,7 @@ resolveURL = function(url) {
 };
 
 
-/* Window object returned by "window.open". */
+// Window object returned by "window.open".
 
 BrowserWindowProxy = (function() {
   BrowserWindowProxy.proxies = {};
@@ -70,14 +70,14 @@ BrowserWindowProxy = (function() {
 
 if (process.guestInstanceId == null) {
 
-  /* Override default window.close. */
+  // Override default window.close.
   window.close = function() {
     return remote.getCurrentWindow().close();
   };
 }
 
 
-/* Make the browser window or guest view emit "new-window" event. */
+// Make the browser window or guest view emit "new-window" event.
 
 window.open = function(url, frameName, features) {
   var feature, guestId, i, ints, j, len, len1, name, options, ref1, ref2, value;
@@ -90,7 +90,7 @@ window.open = function(url, frameName, features) {
   options = {};
   ints = ['x', 'y', 'width', 'height', 'min-width', 'max-width', 'min-height', 'max-height', 'zoom-factor'];
 
-  /* Make sure to get rid of excessive whitespace in the property name */
+  // Make sure to get rid of excessive whitespace in the property name
   ref1 = features.split(/,\s*/);
   for (i = 0, len = ref1.length; i < len; i++) {
     feature = ref1[i];
@@ -117,7 +117,7 @@ window.open = function(url, frameName, features) {
     options.height = 600;
   }
 
-  /* Resolve relative urls. */
+  // Resolve relative urls.
   url = resolveURL(url);
   for (j = 0, len1 = ints.length; j < len1; j++) {
     name = ints[j];
@@ -134,7 +134,7 @@ window.open = function(url, frameName, features) {
 };
 
 
-/* Use the dialog API to implement alert(). */
+// Use the dialog API to implement alert().
 
 window.alert = function(message, title) {
   var buttons;
@@ -149,11 +149,11 @@ window.alert = function(message, title) {
     buttons: buttons
   });
 
-  /* Alert should always return undefined. */
+  // Alert should always return undefined.
 };
 
 
-/* And the confirm(). */
+// And the confirm().
 
 window.confirm = function(message, title) {
   var buttons, cancelId;
@@ -171,7 +171,7 @@ window.confirm = function(message, title) {
 };
 
 
-/* But we do not support prompt(). */
+// But we do not support prompt().
 
 window.prompt = function() {
   throw new Error('prompt() is and will not be supported.');
@@ -183,9 +183,9 @@ if (process.openerId != null) {
 
 ipcRenderer.on('ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', function(event, sourceId, message, sourceOrigin) {
 
-  /* Manually dispatch event instead of using postMessage because we also need to */
+  // Manually dispatch event instead of using postMessage because we also need to
 
-  /* set event.source. */
+  // set event.source.
   event = document.createEvent('Event');
   event.initEvent('message', false, false);
   event.data = message;
@@ -195,7 +195,7 @@ ipcRenderer.on('ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', function(event, sourceId, 
 });
 
 
-/* Forward history operations to browser. */
+// Forward history operations to browser.
 
 sendHistoryOperation = function() {
   var args;
@@ -228,7 +228,7 @@ Object.defineProperty(window.history, 'length', {
 });
 
 
-/* Make document.hidden and document.visibilityState return the correct value. */
+// Make document.hidden and document.visibilityState return the correct value.
 
 Object.defineProperty(document, 'hidden', {
   get: function() {

--- a/atom/renderer/lib/override.js
+++ b/atom/renderer/lib/override.js
@@ -3,9 +3,7 @@ var BrowserWindowProxy, a, getHistoryOperation, ipcRenderer, ref, remote, resolv
 
 ref = require('electron'), ipcRenderer = ref.ipcRenderer, remote = ref.remote;
 
-
 // Helper function to resolve relative url.
-
 a = window.top.document.createElement('a');
 
 resolveURL = function(url) {
@@ -13,9 +11,7 @@ resolveURL = function(url) {
   return a.href;
 };
 
-
 // Window object returned by "window.open".
-
 BrowserWindowProxy = (function() {
   BrowserWindowProxy.proxies = {};
 
@@ -69,16 +65,13 @@ BrowserWindowProxy = (function() {
 })();
 
 if (process.guestInstanceId == null) {
-
   // Override default window.close.
   window.close = function() {
     return remote.getCurrentWindow().close();
   };
 }
 
-
 // Make the browser window or guest view emit "new-window" event.
-
 window.open = function(url, frameName, features) {
   var feature, guestId, i, ints, j, len, len1, name, options, ref1, ref2, value;
   if (frameName == null) {
@@ -133,9 +126,7 @@ window.open = function(url, frameName, features) {
   }
 };
 
-
 // Use the dialog API to implement alert().
-
 window.alert = function(message, title) {
   var buttons;
   if (title == null) {
@@ -152,9 +143,7 @@ window.alert = function(message, title) {
   // Alert should always return undefined.
 };
 
-
 // And the confirm().
-
 window.confirm = function(message, title) {
   var buttons, cancelId;
   if (title == null) {
@@ -170,9 +159,7 @@ window.confirm = function(message, title) {
   });
 };
 
-
 // But we do not support prompt().
-
 window.prompt = function() {
   throw new Error('prompt() is and will not be supported.');
 };
@@ -182,9 +169,7 @@ if (process.openerId != null) {
 }
 
 ipcRenderer.on('ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', function(event, sourceId, message, sourceOrigin) {
-
   // Manually dispatch event instead of using postMessage because we also need to
-
   // set event.source.
   event = document.createEvent('Event');
   event.initEvent('message', false, false);
@@ -194,9 +179,7 @@ ipcRenderer.on('ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', function(event, sourceId, 
   return window.dispatchEvent(event);
 });
 
-
 // Forward history operations to browser.
-
 sendHistoryOperation = function() {
   var args;
   args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
@@ -227,9 +210,7 @@ Object.defineProperty(window.history, 'length', {
   }
 });
 
-
 // Make document.hidden and document.visibilityState return the correct value.
-
 Object.defineProperty(document, 'hidden', {
   get: function() {
     var currentWindow;

--- a/atom/renderer/lib/web-view/web-view-attributes.js
+++ b/atom/renderer/lib/web-view/web-view-attributes.js
@@ -10,9 +10,7 @@ webViewConstants = require('./web-view-constants');
 
 remote = require('electron').remote;
 
-
 // Helper function to resolve url set in attribute.
-
 a = document.createElement('a');
 
 resolveURL = function(url) {
@@ -20,12 +18,8 @@ resolveURL = function(url) {
   return a.href;
 };
 
-
-/*
-  Attribute objects.
-  Default implementation of a WebView attribute.
- */
-
+// Attribute objects.
+// Default implementation of a WebView attribute.
 WebViewAttribute = (function() {
   function WebViewAttribute(name, webViewImpl) {
     this.name = name;
@@ -35,32 +29,24 @@ WebViewAttribute = (function() {
     this.defineProperty();
   }
 
-
   // Retrieves and returns the attribute's value.
-
   WebViewAttribute.prototype.getValue = function() {
     return this.webViewImpl.webviewNode.getAttribute(this.name) || this.value;
   };
 
-
   // Sets the attribute's value.
-
   WebViewAttribute.prototype.setValue = function(value) {
     return this.webViewImpl.webviewNode.setAttribute(this.name, value || '');
   };
 
-
   // Changes the attribute's value without triggering its mutation handler.
-
   WebViewAttribute.prototype.setValueIgnoreMutation = function(value) {
     this.ignoreMutation = true;
     this.setValue(value);
     return this.ignoreMutation = false;
   };
 
-
   // Defines this attribute as a property on the webview node.
-
   WebViewAttribute.prototype.defineProperty = function() {
     return Object.defineProperty(this.webViewImpl.webviewNode, this.name, {
       get: (function(_this) {
@@ -77,18 +63,14 @@ WebViewAttribute = (function() {
     });
   };
 
-
   // Called when the attribute's value changes.
-
   WebViewAttribute.prototype.handleMutation = function() {};
 
   return WebViewAttribute;
 
 })();
 
-
 // An attribute that is treated as a Boolean.
-
 BooleanAttribute = (function(superClass) {
   extend(BooleanAttribute, superClass);
 
@@ -112,9 +94,7 @@ BooleanAttribute = (function(superClass) {
 
 })(WebViewAttribute);
 
-
 // Attribute that specifies whether transparency is allowed in the webview.
-
 AllowTransparencyAttribute = (function(superClass) {
   extend(AllowTransparencyAttribute, superClass);
 
@@ -133,9 +113,7 @@ AllowTransparencyAttribute = (function(superClass) {
 
 })(BooleanAttribute);
 
-
 // Attribute used to define the demension limits of autosizing.
-
 AutosizeDimensionAttribute = (function(superClass) {
   extend(AutosizeDimensionAttribute, superClass);
 
@@ -168,9 +146,7 @@ AutosizeDimensionAttribute = (function(superClass) {
 
 })(WebViewAttribute);
 
-
 // Attribute that specifies whether the webview should be autosized.
-
 AutosizeAttribute = (function(superClass) {
   extend(AutosizeAttribute, superClass);
 
@@ -184,9 +160,7 @@ AutosizeAttribute = (function(superClass) {
 
 })(BooleanAttribute);
 
-
 // Attribute representing the state of the storage partition.
-
 PartitionAttribute = (function(superClass) {
   extend(PartitionAttribute, superClass);
 
@@ -214,9 +188,7 @@ PartitionAttribute = (function(superClass) {
 
 })(WebViewAttribute);
 
-
 // Attribute that handles the location and navigation of the webview.
-
 SrcAttribute = (function(superClass) {
   extend(SrcAttribute, superClass);
 
@@ -236,29 +208,23 @@ SrcAttribute = (function(superClass) {
   SrcAttribute.prototype.setValueIgnoreMutation = function(value) {
     WebViewAttribute.prototype.setValueIgnoreMutation.call(this, value);
 
-    /*
-      takeRecords() is needed to clear queued up src mutations. Without it, it
-      is possible for this change to get picked up asyncronously by src's
-      mutation observer |observer|, and then get handled even though we do not
-      want to handle this mutation.
-     */
+    // takeRecords() is needed to clear queued up src mutations. Without it, it
+    // is possible for this change to get picked up asyncronously by src's
+    // mutation observer |observer|, and then get handled even though we do not
+    // want to handle this mutation.
     return this.observer.takeRecords();
   };
 
   SrcAttribute.prototype.handleMutation = function(oldValue, newValue) {
 
-    /*
-      Once we have navigated, we don't allow clearing the src attribute.
-      Once <webview> enters a navigated state, it cannot return to a
-      placeholder state.
-     */
+    // Once we have navigated, we don't allow clearing the src attribute.
+    // Once <webview> enters a navigated state, it cannot return to a
+    // placeholder state.
     if (!newValue && oldValue) {
 
-      /*
-        src attribute changes normally initiate a navigation. We suppress
-        the next src attribute handler call to avoid reloading the page
-        on every guest-initiated navigation.
-       */
+      // src attribute changes normally initiate a navigation. We suppress
+      // the next src attribute handler call to avoid reloading the page
+      // on every guest-initiated navigation.
       this.setValueIgnoreMutation(oldValue);
       return;
     }
@@ -266,13 +232,10 @@ SrcAttribute = (function(superClass) {
   };
 
 
-  /*
-    The purpose of this mutation observer is to catch assignment to the src
-    attribute without any changes to its value. This is useful in the case
-    where the webview guest has crashed and navigating to the same address
-    spawns off a new process.
-   */
-
+  // The purpose of this mutation observer is to catch assignment to the src
+  // attribute without any changes to its value. This is useful in the case
+  // where the webview guest has crashed and navigating to the same address
+  // spawns off a new process.
   SrcAttribute.prototype.setupMutationObserver = function() {
     var params;
     this.observer = new MutationObserver((function(_this) {
@@ -328,9 +291,7 @@ SrcAttribute = (function(superClass) {
 
 })(WebViewAttribute);
 
-
 // Attribute specifies HTTP referrer.
-
 HttpReferrerAttribute = (function(superClass) {
   extend(HttpReferrerAttribute, superClass);
 
@@ -342,9 +303,7 @@ HttpReferrerAttribute = (function(superClass) {
 
 })(WebViewAttribute);
 
-
 // Attribute specifies user agent
-
 UserAgentAttribute = (function(superClass) {
   extend(UserAgentAttribute, superClass);
 
@@ -356,9 +315,7 @@ UserAgentAttribute = (function(superClass) {
 
 })(WebViewAttribute);
 
-
 // Attribute that set preload script.
-
 PreloadAttribute = (function(superClass) {
   extend(PreloadAttribute, superClass);
 
@@ -384,9 +341,7 @@ PreloadAttribute = (function(superClass) {
 
 })(WebViewAttribute);
 
-
 // Sets up all of the webview attributes.
-
 WebViewImpl.prototype.setupWebViewAttributes = function() {
   var attribute, autosizeAttributes, i, len, results;
   this.attributes = {};

--- a/atom/renderer/lib/web-view/web-view-attributes.js
+++ b/atom/renderer/lib/web-view/web-view-attributes.js
@@ -11,7 +11,7 @@ webViewConstants = require('./web-view-constants');
 remote = require('electron').remote;
 
 
-/* Helper function to resolve url set in attribute. */
+// Helper function to resolve url set in attribute.
 
 a = document.createElement('a');
 
@@ -36,21 +36,21 @@ WebViewAttribute = (function() {
   }
 
 
-  /* Retrieves and returns the attribute's value. */
+  // Retrieves and returns the attribute's value.
 
   WebViewAttribute.prototype.getValue = function() {
     return this.webViewImpl.webviewNode.getAttribute(this.name) || this.value;
   };
 
 
-  /* Sets the attribute's value. */
+  // Sets the attribute's value.
 
   WebViewAttribute.prototype.setValue = function(value) {
     return this.webViewImpl.webviewNode.setAttribute(this.name, value || '');
   };
 
 
-  /* Changes the attribute's value without triggering its mutation handler. */
+  // Changes the attribute's value without triggering its mutation handler.
 
   WebViewAttribute.prototype.setValueIgnoreMutation = function(value) {
     this.ignoreMutation = true;
@@ -59,7 +59,7 @@ WebViewAttribute = (function() {
   };
 
 
-  /* Defines this attribute as a property on the webview node. */
+  // Defines this attribute as a property on the webview node.
 
   WebViewAttribute.prototype.defineProperty = function() {
     return Object.defineProperty(this.webViewImpl.webviewNode, this.name, {
@@ -78,7 +78,7 @@ WebViewAttribute = (function() {
   };
 
 
-  /* Called when the attribute's value changes. */
+  // Called when the attribute's value changes.
 
   WebViewAttribute.prototype.handleMutation = function() {};
 
@@ -87,7 +87,7 @@ WebViewAttribute = (function() {
 })();
 
 
-/* An attribute that is treated as a Boolean. */
+// An attribute that is treated as a Boolean.
 
 BooleanAttribute = (function(superClass) {
   extend(BooleanAttribute, superClass);
@@ -113,7 +113,7 @@ BooleanAttribute = (function(superClass) {
 })(WebViewAttribute);
 
 
-/* Attribute that specifies whether transparency is allowed in the webview. */
+// Attribute that specifies whether transparency is allowed in the webview.
 
 AllowTransparencyAttribute = (function(superClass) {
   extend(AllowTransparencyAttribute, superClass);
@@ -134,7 +134,7 @@ AllowTransparencyAttribute = (function(superClass) {
 })(BooleanAttribute);
 
 
-/* Attribute used to define the demension limits of autosizing. */
+// Attribute used to define the demension limits of autosizing.
 
 AutosizeDimensionAttribute = (function(superClass) {
   extend(AutosizeDimensionAttribute, superClass);
@@ -169,7 +169,7 @@ AutosizeDimensionAttribute = (function(superClass) {
 })(WebViewAttribute);
 
 
-/* Attribute that specifies whether the webview should be autosized. */
+// Attribute that specifies whether the webview should be autosized.
 
 AutosizeAttribute = (function(superClass) {
   extend(AutosizeAttribute, superClass);
@@ -185,7 +185,7 @@ AutosizeAttribute = (function(superClass) {
 })(BooleanAttribute);
 
 
-/* Attribute representing the state of the storage partition. */
+// Attribute representing the state of the storage partition.
 
 PartitionAttribute = (function(superClass) {
   extend(PartitionAttribute, superClass);
@@ -198,7 +198,7 @@ PartitionAttribute = (function(superClass) {
   PartitionAttribute.prototype.handleMutation = function(oldValue, newValue) {
     newValue = newValue || '';
 
-    /* The partition cannot change if the webview has already navigated. */
+    // The partition cannot change if the webview has already navigated.
     if (!this.webViewImpl.beforeFirstNavigation) {
       window.console.error(webViewConstants.ERROR_MSG_ALREADY_NAVIGATED);
       this.setValueIgnoreMutation(oldValue);
@@ -215,7 +215,7 @@ PartitionAttribute = (function(superClass) {
 })(WebViewAttribute);
 
 
-/* Attribute that handles the location and navigation of the webview. */
+// Attribute that handles the location and navigation of the webview.
 
 SrcAttribute = (function(superClass) {
   extend(SrcAttribute, superClass);
@@ -310,7 +310,7 @@ SrcAttribute = (function(superClass) {
       return;
     }
 
-    /* Navigate to |this.src|. */
+    // Navigate to |this.src|.
     opts = {};
     httpreferrer = this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER].getValue();
     if (httpreferrer) {
@@ -329,7 +329,7 @@ SrcAttribute = (function(superClass) {
 })(WebViewAttribute);
 
 
-/* Attribute specifies HTTP referrer. */
+// Attribute specifies HTTP referrer.
 
 HttpReferrerAttribute = (function(superClass) {
   extend(HttpReferrerAttribute, superClass);
@@ -343,7 +343,7 @@ HttpReferrerAttribute = (function(superClass) {
 })(WebViewAttribute);
 
 
-/* Attribute specifies user agent */
+// Attribute specifies user agent
 
 UserAgentAttribute = (function(superClass) {
   extend(UserAgentAttribute, superClass);
@@ -357,7 +357,7 @@ UserAgentAttribute = (function(superClass) {
 })(WebViewAttribute);
 
 
-/* Attribute that set preload script. */
+// Attribute that set preload script.
 
 PreloadAttribute = (function(superClass) {
   extend(PreloadAttribute, superClass);
@@ -385,7 +385,7 @@ PreloadAttribute = (function(superClass) {
 })(WebViewAttribute);
 
 
-/* Sets up all of the webview attributes. */
+// Sets up all of the webview attributes.
 
 WebViewImpl.prototype.setupWebViewAttributes = function() {
   var attribute, autosizeAttributes, i, len, results;

--- a/atom/renderer/lib/web-view/web-view-constants.js
+++ b/atom/renderer/lib/web-view/web-view-constants.js
@@ -1,5 +1,4 @@
 module.exports = {
-
   // Attributes.
   ATTRIBUTE_ALLOWTRANSPARENCY: 'allowtransparency',
   ATTRIBUTE_AUTOSIZE: 'autosize',

--- a/atom/renderer/lib/web-view/web-view-constants.js
+++ b/atom/renderer/lib/web-view/web-view-constants.js
@@ -1,6 +1,6 @@
 module.exports = {
 
-  /* Attributes. */
+  // Attributes.
   ATTRIBUTE_ALLOWTRANSPARENCY: 'allowtransparency',
   ATTRIBUTE_AUTOSIZE: 'autosize',
   ATTRIBUTE_MAXHEIGHT: 'maxheight',
@@ -18,10 +18,10 @@ module.exports = {
   ATTRIBUTE_PRELOAD: 'preload',
   ATTRIBUTE_USERAGENT: 'useragent',
 
-  /* Internal attribute. */
+  // Internal attribute.
   ATTRIBUTE_INTERNALINSTANCEID: 'internalinstanceid',
 
-  /* Error messages. */
+  // Error messages.
   ERROR_MSG_ALREADY_NAVIGATED: 'The object has already navigated, so its partition cannot be changed.',
   ERROR_MSG_CANNOT_INJECT_SCRIPT: '<webview>: ' + 'Script cannot be injected into content until the page has loaded.',
   ERROR_MSG_INVALID_PARTITION_ATTRIBUTE: 'Invalid partition attribute.',

--- a/atom/renderer/lib/web-view/web-view.js
+++ b/atom/renderer/lib/web-view/web-view.js
@@ -13,7 +13,7 @@ guestViewInternal = require('./guest-view-internal');
 webViewConstants = require('./web-view-constants');
 
 
-/* ID generator. */
+// ID generator.
 
 nextId = 0;
 
@@ -22,7 +22,7 @@ getNextId = function() {
 };
 
 
-/* Represents the internal state of the WebView node. */
+// Represents the internal state of the WebView node.
 
 WebViewImpl = (function() {
   function WebViewImpl(webviewNode) {
@@ -33,7 +33,7 @@ WebViewImpl = (function() {
     this.elementAttached = false;
     this.beforeFirstNavigation = true;
 
-    /* on* Event handlers. */
+    // on* Event handlers.
     this.on = {};
     this.browserPluginNode = this.createBrowserPluginNode();
     shadowRoot = this.webviewNode.createShadowRoot();
@@ -62,7 +62,7 @@ WebViewImpl = (function() {
   };
 
 
-  /* Resets some state upon reattaching <webview> element to the DOM. */
+  // Resets some state upon reattaching <webview> element to the DOM.
 
   WebViewImpl.prototype.reset = function() {
     // Unlisten the zoom-level-changed event.
@@ -87,7 +87,7 @@ WebViewImpl = (function() {
   };
 
 
-  /* Sets the <webview>.request property. */
+  // Sets the <webview>.request property.
 
   WebViewImpl.prototype.setRequestPropertyOnWebViewNode = function(request) {
     return Object.defineProperty(this.webviewNode, 'request', {
@@ -110,14 +110,14 @@ WebViewImpl = (function() {
     this.webviewNode.addEventListener('focus', (function(_this) {
       return function(e) {
 
-        /* Focus the BrowserPlugin when the <webview> takes focus. */
+        // Focus the BrowserPlugin when the <webview> takes focus.
         return _this.browserPluginNode.focus();
       };
     })(this));
     return this.webviewNode.addEventListener('blur', (function(_this) {
       return function(e) {
 
-        /* Blur the BrowserPlugin when the <webview> loses focus. */
+        // Blur the BrowserPlugin when the <webview> loses focus.
         return _this.browserPluginNode.blur();
       };
     })(this));
@@ -137,7 +137,7 @@ WebViewImpl = (function() {
       return;
     }
 
-    /* Let the changed attribute handle its own mutation; */
+    // Let the changed attribute handle its own mutation;
     return this.attributes[attributeName].handleMutation(oldValue, newValue);
   };
 
@@ -146,7 +146,7 @@ WebViewImpl = (function() {
       this.browserPluginNode.removeAttribute(webViewConstants.ATTRIBUTE_INTERNALINSTANCEID);
       this.internalInstanceId = parseInt(newValue);
 
-      /* Track when the element resizes using the element resize callback. */
+      // Track when the element resizes using the element resize callback.
       webFrame.registerElementResizeCallback(this.internalInstanceId, this.onElementResize.bind(this));
       if (!this.guestInstanceId) {
         return;
@@ -163,9 +163,9 @@ WebViewImpl = (function() {
     width = node.offsetWidth;
     height = node.offsetHeight;
 
-    /* Check the current bounds to make sure we do not resize <webview> */
+    // Check the current bounds to make sure we do not resize <webview>
 
-    /* outside of current constraints. */
+    // outside of current constraints.
     maxWidth = this.attributes[webViewConstants.ATTRIBUTE_MAXWIDTH].getValue() | width;
     maxHeight = this.attributes[webViewConstants.ATTRIBUTE_MAXHEIGHT].getValue() | width;
     minWidth = this.attributes[webViewConstants.ATTRIBUTE_MINWIDTH].getValue() | width;
@@ -186,7 +186,7 @@ WebViewImpl = (function() {
 
   WebViewImpl.prototype.onElementResize = function(newSize) {
 
-    /* Dispatch the 'resize' event. */
+    // Dispatch the 'resize' event.
     var resizeEvent;
     resizeEvent = new Event('resize', {
       bubbles: true
@@ -214,10 +214,10 @@ WebViewImpl = (function() {
   };
 
 
-  /* Adds an 'on<event>' property on the webview, which can be used to set/unset */
+  // Adds an 'on<event>' property on the webview, which can be used to set/unset
 
 
-  /* an event handler. */
+  // an event handler.
 
   WebViewImpl.prototype.setupEventProperty = function(eventName) {
     var propertyName;
@@ -244,7 +244,7 @@ WebViewImpl = (function() {
   };
 
 
-  /* Updates state upon loadcommit. */
+  // Updates state upon loadcommit.
 
   WebViewImpl.prototype.onLoadCommit = function(webViewEvent) {
     var newValue, oldValue;
@@ -306,7 +306,7 @@ WebViewImpl = (function() {
 })();
 
 
-/* Registers browser plugin <object> custom element. */
+// Registers browser plugin <object> custom element.
 
 registerBrowserPluginElement = function() {
   var proto;
@@ -315,7 +315,7 @@ registerBrowserPluginElement = function() {
     this.setAttribute('type', 'application/browser-plugin');
     this.setAttribute('id', 'browser-plugin-' + getNextId());
 
-    /* The <object> node fills in the <webview> container. */
+    // The <object> node fills in the <webview> container.
     this.style.display = 'block';
     this.style.width = '100%';
     return this.style.height = '100%';
@@ -330,7 +330,7 @@ registerBrowserPluginElement = function() {
   };
   proto.attachedCallback = function() {
 
-    /* Load the plugin immediately. */
+    // Load the plugin immediately.
     var unused;
     return unused = this.nonExistentAttribute;
   };
@@ -345,7 +345,7 @@ registerBrowserPluginElement = function() {
 };
 
 
-/* Registers <webview> custom element. */
+// Registers <webview> custom element.
 
 registerWebViewElement = function() {
   var createBlockHandler, createNonBlockHandler, i, j, len, len1, m, methods, nonblockMethods, proto;
@@ -384,7 +384,7 @@ registerWebViewElement = function() {
     }
   };
 
-  /* Public-facing API methods. */
+  // Public-facing API methods.
   methods = ['getURL', 'getTitle', 'isLoading', 'isWaitingForResponse', 'stop', 'reload', 'reloadIgnoringCache', 'canGoBack', 'canGoForward', 'canGoToOffset', 'clearHistory', 'goBack', 'goForward', 'goToIndex', 'goToOffset', 'isCrashed', 'setUserAgent', 'getUserAgent', 'openDevTools', 'closeDevTools', 'isDevToolsOpened', 'isDevToolsFocused', 'inspectElement', 'setAudioMuted', 'isAudioMuted', 'undo', 'redo', 'cut', 'copy', 'paste', 'pasteAndMatchStyle', 'delete', 'selectAll', 'unselect', 'replace', 'replaceMisspelling', 'findInPage', 'stopFindInPage', 'getId', 'downloadURL', 'inspectServiceWorker', 'print', 'printToPDF'];
   nonblockMethods = [
     'executeJavaScript',
@@ -397,7 +397,7 @@ registerWebViewElement = function() {
     'setZoomLevelLimits',
   ];
 
-  /* Forward proto.foo* method calls to WebViewImpl.foo*. */
+  // Forward proto.foo* method calls to WebViewImpl.foo*.
   createBlockHandler = function(m) {
     return function() {
       var args, internal, ref1;
@@ -423,15 +423,16 @@ registerWebViewElement = function() {
     proto[m] = createNonBlockHandler(m);
   }
 
-  /* Deprecated. */
+  // Deprecated.
   deprecate.rename(proto, 'getUrl', 'getURL');
   window.WebView = webFrame.registerEmbedderCustomElement('webview', {
     prototype: proto
   });
 
-  /* Delete the callbacks so developers cannot call them and produce unexpected */
-
-  /* behavior. */
+  /*
+    Delete the callbacks so developers cannot call them and produce unexpected
+    behavior.
+   */
   delete proto.createdCallback;
   delete proto.attachedCallback;
   delete proto.detachedCallback;


### PR DESCRIPTION
Convert `/* */` comments to `//` and remove extra newlines left over from the CoffeeScript to JavaScript migration.

Follow on from #4065 

/cc @jlord :pear: 