### PR TITLE
Animate window resizing on OS X

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -338,29 +338,19 @@ bool Window::IsFullscreen() {
   return window_->IsFullscreen();
 }
 
-void Window::SetBounds(mate::Arguments* args) {
-  gfx::Rect rect;
+void Window::SetBounds(const gfx::Rect& bounds, mate::Arguments* args) {
   bool animate = false;
-  if (!args->GetNext(&rect) ||
-      (args->Length() == 2 && !args->GetNext(&animate))) {
-    args->ThrowError();
-    return;
-  }
-  window_->SetBounds(rect, animate);
+  args->GetNext(&animate);
+  window_->SetBounds(bounds, animate);
 }
 
 gfx::Rect Window::GetBounds() {
   return window_->GetBounds();
 }
 
-void Window::SetSize(mate::Arguments* args) {
-  int width = 0, height = 0;
+void Window::SetSize(int width, int height, mate::Arguments* args) {
   bool animate = false;
-  if (!args->GetNext(&width) || !args->GetNext(&height) ||
-      (args->Length() == 3 && !args->GetNext(&animate))) {
-    args->ThrowError();
-    return;
-  }
+  args->GetNext(&animate);
   window_->SetSize(gfx::Size(width, height), animate);
 }
 
@@ -372,14 +362,9 @@ std::vector<int> Window::GetSize() {
   return result;
 }
 
-void Window::SetContentSize(mate::Arguments* args) {
-  int width = 0, height = 0;
+void Window::SetContentSize(int width, int height, mate::Arguments* args) {
   bool animate = false;
-  if (!args->GetNext(&width) || !args->GetNext(&height) ||
-      (args->Length() == 3 && !args->GetNext(&animate))) {
-    args->ThrowError();
-    return;
-  }
+  args->GetNext(&animate);
   window_->SetContentSize(gfx::Size(width, height), animate);
 }
 
@@ -435,14 +420,9 @@ void Window::Center() {
   window_->Center();
 }
 
-void Window::SetPosition(mate::Arguments* args) {
-  int x = 0, y = 0;
+void Window::SetPosition(int x, int y, mate::Arguments* args) {
   bool animate = false;
-  if (!args->GetNext(&x) || !args->GetNext(&y) ||
-      (args->Length() == 3 && !args->GetNext(&animate))) {
-    args->ThrowError();
-    return;
-  }
+  args->GetNext(&animate);
   window_->SetPosition(gfx::Point(x, y), animate);
 }
 

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -338,16 +338,30 @@ bool Window::IsFullscreen() {
   return window_->IsFullscreen();
 }
 
-void Window::SetBounds(const gfx::Rect& bounds) {
-  window_->SetBounds(bounds);
+void Window::SetBounds(mate::Arguments* args) {
+  gfx::Rect rect;
+  bool animate = false;
+  if (!args->GetNext(&rect) ||
+      (args->Length() == 2 && !args->GetNext(&animate))) {
+    args->ThrowError();
+    return;
+  }
+  window_->SetBounds(rect, animate);
 }
 
 gfx::Rect Window::GetBounds() {
   return window_->GetBounds();
 }
 
-void Window::SetSize(int width, int height) {
-  window_->SetSize(gfx::Size(width, height));
+void Window::SetSize(mate::Arguments* args) {
+  int width = 0, height = 0;
+  bool animate = false;
+  if (!args->GetNext(&width) || !args->GetNext(&height) ||
+      (args->Length() == 3 && !args->GetNext(&animate))) {
+    args->ThrowError();
+    return;
+  }
+  window_->SetSize(gfx::Size(width, height), animate);
 }
 
 std::vector<int> Window::GetSize() {
@@ -358,8 +372,15 @@ std::vector<int> Window::GetSize() {
   return result;
 }
 
-void Window::SetContentSize(int width, int height) {
-  window_->SetContentSize(gfx::Size(width, height));
+void Window::SetContentSize(mate::Arguments* args) {
+  int width = 0, height = 0;
+  bool animate = false;
+  if (!args->GetNext(&width) || !args->GetNext(&height) ||
+      (args->Length() == 3 && !args->GetNext(&animate))) {
+    args->ThrowError();
+    return;
+  }
+  window_->SetContentSize(gfx::Size(width, height), animate);
 }
 
 std::vector<int> Window::GetContentSize() {
@@ -414,8 +435,15 @@ void Window::Center() {
   window_->Center();
 }
 
-void Window::SetPosition(int x, int y) {
-  window_->SetPosition(gfx::Point(x, y));
+void Window::SetPosition(mate::Arguments* args) {
+  int x = 0, y = 0;
+  bool animate = false;
+  if (!args->GetNext(&x) || !args->GetNext(&y) ||
+      (args->Length() == 3 && !args->GetNext(&animate))) {
+    args->ThrowError();
+    return;
+  }
+  window_->SetPosition(gfx::Point(x, y), animate);
 }
 
 std::vector<int> Window::GetPosition() {

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -94,11 +94,11 @@ class Window : public mate::TrackableObject<Window>,
   bool IsMinimized();
   void SetFullScreen(bool fullscreen);
   bool IsFullscreen();
-  void SetBounds(mate::Arguments* args);
+  void SetBounds(const gfx::Rect& bounds, mate::Arguments* args);
   gfx::Rect GetBounds();
-  void SetSize(mate::Arguments* args);
+  void SetSize(int width, int height, mate::Arguments* args);
   std::vector<int> GetSize();
-  void SetContentSize(mate::Arguments* args);
+  void SetContentSize(int width, int height, mate::Arguments* args);
   std::vector<int> GetContentSize();
   void SetMinimumSize(int width, int height);
   std::vector<int> GetMinimumSize();
@@ -109,7 +109,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetAlwaysOnTop(bool top);
   bool IsAlwaysOnTop();
   void Center();
-  void SetPosition(mate::Arguments* args);
+  void SetPosition(int x, int y, mate::Arguments* args);
   std::vector<int> GetPosition();
   void SetTitle(const std::string& title);
   std::string GetTitle();

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -94,11 +94,11 @@ class Window : public mate::TrackableObject<Window>,
   bool IsMinimized();
   void SetFullScreen(bool fullscreen);
   bool IsFullscreen();
-  void SetBounds(const gfx::Rect& bounds);
+  void SetBounds(mate::Arguments* args);
   gfx::Rect GetBounds();
-  void SetSize(int width, int height);
+  void SetSize(mate::Arguments* args);
   std::vector<int> GetSize();
-  void SetContentSize(int width, int height);
+  void SetContentSize(mate::Arguments* args);
   std::vector<int> GetContentSize();
   void SetMinimumSize(int width, int height);
   std::vector<int> GetMinimumSize();
@@ -109,7 +109,7 @@ class Window : public mate::TrackableObject<Window>,
   void SetAlwaysOnTop(bool top);
   bool IsAlwaysOnTop();
   void Center();
-  void SetPosition(int x, int y);
+  void SetPosition(mate::Arguments* args);
   std::vector<int> GetPosition();
   void SetTitle(const std::string& title);
   std::string GetTitle();

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -92,7 +92,7 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   int x = -1, y = -1;
   bool center;
   if (options.Get(options::kX, &x) && options.Get(options::kY, &y)) {
-    SetPosition(gfx::Point(x, y));
+    SetPosition(gfx::Point(x, y), false);
   } else if (options.Get(options::kCenter, &center) && center) {
     Center();
   }
@@ -154,24 +154,24 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
     Show();
 }
 
-void NativeWindow::SetSize(const gfx::Size& size) {
-  SetBounds(gfx::Rect(GetPosition(), size));
+void NativeWindow::SetSize(const gfx::Size& size, bool animate) {
+  SetBounds(gfx::Rect(GetPosition(), size), animate);
 }
 
 gfx::Size NativeWindow::GetSize() {
   return GetBounds().size();
 }
 
-void NativeWindow::SetPosition(const gfx::Point& position) {
-  SetBounds(gfx::Rect(position, GetSize()));
+void NativeWindow::SetPosition(const gfx::Point& position, bool animate) {
+  SetBounds(gfx::Rect(position, GetSize()), animate);
 }
 
 gfx::Point NativeWindow::GetPosition() {
   return GetBounds().origin();
 }
 
-void NativeWindow::SetContentSize(const gfx::Size& size) {
-  SetSize(ContentSizeToWindowSize(size));
+void NativeWindow::SetContentSize(const gfx::Size& size, bool animate) {
+  SetSize(ContentSizeToWindowSize(size), animate);
 }
 
 gfx::Size NativeWindow::GetContentSize() {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -92,7 +92,7 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   int x = -1, y = -1;
   bool center;
   if (options.Get(options::kX, &x) && options.Get(options::kY, &y)) {
-    SetPosition(gfx::Point(x, y), false);
+    SetPosition(gfx::Point(x, y));
   } else if (options.Get(options::kCenter, &center) && center) {
     Center();
   }

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -105,13 +105,13 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsMinimized() = 0;
   virtual void SetFullScreen(bool fullscreen) = 0;
   virtual bool IsFullscreen() const = 0;
-  virtual void SetBounds(const gfx::Rect& bounds, bool animate) = 0;
+  virtual void SetBounds(const gfx::Rect& bounds, bool animate = false) = 0;
   virtual gfx::Rect GetBounds() = 0;
-  virtual void SetSize(const gfx::Size& size, bool animate);
+  virtual void SetSize(const gfx::Size& size, bool animate = false);
   virtual gfx::Size GetSize();
-  virtual void SetPosition(const gfx::Point& position, bool animate);
+  virtual void SetPosition(const gfx::Point& position, bool animate = false);
   virtual gfx::Point GetPosition();
-  virtual void SetContentSize(const gfx::Size& size, bool animate);
+  virtual void SetContentSize(const gfx::Size& size, bool animate = false);
   virtual gfx::Size GetContentSize();
   virtual void SetSizeConstraints(
       const extensions::SizeConstraints& size_constraints);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -105,13 +105,13 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsMinimized() = 0;
   virtual void SetFullScreen(bool fullscreen) = 0;
   virtual bool IsFullscreen() const = 0;
-  virtual void SetBounds(const gfx::Rect& bounds) = 0;
+  virtual void SetBounds(const gfx::Rect& bounds, bool animate) = 0;
   virtual gfx::Rect GetBounds() = 0;
-  virtual void SetSize(const gfx::Size& size);
+  virtual void SetSize(const gfx::Size& size, bool animate);
   virtual gfx::Size GetSize();
-  virtual void SetPosition(const gfx::Point& position);
+  virtual void SetPosition(const gfx::Point& position, bool animate);
   virtual gfx::Point GetPosition();
-  virtual void SetContentSize(const gfx::Size& size);
+  virtual void SetContentSize(const gfx::Size& size, bool animate);
   virtual gfx::Size GetContentSize();
   virtual void SetSizeConstraints(
       const extensions::SizeConstraints& size_constraints);

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -42,7 +42,7 @@ class NativeWindowMac : public NativeWindow {
   bool IsMinimized() override;
   void SetFullScreen(bool fullscreen) override;
   bool IsFullscreen() const override;
-  void SetBounds(const gfx::Rect& bounds) override;
+  void SetBounds(const gfx::Rect& bounds, bool animate) override;
   gfx::Rect GetBounds() override;
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -42,7 +42,7 @@ class NativeWindowMac : public NativeWindow {
   bool IsMinimized() override;
   void SetFullScreen(bool fullscreen) override;
   bool IsFullscreen() const override;
-  void SetBounds(const gfx::Rect& bounds, bool animate) override;
+  void SetBounds(const gfx::Rect& bounds, bool animate = false) override;
   gfx::Rect GetBounds() override;
   void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -456,7 +456,7 @@ NativeWindowMac::NativeWindowMac(
   bool use_content_size = false;
   options.Get(options::kUseContentSize, &use_content_size);
   if (!has_frame() || !use_content_size)
-    SetSize(gfx::Size(width, height));
+    SetSize(gfx::Size(width, height), false);
 
   // Enable the NSView to accept first mouse event.
   bool acceptsFirstMouse = false;
@@ -576,7 +576,7 @@ bool NativeWindowMac::IsFullscreen() const {
   return [window_ styleMask] & NSFullScreenWindowMask;
 }
 
-void NativeWindowMac::SetBounds(const gfx::Rect& bounds) {
+void NativeWindowMac::SetBounds(const gfx::Rect& bounds, bool animate) {
   NSRect cocoa_bounds = NSMakeRect(bounds.x(), 0,
                                    bounds.width(),
                                    bounds.height());
@@ -585,7 +585,7 @@ void NativeWindowMac::SetBounds(const gfx::Rect& bounds) {
   cocoa_bounds.origin.y =
       NSHeight([screen frame]) - bounds.height() - bounds.y();
 
-  [window_ setFrame:cocoa_bounds display:YES];
+  [window_ setFrame:cocoa_bounds display:YES animate:animate];
 }
 
 gfx::Rect NativeWindowMac::GetBounds() {

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -456,7 +456,7 @@ NativeWindowMac::NativeWindowMac(
   bool use_content_size = false;
   options.Get(options::kUseContentSize, &use_content_size);
   if (!has_frame() || !use_content_size)
-    SetSize(gfx::Size(width, height), false);
+    SetSize(gfx::Size(width, height));
 
   // Enable the NSView to accept first mouse event.
   bool acceptsFirstMouse = false;

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -375,7 +375,7 @@ bool NativeWindowViews::IsFullscreen() const {
   return window_->IsFullscreen();
 }
 
-void NativeWindowViews::SetBounds(const gfx::Rect& bounds, bool animate) {
+void NativeWindowViews::SetBounds(const gfx::Rect& bounds, bool animate = false) {
 #if defined(USE_X11)
   // On Linux the minimum and maximum size should be updated with window size
   // when window is not resizable.
@@ -586,7 +586,7 @@ void NativeWindowViews::SetMenu(ui::MenuModel* menu_model) {
         SetContentSizeConstraints(constraints);
 
         // Resize the window to make sure content size is not changed.
-        SetContentSize(content_size, false);
+        SetContentSize(content_size);
       }
     }
   }

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -375,7 +375,8 @@ bool NativeWindowViews::IsFullscreen() const {
   return window_->IsFullscreen();
 }
 
-void NativeWindowViews::SetBounds(const gfx::Rect& bounds, bool animate = false) {
+void NativeWindowViews::SetBounds(const gfx::Rect& bounds,
+    bool animate = false) {
 #if defined(USE_X11)
   // On Linux the minimum and maximum size should be updated with window size
   // when window is not resizable.

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -375,7 +375,7 @@ bool NativeWindowViews::IsFullscreen() const {
   return window_->IsFullscreen();
 }
 
-void NativeWindowViews::SetBounds(const gfx::Rect& bounds) {
+void NativeWindowViews::SetBounds(const gfx::Rect& bounds, bool animate) {
 #if defined(USE_X11)
   // On Linux the minimum and maximum size should be updated with window size
   // when window is not resizable.
@@ -586,7 +586,7 @@ void NativeWindowViews::SetMenu(ui::MenuModel* menu_model) {
         SetContentSizeConstraints(constraints);
 
         // Resize the window to make sure content size is not changed.
-        SetContentSize(content_size);
+        SetContentSize(content_size, false);
       }
     }
   }

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -61,7 +61,7 @@ class NativeWindowViews : public NativeWindow,
   bool IsMinimized() override;
   void SetFullScreen(bool fullscreen) override;
   bool IsFullscreen() const override;
-  void SetBounds(const gfx::Rect& bounds) override;
+  void SetBounds(const gfx::Rect& bounds, bool animate) override;
   gfx::Rect GetBounds() override;
   gfx::Size GetContentSize() override;
   void SetContentSizeConstraints(

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -121,7 +121,7 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
 
             // When the window is restored we resize it to the previous known
             // normal size.
-            NativeWindow::SetSize(last_normal_size_);
+            NativeWindow::SetSize(last_normal_size_, false);
 
             NotifyWindowUnmaximize();
             break;
@@ -134,7 +134,7 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
 
               // When the window is restored we resize it to the previous known
               // normal size.
-              NativeWindow::SetSize(last_normal_size_);
+              NativeWindow::SetSize(last_normal_size_, false);
 
               NotifyWindowRestore();
             }

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -121,7 +121,7 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
 
             // When the window is restored we resize it to the previous known
             // normal size.
-            NativeWindow::SetSize(last_normal_size_, false);
+            NativeWindow::SetSize(last_normal_size_);
 
             NotifyWindowUnmaximize();
             break;
@@ -134,7 +134,7 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
 
               // When the window is restored we resize it to the previous known
               // normal size.
-              NativeWindow::SetSize(last_normal_size_, false);
+              NativeWindow::SetSize(last_normal_size_);
 
               NotifyWindowRestore();
             }

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -450,14 +450,14 @@ height areas you have within the overall content view.
 
 ### `win.setBounds(options[, animate])`
 
-`options` Object, properties:
+* `options` Object, properties:
 
-* `x` Integer
-* `y` Integer
-* `width` Integer
-* `height` Integer
+  * `x` Integer
+  * `y` Integer
+  * `width` Integer
+  * `height` Integer
 
-`animate` Boolean (optional) _OS X_
+* `animate` Boolean (optional) _OS X_
 
 Resizes and moves the window to `width`, `height`, `x`, `y`.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -456,7 +456,8 @@ height areas you have within the overall content view.
 * `y` Integer
 * `width` Integer
 * `height` Integer
-* `animate` Boolean (optional) _OS X_
+
+`animate` Boolean (optional) _OS X_
 
 Resizes and moves the window to `width`, `height`, `x`, `y`.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -448,7 +448,7 @@ the player itself we would call this function with arguments of 16/9 and
 are within the content view--only that they exist. Just sum any extra width and
 height areas you have within the overall content view.
 
-### `win.setBounds(options)`
+### `win.setBounds(options[, animate])`
 
 `options` Object, properties:
 
@@ -456,6 +456,7 @@ height areas you have within the overall content view.
 * `y` Integer
 * `width` Integer
 * `height` Integer
+* `animate` Boolean (optional) _OS X_
 
 Resizes and moves the window to `width`, `height`, `x`, `y`.
 
@@ -463,10 +464,11 @@ Resizes and moves the window to `width`, `height`, `x`, `y`.
 
 Returns an object that contains window's width, height, x and y values.
 
-### `win.setSize(width, height)`
+### `win.setSize(width, height[, animate])`
 
 * `width` Integer
 * `height` Integer
+* `animate` Boolean (optional) _OS X_
 
 Resizes the window to `width` and `height`.
 
@@ -474,10 +476,11 @@ Resizes the window to `width` and `height`.
 
 Returns an array that contains window's width and height.
 
-### `win.setContentSize(width, height)`
+### `win.setContentSize(width, height[, animate])`
 
 * `width` Integer
 * `height` Integer
+* `animate` Boolean (optional) _OS X_
 
 Resizes the window's client area (e.g. the web page) to `width` and `height`.
 
@@ -533,10 +536,11 @@ Returns whether the window is always on top of other windows.
 
 Moves window to the center of the screen.
 
-### `win.setPosition(x, y)`
+### `win.setPosition(x, y[, animate])`
 
 * `x` Integer
 * `y` Integer
+* `animate` Boolean (optional) _OS X_
 
 Moves window to `x` and `y`.
 


### PR DESCRIPTION
I've added `animate` parameter to `BrowserWindows`'s `setBounds`, `setSize`, `setContentSize` and `setPosition` methods, works natively on OS X. What do you think?