### PR TITLE
Ensure we close FD on Windows

### DIFF
--- a/atom/common/asar/archive.cc
+++ b/atom/common/asar/archive.cc
@@ -129,6 +129,9 @@ Archive::Archive(const base::FilePath& path)
 }
 
 Archive::~Archive() {
+#if defined(OS_WIN)
+   _close(fd_)
+#endif
 }
 
 bool Archive::Init() {


### PR DESCRIPTION
In relation to https://github.com/atom/electron/issues/3949

This is done so that we can close archives while running, unlocking them to be moved/renamed/etc.

For example for auto-updating purposes
