### PR TITLE
Format leftover CoffeeScript helpers

### DIFF
--- a/atom/browser/api/lib/auto-updater/auto-updater-win.js
+++ b/atom/browser/api/lib/auto-updater/auto-updater-win.js
@@ -1,63 +1,64 @@
+'use strict';
+
 const app = require('electron').app;
 const EventEmitter = require('events').EventEmitter;
 const url = require('url');
 const squirrelUpdate = require('./squirrel-update-win');
-const util = require('util');
 
-function AutoUpdater() {
-  AutoUpdater.super_.call(this);
-}
-
-util.inherits(AutoUpdater, EventEmitter);
-
-AutoUpdater.prototype.quitAndInstall = function() {
-  squirrelUpdate.processStart();
-  return app.quit();
-};
-
-AutoUpdater.prototype.setFeedURL = function(updateURL) {
-  return this.updateURL = updateURL;
-};
-
-AutoUpdater.prototype.checkForUpdates = function() {
-  if (!this.updateURL) {
-    return this.emitError('Update URL is not set');
+class AutoUpdater extends EventEmitter {
+  constructor() {
+    super();
   }
-  if (!squirrelUpdate.supported()) {
-    return this.emitError('Can not find Squirrel');
+
+  quitAndInstall() {
+    squirrelUpdate.processStart();
+    return app.quit();
   }
-  this.emit('checking-for-update');
-  return squirrelUpdate.download(this.updateURL, (function(_this) {
-    return function(error, update) {
-      if (error != null) {
-        return _this.emitError(error);
-      }
-      if (update == null) {
-        return _this.emit('update-not-available');
-      }
-      _this.emit('update-available');
-      return squirrelUpdate.update(_this.updateURL, function(error) {
-        var date, releaseNotes, version;
+
+  setFeedURL(updateURL) {
+    return this.updateURL = updateURL;
+  }
+
+  checkForUpdates() {
+    if (!this.updateURL) {
+      return this.emitError('Update URL is not set');
+    }
+    if (!squirrelUpdate.supported()) {
+      return this.emitError('Can not find Squirrel');
+    }
+    this.emit('checking-for-update');
+    return squirrelUpdate.download(this.updateURL, (function(_this) {
+      return function(error, update) {
         if (error != null) {
           return _this.emitError(error);
         }
-        releaseNotes = update.releaseNotes, version = update.version;
+        if (update == null) {
+          return _this.emit('update-not-available');
+        }
+        _this.emit('update-available');
+        return squirrelUpdate.update(_this.updateURL, function(error) {
+          var date, releaseNotes, version;
+          if (error != null) {
+            return _this.emitError(error);
+          }
+          releaseNotes = update.releaseNotes, version = update.version;
 
-        // Following information is not available on Windows, so fake them.
-        date = new Date;
-        url = _this.updateURL;
-        return _this.emit('update-downloaded', {}, releaseNotes, version, date, url, function() {
-          return _this.quitAndInstall();
+          // Following information is not available on Windows, so fake them.
+          date = new Date;
+          url = _this.updateURL;
+          return _this.emit('update-downloaded', {}, releaseNotes, version, date, url, function() {
+            return _this.quitAndInstall();
+          });
         });
-      });
-    };
-  })(this));
-};
+      };
+    })(this));
+  }
 
-// Private: Emit both error object and message, this is to keep compatibility
-// with Old APIs.
-AutoUpdater.prototype.emitError = function(message) {
-  return this.emit('error', new Error(message), message);
-};
+  // Private: Emit both error object and message, this is to keep compatibility
+  // with Old APIs.
+  emitError(message) {
+    return this.emit('error', new Error(message), message);
+  }
+}
 
 module.exports = new AutoUpdater;

--- a/atom/browser/api/lib/auto-updater/auto-updater-win.js
+++ b/atom/browser/api/lib/auto-updater/auto-updater-win.js
@@ -2,70 +2,62 @@ const app = require('electron').app;
 const EventEmitter = require('events').EventEmitter;
 const url = require('url');
 const squirrelUpdate = require('./squirrel-update-win');
+const util = require('util');
 
-var extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
-hasProp = {}.hasOwnProperty;
+function AutoUpdater() {
+  AutoUpdater.super_.call(this);
+}
 
-var AutoUpdater = (function(superClass) {
-  extend(AutoUpdater, superClass);
+util.inherits(AutoUpdater, EventEmitter);
 
-  function AutoUpdater() {
-    return AutoUpdater.__super__.constructor.apply(this, arguments);
+AutoUpdater.prototype.quitAndInstall = function() {
+  squirrelUpdate.processStart();
+  return app.quit();
+};
+
+AutoUpdater.prototype.setFeedURL = function(updateURL) {
+  return this.updateURL = updateURL;
+};
+
+AutoUpdater.prototype.checkForUpdates = function() {
+  if (!this.updateURL) {
+    return this.emitError('Update URL is not set');
   }
-
-  AutoUpdater.prototype.quitAndInstall = function() {
-    squirrelUpdate.processStart();
-    return app.quit();
-  };
-
-  AutoUpdater.prototype.setFeedURL = function(updateURL) {
-    return this.updateURL = updateURL;
-  };
-
-  AutoUpdater.prototype.checkForUpdates = function() {
-    if (!this.updateURL) {
-      return this.emitError('Update URL is not set');
-    }
-    if (!squirrelUpdate.supported()) {
-      return this.emitError('Can not find Squirrel');
-    }
-    this.emit('checking-for-update');
-    return squirrelUpdate.download(this.updateURL, (function(_this) {
-      return function(error, update) {
+  if (!squirrelUpdate.supported()) {
+    return this.emitError('Can not find Squirrel');
+  }
+  this.emit('checking-for-update');
+  return squirrelUpdate.download(this.updateURL, (function(_this) {
+    return function(error, update) {
+      if (error != null) {
+        return _this.emitError(error);
+      }
+      if (update == null) {
+        return _this.emit('update-not-available');
+      }
+      _this.emit('update-available');
+      return squirrelUpdate.update(_this.updateURL, function(error) {
+        var date, releaseNotes, version;
         if (error != null) {
           return _this.emitError(error);
         }
-        if (update == null) {
-          return _this.emit('update-not-available');
-        }
-        _this.emit('update-available');
-        return squirrelUpdate.update(_this.updateURL, function(error) {
-          var date, releaseNotes, version;
-          if (error != null) {
-            return _this.emitError(error);
-          }
-          releaseNotes = update.releaseNotes, version = update.version;
+        releaseNotes = update.releaseNotes, version = update.version;
 
-          // Following information is not available on Windows, so fake them.
-          date = new Date;
-          url = _this.updateURL;
-          return _this.emit('update-downloaded', {}, releaseNotes, version, date, url, function() {
-            return _this.quitAndInstall();
-          });
+        // Following information is not available on Windows, so fake them.
+        date = new Date;
+        url = _this.updateURL;
+        return _this.emit('update-downloaded', {}, releaseNotes, version, date, url, function() {
+          return _this.quitAndInstall();
         });
-      };
-    })(this));
-  };
+      });
+    };
+  })(this));
+};
 
-
-  // Private: Emit both error object and message, this is to keep compatibility
-  // with Old APIs.
-  AutoUpdater.prototype.emitError = function(message) {
-    return this.emit('error', new Error(message), message);
-  };
-
-  return AutoUpdater;
-
-})(EventEmitter);
+// Private: Emit both error object and message, this is to keep compatibility
+// with Old APIs.
+AutoUpdater.prototype.emitError = function(message) {
+  return this.emit('error', new Error(message), message);
+};
 
 module.exports = new AutoUpdater;

--- a/atom/browser/api/lib/dialog.js
+++ b/atom/browser/api/lib/dialog.js
@@ -4,6 +4,7 @@ const binding = process.atomBinding('dialog');
 const v8Util = process.atomBinding('v8_util');
 
 var slice = [].slice;
+var includes = [].includes;
 var indexOf = [].indexOf;
 
 var fileDialogProperties = {
@@ -61,7 +62,7 @@ module.exports = {
     properties = 0;
     for (prop in fileDialogProperties) {
       value = fileDialogProperties[prop];
-      if (indexOf.call(options.properties, prop) >= 0) {
+      if (includes.call(options.properties, prop)) {
         properties |= value;
       }
     }

--- a/atom/browser/api/lib/dialog.js
+++ b/atom/browser/api/lib/dialog.js
@@ -4,7 +4,7 @@ const binding = process.atomBinding('dialog');
 const v8Util = process.atomBinding('v8_util');
 
 var slice = [].slice;
-var indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+var indexOf = [].indexOf;
 
 var fileDialogProperties = {
   openFile: 1 << 0,

--- a/atom/browser/lib/objects-registry.js
+++ b/atom/browser/lib/objects-registry.js
@@ -1,115 +1,110 @@
 const EventEmitter = require('events').EventEmitter;
+const util = require('util');
 const v8Util = process.atomBinding('v8_util');
 
-var extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
-var hasProp = {}.hasOwnProperty;
+function ObjectsRegistry() {
+  ObjectsRegistry.super_.call(this);
 
-var ObjectsRegistry = (function(superClass) {
-  extend(ObjectsRegistry, superClass);
+  this.setMaxListeners(Number.MAX_VALUE);
+  this.nextId = 0;
 
-  function ObjectsRegistry() {
-    this.setMaxListeners(Number.MAX_VALUE);
-    this.nextId = 0;
+  // Stores all objects by ref-counting.
+  // (id) => {object, count}
+  this.storage = {};
 
-    // Stores all objects by ref-counting.
-    // (id) => {object, count}
-    this.storage = {};
+  // Stores the IDs of objects referenced by WebContents.
+  // (webContentsId) => {(id) => (count)}
+  this.owners = {};
+}
 
-    // Stores the IDs of objects referenced by WebContents.
-    // (webContentsId) => {(id) => (count)}
-    this.owners = {};
+util.inherits(ObjectsRegistry, EventEmitter);
+
+// Register a new object, the object would be kept referenced until you release
+// it explicitly.
+ObjectsRegistry.prototype.add = function(webContentsId, obj) {
+  var base, base1, id;
+  id = this.saveToStorage(obj);
+
+  // Remember the owner.
+  if ((base = this.owners)[webContentsId] == null) {
+    base[webContentsId] = {};
   }
+  if ((base1 = this.owners[webContentsId])[id] == null) {
+    base1[id] = 0;
+  }
+  this.owners[webContentsId][id]++;
 
-  // Register a new object, the object would be kept referenced until you release
-  // it explicitly.
-  ObjectsRegistry.prototype.add = function(webContentsId, obj) {
-    var base, base1, id;
-    id = this.saveToStorage(obj);
-
-    // Remember the owner.
-    if ((base = this.owners)[webContentsId] == null) {
-      base[webContentsId] = {};
-    }
-    if ((base1 = this.owners[webContentsId])[id] == null) {
-      base1[id] = 0;
-    }
-    this.owners[webContentsId][id]++;
-
-    // Returns object's id
-    return id;
-  };
+  // Returns object's id
+  return id;
+};
 
 
-  // Get an object according to its ID.
-  ObjectsRegistry.prototype.get = function(id) {
-    var ref;
-    return (ref = this.storage[id]) != null ? ref.object : void 0;
-  };
+// Get an object according to its ID.
+ObjectsRegistry.prototype.get = function(id) {
+  var ref;
+  return (ref = this.storage[id]) != null ? ref.object : void 0;
+};
 
 
-  // Dereference an object according to its ID.
-  ObjectsRegistry.prototype.remove = function(webContentsId, id) {
-    var pointer;
-    this.dereference(id, 1);
+// Dereference an object according to its ID.
+ObjectsRegistry.prototype.remove = function(webContentsId, id) {
+  var pointer;
+  this.dereference(id, 1);
 
-    // Also reduce the count in owner.
-    pointer = this.owners[webContentsId];
-    if (pointer == null) {
-      return;
-    }
-    --pointer[id];
-    if (pointer[id] === 0) {
-      return delete pointer[id];
-    }
-  };
+  // Also reduce the count in owner.
+  pointer = this.owners[webContentsId];
+  if (pointer == null) {
+    return;
+  }
+  --pointer[id];
+  if (pointer[id] === 0) {
+    return delete pointer[id];
+  }
+};
 
-  // Clear all references to objects refrenced by the WebContents.
-  ObjectsRegistry.prototype.clear = function(webContentsId) {
-    var count, id, ref;
-    this.emit("clear-" + webContentsId);
-    if (this.owners[webContentsId] == null) {
-      return;
-    }
-    ref = this.owners[webContentsId];
-    for (id in ref) {
-      count = ref[id];
-      this.dereference(id, count);
-    }
-    return delete this.owners[webContentsId];
-  };
+// Clear all references to objects refrenced by the WebContents.
+ObjectsRegistry.prototype.clear = function(webContentsId) {
+  var count, id, ref;
+  this.emit("clear-" + webContentsId);
+  if (this.owners[webContentsId] == null) {
+    return;
+  }
+  ref = this.owners[webContentsId];
+  for (id in ref) {
+    count = ref[id];
+    this.dereference(id, count);
+  }
+  return delete this.owners[webContentsId];
+};
 
-  // Private: Saves the object into storage and assigns an ID for it.
-  ObjectsRegistry.prototype.saveToStorage = function(object) {
-    var id;
-    id = v8Util.getHiddenValue(object, 'atomId');
-    if (!id) {
-      id = ++this.nextId;
-      this.storage[id] = {
-        count: 0,
-        object: object
-      };
-      v8Util.setHiddenValue(object, 'atomId', id);
-    }
-    ++this.storage[id].count;
-    return id;
-  };
+// Private: Saves the object into storage and assigns an ID for it.
+ObjectsRegistry.prototype.saveToStorage = function(object) {
+  var id;
+  id = v8Util.getHiddenValue(object, 'atomId');
+  if (!id) {
+    id = ++this.nextId;
+    this.storage[id] = {
+      count: 0,
+      object: object
+    };
+    v8Util.setHiddenValue(object, 'atomId', id);
+  }
+  ++this.storage[id].count;
+  return id;
+};
 
-  // Private: Dereference the object from store.
-  ObjectsRegistry.prototype.dereference = function(id, count) {
-    var pointer;
-    pointer = this.storage[id];
-    if (pointer == null) {
-      return;
-    }
-    pointer.count -= count;
-    if (pointer.count === 0) {
-      v8Util.deleteHiddenValue(pointer.object, 'atomId');
-      return delete this.storage[id];
-    }
-  };
-
-  return ObjectsRegistry;
-
-})(EventEmitter);
+// Private: Dereference the object from store.
+ObjectsRegistry.prototype.dereference = function(id, count) {
+  var pointer;
+  pointer = this.storage[id];
+  if (pointer == null) {
+    return;
+  }
+  pointer.count -= count;
+  if (pointer.count === 0) {
+    v8Util.deleteHiddenValue(pointer.object, 'atomId');
+    return delete this.storage[id];
+  }
+};
 
 module.exports = new ObjectsRegistry;

--- a/atom/browser/lib/objects-registry.js
+++ b/atom/browser/lib/objects-registry.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EventEmitter = require('events').EventEmitter;
+const v8Util = process.atomBinding('v8_util');
 
 class ObjectsRegistry extends EventEmitter {
   constructor() {

--- a/atom/browser/lib/objects-registry.js
+++ b/atom/browser/lib/objects-registry.js
@@ -1,110 +1,108 @@
+'use strict';
+
 const EventEmitter = require('events').EventEmitter;
-const util = require('util');
-const v8Util = process.atomBinding('v8_util');
 
-function ObjectsRegistry() {
-  ObjectsRegistry.super_.call(this);
+class ObjectsRegistry extends EventEmitter {
+  constructor() {
+    super();
 
-  this.setMaxListeners(Number.MAX_VALUE);
-  this.nextId = 0;
+    this.setMaxListeners(Number.MAX_VALUE);
+    this.nextId = 0;
 
-  // Stores all objects by ref-counting.
-  // (id) => {object, count}
-  this.storage = {};
+    // Stores all objects by ref-counting.
+    // (id) => {object, count}
+    this.storage = {};
 
-  // Stores the IDs of objects referenced by WebContents.
-  // (webContentsId) => {(id) => (count)}
-  this.owners = {};
+    // Stores the IDs of objects referenced by WebContents.
+    // (webContentsId) => {(id) => (count)}
+    this.owners = {};
+  }
+
+  // Register a new object, the object would be kept referenced until you release
+  // it explicitly.
+  add(webContentsId, obj) {
+    var base, base1, id;
+    id = this.saveToStorage(obj);
+
+    // Remember the owner.
+    if ((base = this.owners)[webContentsId] == null) {
+      base[webContentsId] = {};
+    }
+    if ((base1 = this.owners[webContentsId])[id] == null) {
+      base1[id] = 0;
+    }
+    this.owners[webContentsId][id]++;
+
+    // Returns object's id
+    return id;
+  }
+
+  // Get an object according to its ID.
+  get(id) {
+    var ref;
+    return (ref = this.storage[id]) != null ? ref.object : void 0;
+  }
+
+  // Dereference an object according to its ID.
+  remove(webContentsId, id) {
+    var pointer;
+    this.dereference(id, 1);
+
+    // Also reduce the count in owner.
+    pointer = this.owners[webContentsId];
+    if (pointer == null) {
+      return;
+    }
+    --pointer[id];
+    if (pointer[id] === 0) {
+      return delete pointer[id];
+    }
+  }
+
+  // Clear all references to objects refrenced by the WebContents.
+  clear(webContentsId) {
+    var count, id, ref;
+    this.emit("clear-" + webContentsId);
+    if (this.owners[webContentsId] == null) {
+      return;
+    }
+    ref = this.owners[webContentsId];
+    for (id in ref) {
+      count = ref[id];
+      this.dereference(id, count);
+    }
+    return delete this.owners[webContentsId];
+  }
+
+  // Private: Saves the object into storage and assigns an ID for it.
+  saveToStorage(object) {
+    var id;
+    id = v8Util.getHiddenValue(object, 'atomId');
+    if (!id) {
+      id = ++this.nextId;
+      this.storage[id] = {
+        count: 0,
+        object: object
+      };
+      v8Util.setHiddenValue(object, 'atomId', id);
+    }
+    ++this.storage[id].count;
+    return id;
+  }
+
+  // Private: Dereference the object from store.
+  dereference(id, count) {
+    var pointer;
+    pointer = this.storage[id];
+    if (pointer == null) {
+      return;
+    }
+    pointer.count -= count;
+    if (pointer.count === 0) {
+      v8Util.deleteHiddenValue(pointer.object, 'atomId');
+      return delete this.storage[id];
+    }
+  }
 }
-
-util.inherits(ObjectsRegistry, EventEmitter);
-
-// Register a new object, the object would be kept referenced until you release
-// it explicitly.
-ObjectsRegistry.prototype.add = function(webContentsId, obj) {
-  var base, base1, id;
-  id = this.saveToStorage(obj);
-
-  // Remember the owner.
-  if ((base = this.owners)[webContentsId] == null) {
-    base[webContentsId] = {};
-  }
-  if ((base1 = this.owners[webContentsId])[id] == null) {
-    base1[id] = 0;
-  }
-  this.owners[webContentsId][id]++;
-
-  // Returns object's id
-  return id;
-};
-
-
-// Get an object according to its ID.
-ObjectsRegistry.prototype.get = function(id) {
-  var ref;
-  return (ref = this.storage[id]) != null ? ref.object : void 0;
-};
-
-
-// Dereference an object according to its ID.
-ObjectsRegistry.prototype.remove = function(webContentsId, id) {
-  var pointer;
-  this.dereference(id, 1);
-
-  // Also reduce the count in owner.
-  pointer = this.owners[webContentsId];
-  if (pointer == null) {
-    return;
-  }
-  --pointer[id];
-  if (pointer[id] === 0) {
-    return delete pointer[id];
-  }
-};
-
-// Clear all references to objects refrenced by the WebContents.
-ObjectsRegistry.prototype.clear = function(webContentsId) {
-  var count, id, ref;
-  this.emit("clear-" + webContentsId);
-  if (this.owners[webContentsId] == null) {
-    return;
-  }
-  ref = this.owners[webContentsId];
-  for (id in ref) {
-    count = ref[id];
-    this.dereference(id, count);
-  }
-  return delete this.owners[webContentsId];
-};
-
-// Private: Saves the object into storage and assigns an ID for it.
-ObjectsRegistry.prototype.saveToStorage = function(object) {
-  var id;
-  id = v8Util.getHiddenValue(object, 'atomId');
-  if (!id) {
-    id = ++this.nextId;
-    this.storage[id] = {
-      count: 0,
-      object: object
-    };
-    v8Util.setHiddenValue(object, 'atomId', id);
-  }
-  ++this.storage[id].count;
-  return id;
-};
-
-// Private: Dereference the object from store.
-ObjectsRegistry.prototype.dereference = function(id, count) {
-  var pointer;
-  pointer = this.storage[id];
-  if (pointer == null) {
-    return;
-  }
-  pointer.count -= count;
-  if (pointer.count === 0) {
-    v8Util.deleteHiddenValue(pointer.object, 'atomId');
-    return delete this.storage[id];
-  }
-};
 
 module.exports = new ObjectsRegistry;

--- a/atom/common/api/lib/callbacks-registry.js
+++ b/atom/common/api/lib/callbacks-registry.js
@@ -1,7 +1,7 @@
-var CallbacksRegistry, v8Util,
-  slice = [].slice;
+var CallbacksRegistry;
+var slice = [].slice;
 
-v8Util = process.atomBinding('v8_util');
+const v8Util = process.atomBinding('v8_util');
 
 module.exports = CallbacksRegistry = (function() {
   function CallbacksRegistry() {

--- a/atom/common/api/lib/callbacks-registry.js
+++ b/atom/common/api/lib/callbacks-registry.js
@@ -1,15 +1,16 @@
-var CallbacksRegistry;
+'use strict';
+
 var slice = [].slice;
 
 const v8Util = process.atomBinding('v8_util');
 
-module.exports = CallbacksRegistry = (function() {
-  function CallbacksRegistry() {
+class CallbacksRegistry {
+  constructor() {
     this.nextId = 0;
     this.callbacks = {};
   }
 
-  CallbacksRegistry.prototype.add = function(callback) {
+  add(callback) {
     // The callback is already added.
     var filenameAndLine, id, location, match, ref, regexp, stackString, x;
     id = v8Util.getHiddenValue(callback, 'callbackId');
@@ -37,29 +38,28 @@ module.exports = CallbacksRegistry = (function() {
     v8Util.setHiddenValue(callback, 'callbackId', id);
     v8Util.setHiddenValue(callback, 'location', filenameAndLine);
     return id;
-  };
+  }
 
-  CallbacksRegistry.prototype.get = function(id) {
+  get(id) {
     var ref;
     return (ref = this.callbacks[id]) != null ? ref : function() {};
-  };
+  }
 
-  CallbacksRegistry.prototype.call = function() {
+  call() {
     var args, id, ref;
     id = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
     return (ref = this.get(id)).call.apply(ref, [global].concat(slice.call(args)));
-  };
+  }
 
-  CallbacksRegistry.prototype.apply = function() {
+  apply() {
     var args, id, ref;
     id = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
     return (ref = this.get(id)).apply.apply(ref, [global].concat(slice.call(args)));
-  };
+  }
 
-  CallbacksRegistry.prototype.remove = function(id) {
+  remove(id) {
     return delete this.callbacks[id];
-  };
+  }
+}
 
-  return CallbacksRegistry;
-
-})();
+modules.exports = CallbacksRegistry

--- a/atom/renderer/api/lib/desktop-capturer.js
+++ b/atom/renderer/api/lib/desktop-capturer.js
@@ -2,7 +2,7 @@ const ipcRenderer = require('electron').ipcRenderer;
 const nativeImage = require('electron').nativeImage;
 
 var nextId = 0;
-var indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+var indexOf = [].indexOf;
 
 var getNextId = function() {
   return ++nextId;

--- a/atom/renderer/api/lib/desktop-capturer.js
+++ b/atom/renderer/api/lib/desktop-capturer.js
@@ -2,7 +2,7 @@ const ipcRenderer = require('electron').ipcRenderer;
 const nativeImage = require('electron').nativeImage;
 
 var nextId = 0;
-var indexOf = [].indexOf;
+var includes = [].includes;
 
 var getNextId = function() {
   return ++nextId;
@@ -18,8 +18,8 @@ exports.getSources = function(options, callback) {
   if (!isValid(options)) {
     return callback(new Error('Invalid options'));
   }
-  captureWindow = indexOf.call(options.types, 'window') >= 0;
-  captureScreen = indexOf.call(options.types, 'screen') >= 0;
+  captureWindow = includes.call(options.types, 'window');
+  captureScreen = includes.call(options.types, 'screen');
   if (options.thumbnailSize == null) {
     options.thumbnailSize = {
       width: 150,

--- a/atom/renderer/api/lib/remote.js
+++ b/atom/renderer/api/lib/remote.js
@@ -4,7 +4,7 @@ const v8Util = process.atomBinding('v8_util');
 
 const callbacksRegistry = new CallbacksRegistry;
 
-var indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+var indexOf = [].indexOf;
 
 // Check for circular reference.
 var isCircular = function(field, visited) {

--- a/atom/renderer/api/lib/remote.js
+++ b/atom/renderer/api/lib/remote.js
@@ -4,12 +4,12 @@ const v8Util = process.atomBinding('v8_util');
 
 const callbacksRegistry = new CallbacksRegistry;
 
-var indexOf = [].indexOf;
+var includes = [].includes;
 
 // Check for circular reference.
 var isCircular = function(field, visited) {
   if (typeof field === 'object') {
-    if (indexOf.call(visited, field) >= 0) {
+    if (includes.call(visited, field)) {
       return true;
     }
     visited.push(field);

--- a/atom/renderer/lib/web-view/web-view-attributes.js
+++ b/atom/renderer/lib/web-view/web-view-attributes.js
@@ -56,7 +56,7 @@ class WebViewAttribute {
       })(this),
       enumerable: true
     });
-  };
+  }
 
   // Called when the attribute's value changes.
   handleMutation() {}

--- a/atom/renderer/lib/web-view/web-view-attributes.js
+++ b/atom/renderer/lib/web-view/web-view-attributes.js
@@ -1,8 +1,9 @@
+'use strict';
+
 const WebViewImpl = require('./web-view');
 const guestViewInternal = require('./guest-view-internal');
 const webViewConstants = require('./web-view-constants');
 const remote = require('electron').remote;
-const util = require('util');
 
 // Helper function to resolve url set in attribute.
 var a = document.createElement('a');
@@ -14,275 +15,278 @@ var resolveURL = function(url) {
 
 // Attribute objects.
 // Default implementation of a WebView attribute.
-function WebViewAttribute(name, webViewImpl) {
-  this.name = name;
-  this.value = webViewImpl.webviewNode[name] || '';
-  this.webViewImpl = webViewImpl;
-  this.ignoreMutation = false;
-  this.defineProperty();
+class WebViewAttribute {
+  constructor(name, webViewImpl) {
+    this.name = name;
+    this.value = webViewImpl.webviewNode[name] || '';
+    this.webViewImpl = webViewImpl;
+    this.ignoreMutation = false;
+    this.defineProperty();
+  }
+
+  // Retrieves and returns the attribute's value.
+  getValue() {
+    return this.webViewImpl.webviewNode.getAttribute(this.name) || this.value;
+  }
+
+  // Sets the attribute's value.
+  setValue(value) {
+    return this.webViewImpl.webviewNode.setAttribute(this.name, value || '');
+  }
+
+  // Changes the attribute's value without triggering its mutation handler.
+  setValueIgnoreMutation(value) {
+    this.ignoreMutation = true;
+    this.setValue(value);
+    return this.ignoreMutation = false;
+  }
+
+  // Defines this attribute as a property on the webview node.
+  defineProperty() {
+    return Object.defineProperty(this.webViewImpl.webviewNode, this.name, {
+      get: (function(_this) {
+        return function() {
+          return _this.getValue();
+        };
+      })(this),
+      set: (function(_this) {
+        return function(value) {
+          return _this.setValue(value);
+        };
+      })(this),
+      enumerable: true
+    });
+  };
+
+  // Called when the attribute's value changes.
+  handleMutation() {}
 }
-
-// Retrieves and returns the attribute's value.
-WebViewAttribute.prototype.getValue = function() {
-  return this.webViewImpl.webviewNode.getAttribute(this.name) || this.value;
-};
-
-// Sets the attribute's value.
-WebViewAttribute.prototype.setValue = function(value) {
-  return this.webViewImpl.webviewNode.setAttribute(this.name, value || '');
-};
-
-// Changes the attribute's value without triggering its mutation handler.
-WebViewAttribute.prototype.setValueIgnoreMutation = function(value) {
-  this.ignoreMutation = true;
-  this.setValue(value);
-  return this.ignoreMutation = false;
-};
-
-// Defines this attribute as a property on the webview node.
-WebViewAttribute.prototype.defineProperty = function() {
-  return Object.defineProperty(this.webViewImpl.webviewNode, this.name, {
-    get: (function(_this) {
-      return function() {
-        return _this.getValue();
-      };
-    })(this),
-    set: (function(_this) {
-      return function(value) {
-        return _this.setValue(value);
-      };
-    })(this),
-    enumerable: true
-  });
-};
-
-// Called when the attribute's value changes.
-WebViewAttribute.prototype.handleMutation = function() {};
 
 // An attribute that is treated as a Boolean.
-function BooleanAttribute(name, webViewImpl) {
-  BooleanAttribute.super_.call(this, name, webViewImpl)
-}
-
-util.inherits(BooleanAttribute, WebViewAttribute);
-
-BooleanAttribute.prototype.getValue = function() {
-  return this.webViewImpl.webviewNode.hasAttribute(this.name);
-};
-
-BooleanAttribute.prototype.setValue = function(value) {
-  if (!value) {
-    return this.webViewImpl.webviewNode.removeAttribute(this.name);
-  } else {
-    return this.webViewImpl.webviewNode.setAttribute(this.name, '');
+class BooleanAttribute extends WebViewAttribute {
+  constructor(name, webViewImpl) {
+    super(name, webViewImpl);
   }
-};
+
+  getValue() {
+    return this.webViewImpl.webviewNode.hasAttribute(this.name);
+  }
+
+  setValue(value) {
+    if (!value) {
+      return this.webViewImpl.webviewNode.removeAttribute(this.name);
+    } else {
+      return this.webViewImpl.webviewNode.setAttribute(this.name, '');
+    }
+  }
+}
 
 // Attribute that specifies whether transparency is allowed in the webview.
-function AllowTransparencyAttribute(webViewImpl) {
-  AllowTransparencyAttribute.super_.call(this, webViewConstants.ATTRIBUTE_ALLOWTRANSPARENCY, webViewImpl);
-}
-
-util.inherits(AllowTransparencyAttribute, BooleanAttribute);
-
-AllowTransparencyAttribute.prototype.handleMutation = function(oldValue, newValue) {
-  if (!this.webViewImpl.guestInstanceId) {
-    return;
+class AllowTransparencyAttribute extends BooleanAttribute {
+  constructor(webViewImpl) {
+    super(webViewConstants.ATTRIBUTE_ALLOWTRANSPARENCY, webViewImpl);
   }
-  return guestViewInternal.setAllowTransparency(this.webViewImpl.guestInstanceId, this.getValue());
-};
+
+  handleMutation(oldValue, newValue) {
+    if (!this.webViewImpl.guestInstanceId) {
+      return;
+    }
+    return guestViewInternal.setAllowTransparency(this.webViewImpl.guestInstanceId, this.getValue());
+  }
+}
 
 // Attribute used to define the demension limits of autosizing.
-function AutosizeDimensionAttribute(name, webViewImpl) {
-  AutosizeDimensionAttribute.super_.call(this, name, webViewImpl);
+class AutosizeDimensionAttribute extends WebViewAttribute {
+  constructor(name, webViewImpl) {
+    super(name, webViewImpl);
+  }
+
+  getValue() {
+    return parseInt(this.webViewImpl.webviewNode.getAttribute(this.name)) || 0;
+  }
+
+  handleMutation(oldValue, newValue) {
+    if (!this.webViewImpl.guestInstanceId) {
+      return;
+    }
+    return guestViewInternal.setSize(this.webViewImpl.guestInstanceId, {
+      enableAutoSize: this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_AUTOSIZE].getValue(),
+      min: {
+        width: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MINWIDTH].getValue() || 0),
+        height: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MINHEIGHT].getValue() || 0)
+      },
+      max: {
+        width: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MAXWIDTH].getValue() || 0),
+        height: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MAXHEIGHT].getValue() || 0)
+      }
+    });
+  }
 }
 
-util.inherits(AutosizeDimensionAttribute, WebViewAttribute);
-
-AutosizeDimensionAttribute.prototype.getValue = function() {
-  return parseInt(this.webViewImpl.webviewNode.getAttribute(this.name)) || 0;
-};
-
-AutosizeDimensionAttribute.prototype.handleMutation = function(oldValue, newValue) {
-  if (!this.webViewImpl.guestInstanceId) {
-    return;
-  }
-  return guestViewInternal.setSize(this.webViewImpl.guestInstanceId, {
-    enableAutoSize: this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_AUTOSIZE].getValue(),
-    min: {
-      width: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MINWIDTH].getValue() || 0),
-      height: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MINHEIGHT].getValue() || 0)
-    },
-    max: {
-      width: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MAXWIDTH].getValue() || 0),
-      height: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MAXHEIGHT].getValue() || 0)
-    }
-  });
-};
 
 // Attribute that specifies whether the webview should be autosized.
-function AutosizeAttribute(webViewImpl) {
-  AutosizeAttribute.super_.call(this, webViewConstants.ATTRIBUTE_AUTOSIZE, webViewImpl);
+class AutosizeAttribute extends BooleanAttribute {
+  constructor(webViewImpl) {
+    super(webViewConstants.ATTRIBUTE_AUTOSIZE, webViewImpl);
+  }
 }
-
-util.inherits(AutosizeAttribute, BooleanAttribute);
 
 AutosizeAttribute.prototype.handleMutation = AutosizeDimensionAttribute.prototype.handleMutation;
 
 // Attribute representing the state of the storage partition.
-function PartitionAttribute(webViewImpl) {
-  PartitionAttribute.super_.call(this, webViewConstants.ATTRIBUTE_PARTITION, webViewImpl);
-  this.validPartitionId = true;
+class PartitionAttribute extends WebViewAttribute {
+  constructor(webViewImpl) {
+    super(webViewConstants.ATTRIBUTE_PARTITION, webViewImpl);
+    this.validPartitionId = true;
+  }
+
+  handleMutation(oldValue, newValue) {
+    newValue = newValue || '';
+
+    // The partition cannot change if the webview has already navigated.
+    if (!this.webViewImpl.beforeFirstNavigation) {
+      window.console.error(webViewConstants.ERROR_MSG_ALREADY_NAVIGATED);
+      this.setValueIgnoreMutation(oldValue);
+      return;
+    }
+    if (newValue === 'persist:') {
+      this.validPartitionId = false;
+      return window.console.error(webViewConstants.ERROR_MSG_INVALID_PARTITION_ATTRIBUTE);
+    }
+  }
 }
-
-util.inherits(PartitionAttribute, WebViewAttribute);
-
-PartitionAttribute.prototype.handleMutation = function(oldValue, newValue) {
-  newValue = newValue || '';
-
-  // The partition cannot change if the webview has already navigated.
-  if (!this.webViewImpl.beforeFirstNavigation) {
-    window.console.error(webViewConstants.ERROR_MSG_ALREADY_NAVIGATED);
-    this.setValueIgnoreMutation(oldValue);
-    return;
-  }
-  if (newValue === 'persist:') {
-    this.validPartitionId = false;
-    return window.console.error(webViewConstants.ERROR_MSG_INVALID_PARTITION_ATTRIBUTE);
-  }
-};
 
 // Attribute that handles the location and navigation of the webview.
-function SrcAttribute(webViewImpl) {
-  SrcAttribute.super_.call(this, webViewConstants.ATTRIBUTE_SRC, webViewImpl);
-  this.setupMutationObserver();
-}
-
-util.inherits(SrcAttribute, WebViewAttribute);
-
-SrcAttribute.prototype.getValue = function() {
-  if (this.webViewImpl.webviewNode.hasAttribute(this.name)) {
-    return resolveURL(this.webViewImpl.webviewNode.getAttribute(this.name));
-  } else {
-    return this.value;
+class SrcAttribute extends WebViewAttribute {
+  constructor(webViewImpl) {
+    super(webViewConstants.ATTRIBUTE_SRC, webViewImpl);
+    this.setupMutationObserver();
   }
-};
 
-SrcAttribute.prototype.setValueIgnoreMutation = function(value) {
-  WebViewAttribute.prototype.setValueIgnoreMutation.call(this, value);
-
-  // takeRecords() is needed to clear queued up src mutations. Without it, it
-  // is possible for this change to get picked up asyncronously by src's
-  // mutation observer |observer|, and then get handled even though we do not
-  // want to handle this mutation.
-  return this.observer.takeRecords();
-};
-
-SrcAttribute.prototype.handleMutation = function(oldValue, newValue) {
-
-  // Once we have navigated, we don't allow clearing the src attribute.
-  // Once <webview> enters a navigated state, it cannot return to a
-  // placeholder state.
-  if (!newValue && oldValue) {
-
-    // src attribute changes normally initiate a navigation. We suppress
-    // the next src attribute handler call to avoid reloading the page
-    // on every guest-initiated navigation.
-    this.setValueIgnoreMutation(oldValue);
-    return;
-  }
-  return this.parse();
-};
-
-// The purpose of this mutation observer is to catch assignment to the src
-// attribute without any changes to its value. This is useful in the case
-// where the webview guest has crashed and navigating to the same address
-// spawns off a new process.
-SrcAttribute.prototype.setupMutationObserver = function() {
-  var params;
-  this.observer = new MutationObserver((function(_this) {
-    return function(mutations) {
-      var i, len, mutation, newValue, oldValue;
-      for (i = 0, len = mutations.length; i < len; i++) {
-        mutation = mutations[i];
-        oldValue = mutation.oldValue;
-        newValue = _this.getValue();
-        if (oldValue !== newValue) {
-          return;
-        }
-        _this.handleMutation(oldValue, newValue);
-      }
-    };
-  })(this));
-  params = {
-    attributes: true,
-    attributeOldValue: true,
-    attributeFilter: [this.name]
-  };
-  return this.observer.observe(this.webViewImpl.webviewNode, params);
-};
-
-SrcAttribute.prototype.parse = function() {
-  var guestContents, httpreferrer, opts, useragent;
-  if (!this.webViewImpl.elementAttached || !this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_PARTITION].validPartitionId || !this.getValue()) {
-    return;
-  }
-  if (this.webViewImpl.guestInstanceId == null) {
-    if (this.webViewImpl.beforeFirstNavigation) {
-      this.webViewImpl.beforeFirstNavigation = false;
-      this.webViewImpl.createGuest();
+  getValue() {
+    if (this.webViewImpl.webviewNode.hasAttribute(this.name)) {
+      return resolveURL(this.webViewImpl.webviewNode.getAttribute(this.name));
+    } else {
+      return this.value;
     }
-    return;
   }
 
-  // Navigate to |this.src|.
-  opts = {};
-  httpreferrer = this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER].getValue();
-  if (httpreferrer) {
-    opts.httpReferrer = httpreferrer;
+  setValueIgnoreMutation(value) {
+    super.setValueIgnoreMutation(value);
+
+    // takeRecords() is needed to clear queued up src mutations. Without it, it
+    // is possible for this change to get picked up asyncronously by src's
+    // mutation observer |observer|, and then get handled even though we do not
+    // want to handle this mutation.
+    return this.observer.takeRecords();
   }
-  useragent = this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_USERAGENT].getValue();
-  if (useragent) {
-    opts.userAgent = useragent;
+
+  handleMutation(oldValue, newValue) {
+
+    // Once we have navigated, we don't allow clearing the src attribute.
+    // Once <webview> enters a navigated state, it cannot return to a
+    // placeholder state.
+    if (!newValue && oldValue) {
+
+      // src attribute changes normally initiate a navigation. We suppress
+      // the next src attribute handler call to avoid reloading the page
+      // on every guest-initiated navigation.
+      this.setValueIgnoreMutation(oldValue);
+      return;
+    }
+    return this.parse();
   }
-  guestContents = remote.getGuestWebContents(this.webViewImpl.guestInstanceId);
-  return guestContents.loadURL(this.getValue(), opts);
-};
+
+  // The purpose of this mutation observer is to catch assignment to the src
+  // attribute without any changes to its value. This is useful in the case
+  // where the webview guest has crashed and navigating to the same address
+  // spawns off a new process.
+  setupMutationObserver() {
+    var params;
+    this.observer = new MutationObserver((function(_this) {
+      return function(mutations) {
+        var i, len, mutation, newValue, oldValue;
+        for (i = 0, len = mutations.length; i < len; i++) {
+          mutation = mutations[i];
+          oldValue = mutation.oldValue;
+          newValue = _this.getValue();
+          if (oldValue !== newValue) {
+            return;
+          }
+          _this.handleMutation(oldValue, newValue);
+        }
+      };
+    })(this));
+    params = {
+      attributes: true,
+      attributeOldValue: true,
+      attributeFilter: [this.name]
+    };
+    return this.observer.observe(this.webViewImpl.webviewNode, params);
+  }
+
+  parse() {
+    var guestContents, httpreferrer, opts, useragent;
+    if (!this.webViewImpl.elementAttached || !this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_PARTITION].validPartitionId || !this.getValue()) {
+      return;
+    }
+    if (this.webViewImpl.guestInstanceId == null) {
+      if (this.webViewImpl.beforeFirstNavigation) {
+        this.webViewImpl.beforeFirstNavigation = false;
+        this.webViewImpl.createGuest();
+      }
+      return;
+    }
+
+    // Navigate to |this.src|.
+    opts = {};
+    httpreferrer = this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER].getValue();
+    if (httpreferrer) {
+      opts.httpReferrer = httpreferrer;
+    }
+    useragent = this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_USERAGENT].getValue();
+    if (useragent) {
+      opts.userAgent = useragent;
+    }
+    guestContents = remote.getGuestWebContents(this.webViewImpl.guestInstanceId);
+    return guestContents.loadURL(this.getValue(), opts);
+  }
+}
 
 // Attribute specifies HTTP referrer.
-function HttpReferrerAttribute(webViewImpl) {
-  HttpReferrerAttribute.super_.call(this, webViewConstants.ATTRIBUTE_HTTPREFERRER, webViewImpl);
+class HttpReferrerAttribute extends WebViewAttribute {
+  constructor(webViewImpl) {
+    super(webViewConstants.ATTRIBUTE_HTTPREFERRER, webViewImpl);
+  }
 }
-
-util.inherits(HttpReferrerAttribute, WebViewAttribute);
 
 // Attribute specifies user agent
-function UserAgentAttribute(webViewImpl) {
-  UserAgentAttribute.super_.call(this, webViewConstants.ATTRIBUTE_USERAGENT, webViewImpl);
+class UserAgentAttribute extends WebViewAttribute {
+  constructor(webViewImpl) {
+    super(webViewConstants.ATTRIBUTE_USERAGENT, webViewImpl);
+  }
 }
-
-util.inherits(UserAgentAttribute, WebViewAttribute);
 
 // Attribute that set preload script.
-function PreloadAttribute(webViewImpl) {
-  PreloadAttribute.super_.call(this, webViewConstants.ATTRIBUTE_PRELOAD, webViewImpl);
+class PreloadAttribute extends WebViewAttribute
+  constructor(webViewImpl) {
+    super(webViewConstants.ATTRIBUTE_PRELOAD, webViewImpl);
+  }
+
+  getValue() {
+    var preload, protocol;
+    if (!this.webViewImpl.webviewNode.hasAttribute(this.name)) {
+      return this.value;
+    }
+    preload = resolveURL(this.webViewImpl.webviewNode.getAttribute(this.name));
+    protocol = preload.substr(0, 5);
+    if (protocol !== 'file:') {
+      console.error(webViewConstants.ERROR_MSG_INVALID_PRELOAD_ATTRIBUTE);
+      preload = '';
+    }
+    return preload;
+  }
 }
-
-util.inherits(PreloadAttribute, WebViewAttribute);
-
-PreloadAttribute.prototype.getValue = function() {
-  var preload, protocol;
-  if (!this.webViewImpl.webviewNode.hasAttribute(this.name)) {
-    return this.value;
-  }
-  preload = resolveURL(this.webViewImpl.webviewNode.getAttribute(this.name));
-  protocol = preload.substr(0, 5);
-  if (protocol !== 'file:') {
-    console.error(webViewConstants.ERROR_MSG_INVALID_PRELOAD_ATTRIBUTE);
-    preload = '';
-  }
-  return preload;
-};
 
 // Sets up all of the webview attributes.
 WebViewImpl.prototype.setupWebViewAttributes = function() {

--- a/atom/renderer/lib/web-view/web-view-attributes.js
+++ b/atom/renderer/lib/web-view/web-view-attributes.js
@@ -268,7 +268,7 @@ class UserAgentAttribute extends WebViewAttribute {
 }
 
 // Attribute that set preload script.
-class PreloadAttribute extends WebViewAttribute
+class PreloadAttribute extends WebViewAttribute {
   constructor(webViewImpl) {
     super(webViewConstants.ATTRIBUTE_PRELOAD, webViewImpl);
   }

--- a/atom/renderer/lib/web-view/web-view-attributes.js
+++ b/atom/renderer/lib/web-view/web-view-attributes.js
@@ -2,7 +2,7 @@ const WebViewImpl = require('./web-view');
 const guestViewInternal = require('./guest-view-internal');
 const webViewConstants = require('./web-view-constants');
 const remote = require('electron').remote;
-var util = require('util');
+const util = require('util');
 
 // Helper function to resolve url set in attribute.
 var a = document.createElement('a');

--- a/atom/renderer/lib/web-view/web-view-attributes.js
+++ b/atom/renderer/lib/web-view/web-view-attributes.js
@@ -2,10 +2,7 @@ const WebViewImpl = require('./web-view');
 const guestViewInternal = require('./guest-view-internal');
 const webViewConstants = require('./web-view-constants');
 const remote = require('electron').remote;
-
-var extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
-
-var hasProp = {}.hasOwnProperty;
+var util = require('util');
 
 // Helper function to resolve url set in attribute.
 var a = document.createElement('a');
@@ -17,326 +14,275 @@ var resolveURL = function(url) {
 
 // Attribute objects.
 // Default implementation of a WebView attribute.
-var WebViewAttribute = (function() {
-  function WebViewAttribute(name, webViewImpl) {
-    this.name = name;
-    this.value = webViewImpl.webviewNode[name] || '';
-    this.webViewImpl = webViewImpl;
-    this.ignoreMutation = false;
-    this.defineProperty();
-  }
+function WebViewAttribute(name, webViewImpl) {
+  this.name = name;
+  this.value = webViewImpl.webviewNode[name] || '';
+  this.webViewImpl = webViewImpl;
+  this.ignoreMutation = false;
+  this.defineProperty();
+}
 
-  // Retrieves and returns the attribute's value.
-  WebViewAttribute.prototype.getValue = function() {
-    return this.webViewImpl.webviewNode.getAttribute(this.name) || this.value;
-  };
+// Retrieves and returns the attribute's value.
+WebViewAttribute.prototype.getValue = function() {
+  return this.webViewImpl.webviewNode.getAttribute(this.name) || this.value;
+};
 
-  // Sets the attribute's value.
-  WebViewAttribute.prototype.setValue = function(value) {
-    return this.webViewImpl.webviewNode.setAttribute(this.name, value || '');
-  };
+// Sets the attribute's value.
+WebViewAttribute.prototype.setValue = function(value) {
+  return this.webViewImpl.webviewNode.setAttribute(this.name, value || '');
+};
 
-  // Changes the attribute's value without triggering its mutation handler.
-  WebViewAttribute.prototype.setValueIgnoreMutation = function(value) {
-    this.ignoreMutation = true;
-    this.setValue(value);
-    return this.ignoreMutation = false;
-  };
+// Changes the attribute's value without triggering its mutation handler.
+WebViewAttribute.prototype.setValueIgnoreMutation = function(value) {
+  this.ignoreMutation = true;
+  this.setValue(value);
+  return this.ignoreMutation = false;
+};
 
-  // Defines this attribute as a property on the webview node.
-  WebViewAttribute.prototype.defineProperty = function() {
-    return Object.defineProperty(this.webViewImpl.webviewNode, this.name, {
-      get: (function(_this) {
-        return function() {
-          return _this.getValue();
-        };
-      })(this),
-      set: (function(_this) {
-        return function(value) {
-          return _this.setValue(value);
-        };
-      })(this),
-      enumerable: true
-    });
-  };
+// Defines this attribute as a property on the webview node.
+WebViewAttribute.prototype.defineProperty = function() {
+  return Object.defineProperty(this.webViewImpl.webviewNode, this.name, {
+    get: (function(_this) {
+      return function() {
+        return _this.getValue();
+      };
+    })(this),
+    set: (function(_this) {
+      return function(value) {
+        return _this.setValue(value);
+      };
+    })(this),
+    enumerable: true
+  });
+};
 
-  // Called when the attribute's value changes.
-  WebViewAttribute.prototype.handleMutation = function() {};
-
-  return WebViewAttribute;
-
-})();
+// Called when the attribute's value changes.
+WebViewAttribute.prototype.handleMutation = function() {};
 
 // An attribute that is treated as a Boolean.
-var BooleanAttribute = (function(superClass) {
-  extend(BooleanAttribute, superClass);
+function BooleanAttribute(name, webViewImpl) {
+  BooleanAttribute.super_.call(this, name, webViewImpl)
+}
 
-  function BooleanAttribute(name, webViewImpl) {
-    BooleanAttribute.__super__.constructor.call(this, name, webViewImpl);
+util.inherits(BooleanAttribute, WebViewAttribute);
+
+BooleanAttribute.prototype.getValue = function() {
+  return this.webViewImpl.webviewNode.hasAttribute(this.name);
+};
+
+BooleanAttribute.prototype.setValue = function(value) {
+  if (!value) {
+    return this.webViewImpl.webviewNode.removeAttribute(this.name);
+  } else {
+    return this.webViewImpl.webviewNode.setAttribute(this.name, '');
   }
-
-  BooleanAttribute.prototype.getValue = function() {
-    return this.webViewImpl.webviewNode.hasAttribute(this.name);
-  };
-
-  BooleanAttribute.prototype.setValue = function(value) {
-    if (!value) {
-      return this.webViewImpl.webviewNode.removeAttribute(this.name);
-    } else {
-      return this.webViewImpl.webviewNode.setAttribute(this.name, '');
-    }
-  };
-
-  return BooleanAttribute;
-
-})(WebViewAttribute);
+};
 
 // Attribute that specifies whether transparency is allowed in the webview.
-var AllowTransparencyAttribute = (function(superClass) {
-  extend(AllowTransparencyAttribute, superClass);
+function AllowTransparencyAttribute(webViewImpl) {
+  AllowTransparencyAttribute.super_.call(this, webViewConstants.ATTRIBUTE_ALLOWTRANSPARENCY, webViewImpl);
+}
 
-  function AllowTransparencyAttribute(webViewImpl) {
-    AllowTransparencyAttribute.__super__.constructor.call(this, webViewConstants.ATTRIBUTE_ALLOWTRANSPARENCY, webViewImpl);
+util.inherits(AllowTransparencyAttribute, BooleanAttribute);
+
+AllowTransparencyAttribute.prototype.handleMutation = function(oldValue, newValue) {
+  if (!this.webViewImpl.guestInstanceId) {
+    return;
   }
-
-  AllowTransparencyAttribute.prototype.handleMutation = function(oldValue, newValue) {
-    if (!this.webViewImpl.guestInstanceId) {
-      return;
-    }
-    return guestViewInternal.setAllowTransparency(this.webViewImpl.guestInstanceId, this.getValue());
-  };
-
-  return AllowTransparencyAttribute;
-
-})(BooleanAttribute);
+  return guestViewInternal.setAllowTransparency(this.webViewImpl.guestInstanceId, this.getValue());
+};
 
 // Attribute used to define the demension limits of autosizing.
-var AutosizeDimensionAttribute = (function(superClass) {
-  extend(AutosizeDimensionAttribute, superClass);
+function AutosizeDimensionAttribute(name, webViewImpl) {
+  AutosizeDimensionAttribute.super_.call(this, name, webViewImpl);
+}
 
-  function AutosizeDimensionAttribute(name, webViewImpl) {
-    AutosizeDimensionAttribute.__super__.constructor.call(this, name, webViewImpl);
+util.inherits(AutosizeDimensionAttribute, WebViewAttribute);
+
+AutosizeDimensionAttribute.prototype.getValue = function() {
+  return parseInt(this.webViewImpl.webviewNode.getAttribute(this.name)) || 0;
+};
+
+AutosizeDimensionAttribute.prototype.handleMutation = function(oldValue, newValue) {
+  if (!this.webViewImpl.guestInstanceId) {
+    return;
   }
-
-  AutosizeDimensionAttribute.prototype.getValue = function() {
-    return parseInt(this.webViewImpl.webviewNode.getAttribute(this.name)) || 0;
-  };
-
-  AutosizeDimensionAttribute.prototype.handleMutation = function(oldValue, newValue) {
-    if (!this.webViewImpl.guestInstanceId) {
-      return;
+  return guestViewInternal.setSize(this.webViewImpl.guestInstanceId, {
+    enableAutoSize: this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_AUTOSIZE].getValue(),
+    min: {
+      width: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MINWIDTH].getValue() || 0),
+      height: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MINHEIGHT].getValue() || 0)
+    },
+    max: {
+      width: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MAXWIDTH].getValue() || 0),
+      height: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MAXHEIGHT].getValue() || 0)
     }
-    return guestViewInternal.setSize(this.webViewImpl.guestInstanceId, {
-      enableAutoSize: this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_AUTOSIZE].getValue(),
-      min: {
-        width: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MINWIDTH].getValue() || 0),
-        height: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MINHEIGHT].getValue() || 0)
-      },
-      max: {
-        width: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MAXWIDTH].getValue() || 0),
-        height: parseInt(this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_MAXHEIGHT].getValue() || 0)
-      }
-    });
-  };
-
-  return AutosizeDimensionAttribute;
-
-})(WebViewAttribute);
+  });
+};
 
 // Attribute that specifies whether the webview should be autosized.
-var AutosizeAttribute = (function(superClass) {
-  extend(AutosizeAttribute, superClass);
+function AutosizeAttribute(webViewImpl) {
+  AutosizeAttribute.super_.constructor.call(this, webViewConstants.ATTRIBUTE_AUTOSIZE, webViewImpl);
+}
 
-  function AutosizeAttribute(webViewImpl) {
-    AutosizeAttribute.__super__.constructor.call(this, webViewConstants.ATTRIBUTE_AUTOSIZE, webViewImpl);
-  }
+util.inherits(AutosizeAttribute, BooleanAttribute);
 
-  AutosizeAttribute.prototype.handleMutation = AutosizeDimensionAttribute.prototype.handleMutation;
-
-  return AutosizeAttribute;
-
-})(BooleanAttribute);
+AutosizeAttribute.prototype.handleMutation = AutosizeDimensionAttribute.prototype.handleMutation;
 
 // Attribute representing the state of the storage partition.
-var PartitionAttribute = (function(superClass) {
-  extend(PartitionAttribute, superClass);
+function PartitionAttribute(webViewImpl) {
+  PartitionAttribute.super_.constructor.call(this, webViewConstants.ATTRIBUTE_PARTITION, webViewImpl);
+  this.validPartitionId = true;
+}
 
-  function PartitionAttribute(webViewImpl) {
-    PartitionAttribute.__super__.constructor.call(this, webViewConstants.ATTRIBUTE_PARTITION, webViewImpl);
-    this.validPartitionId = true;
+util.inherits(PartitionAttribute, WebViewAttribute);
+
+PartitionAttribute.prototype.handleMutation = function(oldValue, newValue) {
+  newValue = newValue || '';
+
+  // The partition cannot change if the webview has already navigated.
+  if (!this.webViewImpl.beforeFirstNavigation) {
+    window.console.error(webViewConstants.ERROR_MSG_ALREADY_NAVIGATED);
+    this.setValueIgnoreMutation(oldValue);
+    return;
   }
-
-  PartitionAttribute.prototype.handleMutation = function(oldValue, newValue) {
-    newValue = newValue || '';
-
-    // The partition cannot change if the webview has already navigated.
-    if (!this.webViewImpl.beforeFirstNavigation) {
-      window.console.error(webViewConstants.ERROR_MSG_ALREADY_NAVIGATED);
-      this.setValueIgnoreMutation(oldValue);
-      return;
-    }
-    if (newValue === 'persist:') {
-      this.validPartitionId = false;
-      return window.console.error(webViewConstants.ERROR_MSG_INVALID_PARTITION_ATTRIBUTE);
-    }
-  };
-
-  return PartitionAttribute;
-
-})(WebViewAttribute);
+  if (newValue === 'persist:') {
+    this.validPartitionId = false;
+    return window.console.error(webViewConstants.ERROR_MSG_INVALID_PARTITION_ATTRIBUTE);
+  }
+};
 
 // Attribute that handles the location and navigation of the webview.
-var SrcAttribute = (function(superClass) {
-  extend(SrcAttribute, superClass);
+function SrcAttribute(webViewImpl) {
+  SrcAttribute.super_.constructor.call(this, webViewConstants.ATTRIBUTE_SRC, webViewImpl);
+  this.setupMutationObserver();
+}
 
-  function SrcAttribute(webViewImpl) {
-    SrcAttribute.__super__.constructor.call(this, webViewConstants.ATTRIBUTE_SRC, webViewImpl);
-    this.setupMutationObserver();
+util.inherits(SrcAttribute, WebViewAttribute);
+
+SrcAttribute.prototype.getValue = function() {
+  if (this.webViewImpl.webviewNode.hasAttribute(this.name)) {
+    return resolveURL(this.webViewImpl.webviewNode.getAttribute(this.name));
+  } else {
+    return this.value;
+  }
+};
+
+SrcAttribute.prototype.setValueIgnoreMutation = function(value) {
+  WebViewAttribute.prototype.setValueIgnoreMutation.call(this, value);
+
+  // takeRecords() is needed to clear queued up src mutations. Without it, it
+  // is possible for this change to get picked up asyncronously by src's
+  // mutation observer |observer|, and then get handled even though we do not
+  // want to handle this mutation.
+  return this.observer.takeRecords();
+};
+
+SrcAttribute.prototype.handleMutation = function(oldValue, newValue) {
+
+  // Once we have navigated, we don't allow clearing the src attribute.
+  // Once <webview> enters a navigated state, it cannot return to a
+  // placeholder state.
+  if (!newValue && oldValue) {
+
+    // src attribute changes normally initiate a navigation. We suppress
+    // the next src attribute handler call to avoid reloading the page
+    // on every guest-initiated navigation.
+    this.setValueIgnoreMutation(oldValue);
+    return;
+  }
+  return this.parse();
+};
+
+// The purpose of this mutation observer is to catch assignment to the src
+// attribute without any changes to its value. This is useful in the case
+// where the webview guest has crashed and navigating to the same address
+// spawns off a new process.
+SrcAttribute.prototype.setupMutationObserver = function() {
+  var params;
+  this.observer = new MutationObserver((function(_this) {
+    return function(mutations) {
+      var i, len, mutation, newValue, oldValue;
+      for (i = 0, len = mutations.length; i < len; i++) {
+        mutation = mutations[i];
+        oldValue = mutation.oldValue;
+        newValue = _this.getValue();
+        if (oldValue !== newValue) {
+          return;
+        }
+        _this.handleMutation(oldValue, newValue);
+      }
+    };
+  })(this));
+  params = {
+    attributes: true,
+    attributeOldValue: true,
+    attributeFilter: [this.name]
+  };
+  return this.observer.observe(this.webViewImpl.webviewNode, params);
+};
+
+SrcAttribute.prototype.parse = function() {
+  var guestContents, httpreferrer, opts, useragent;
+  if (!this.webViewImpl.elementAttached || !this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_PARTITION].validPartitionId || !this.getValue()) {
+    return;
+  }
+  if (this.webViewImpl.guestInstanceId == null) {
+    if (this.webViewImpl.beforeFirstNavigation) {
+      this.webViewImpl.beforeFirstNavigation = false;
+      this.webViewImpl.createGuest();
+    }
+    return;
   }
 
-  SrcAttribute.prototype.getValue = function() {
-    if (this.webViewImpl.webviewNode.hasAttribute(this.name)) {
-      return resolveURL(this.webViewImpl.webviewNode.getAttribute(this.name));
-    } else {
-      return this.value;
-    }
-  };
-
-  SrcAttribute.prototype.setValueIgnoreMutation = function(value) {
-    WebViewAttribute.prototype.setValueIgnoreMutation.call(this, value);
-
-    // takeRecords() is needed to clear queued up src mutations. Without it, it
-    // is possible for this change to get picked up asyncronously by src's
-    // mutation observer |observer|, and then get handled even though we do not
-    // want to handle this mutation.
-    return this.observer.takeRecords();
-  };
-
-  SrcAttribute.prototype.handleMutation = function(oldValue, newValue) {
-
-    // Once we have navigated, we don't allow clearing the src attribute.
-    // Once <webview> enters a navigated state, it cannot return to a
-    // placeholder state.
-    if (!newValue && oldValue) {
-
-      // src attribute changes normally initiate a navigation. We suppress
-      // the next src attribute handler call to avoid reloading the page
-      // on every guest-initiated navigation.
-      this.setValueIgnoreMutation(oldValue);
-      return;
-    }
-    return this.parse();
-  };
-
-
-  // The purpose of this mutation observer is to catch assignment to the src
-  // attribute without any changes to its value. This is useful in the case
-  // where the webview guest has crashed and navigating to the same address
-  // spawns off a new process.
-  SrcAttribute.prototype.setupMutationObserver = function() {
-    var params;
-    this.observer = new MutationObserver((function(_this) {
-      return function(mutations) {
-        var i, len, mutation, newValue, oldValue;
-        for (i = 0, len = mutations.length; i < len; i++) {
-          mutation = mutations[i];
-          oldValue = mutation.oldValue;
-          newValue = _this.getValue();
-          if (oldValue !== newValue) {
-            return;
-          }
-          _this.handleMutation(oldValue, newValue);
-        }
-      };
-    })(this));
-    params = {
-      attributes: true,
-      attributeOldValue: true,
-      attributeFilter: [this.name]
-    };
-    return this.observer.observe(this.webViewImpl.webviewNode, params);
-  };
-
-  SrcAttribute.prototype.parse = function() {
-    var guestContents, httpreferrer, opts, useragent;
-    if (!this.webViewImpl.elementAttached || !this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_PARTITION].validPartitionId || !this.getValue()) {
-      return;
-    }
-    if (this.webViewImpl.guestInstanceId == null) {
-      if (this.webViewImpl.beforeFirstNavigation) {
-        this.webViewImpl.beforeFirstNavigation = false;
-        this.webViewImpl.createGuest();
-      }
-      return;
-    }
-
-    // Navigate to |this.src|.
-    opts = {};
-    httpreferrer = this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER].getValue();
-    if (httpreferrer) {
-      opts.httpReferrer = httpreferrer;
-    }
-    useragent = this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_USERAGENT].getValue();
-    if (useragent) {
-      opts.userAgent = useragent;
-    }
-    guestContents = remote.getGuestWebContents(this.webViewImpl.guestInstanceId);
-    return guestContents.loadURL(this.getValue(), opts);
-  };
-
-  return SrcAttribute;
-
-})(WebViewAttribute);
+  // Navigate to |this.src|.
+  opts = {};
+  httpreferrer = this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_HTTPREFERRER].getValue();
+  if (httpreferrer) {
+    opts.httpReferrer = httpreferrer;
+  }
+  useragent = this.webViewImpl.attributes[webViewConstants.ATTRIBUTE_USERAGENT].getValue();
+  if (useragent) {
+    opts.userAgent = useragent;
+  }
+  guestContents = remote.getGuestWebContents(this.webViewImpl.guestInstanceId);
+  return guestContents.loadURL(this.getValue(), opts);
+};
 
 // Attribute specifies HTTP referrer.
-var HttpReferrerAttribute = (function(superClass) {
-  extend(HttpReferrerAttribute, superClass);
+function HttpReferrerAttribute(webViewImpl) {
+  HttpReferrerAttribute.super_.constructor.call(this, webViewConstants.ATTRIBUTE_HTTPREFERRER, webViewImpl);
+}
 
-  function HttpReferrerAttribute(webViewImpl) {
-    HttpReferrerAttribute.__super__.constructor.call(this, webViewConstants.ATTRIBUTE_HTTPREFERRER, webViewImpl);
-  }
-
-  return HttpReferrerAttribute;
-
-})(WebViewAttribute);
+util.inherits(HttpReferrerAttribute, WebViewAttribute);
 
 // Attribute specifies user agent
-var UserAgentAttribute = (function(superClass) {
-  extend(UserAgentAttribute, superClass);
+function UserAgentAttribute(webViewImpl) {
+  UserAgentAttribute.super_.constructor.call(this, webViewConstants.ATTRIBUTE_USERAGENT, webViewImpl);
+}
 
-  function UserAgentAttribute(webViewImpl) {
-    UserAgentAttribute.__super__.constructor.call(this, webViewConstants.ATTRIBUTE_USERAGENT, webViewImpl);
-  }
-
-  return UserAgentAttribute;
-
-})(WebViewAttribute);
+util.inherits(UserAgentAttribute, WebViewAttribute);
 
 // Attribute that set preload script.
-var PreloadAttribute = (function(superClass) {
-  extend(PreloadAttribute, superClass);
+function PreloadAttribute(webViewImpl) {
+  PreloadAttribute.super_.constructor.call(this, webViewConstants.ATTRIBUTE_PRELOAD, webViewImpl);
+}
 
-  function PreloadAttribute(webViewImpl) {
-    PreloadAttribute.__super__.constructor.call(this, webViewConstants.ATTRIBUTE_PRELOAD, webViewImpl);
+util.inherits(PreloadAttribute, WebViewAttribute);
+
+PreloadAttribute.prototype.getValue = function() {
+  var preload, protocol;
+  if (!this.webViewImpl.webviewNode.hasAttribute(this.name)) {
+    return this.value;
   }
-
-  PreloadAttribute.prototype.getValue = function() {
-    var preload, protocol;
-    if (!this.webViewImpl.webviewNode.hasAttribute(this.name)) {
-      return this.value;
-    }
-    preload = resolveURL(this.webViewImpl.webviewNode.getAttribute(this.name));
-    protocol = preload.substr(0, 5);
-    if (protocol !== 'file:') {
-      console.error(webViewConstants.ERROR_MSG_INVALID_PRELOAD_ATTRIBUTE);
-      preload = '';
-    }
-    return preload;
-  };
-
-  return PreloadAttribute;
-
-})(WebViewAttribute);
+  preload = resolveURL(this.webViewImpl.webviewNode.getAttribute(this.name));
+  protocol = preload.substr(0, 5);
+  if (protocol !== 'file:') {
+    console.error(webViewConstants.ERROR_MSG_INVALID_PRELOAD_ATTRIBUTE);
+    preload = '';
+  }
+  return preload;
+};
 
 // Sets up all of the webview attributes.
 WebViewImpl.prototype.setupWebViewAttributes = function() {

--- a/atom/renderer/lib/web-view/web-view-attributes.js
+++ b/atom/renderer/lib/web-view/web-view-attributes.js
@@ -122,7 +122,7 @@ AutosizeDimensionAttribute.prototype.handleMutation = function(oldValue, newValu
 
 // Attribute that specifies whether the webview should be autosized.
 function AutosizeAttribute(webViewImpl) {
-  AutosizeAttribute.super_.constructor.call(this, webViewConstants.ATTRIBUTE_AUTOSIZE, webViewImpl);
+  AutosizeAttribute.super_.call(this, webViewConstants.ATTRIBUTE_AUTOSIZE, webViewImpl);
 }
 
 util.inherits(AutosizeAttribute, BooleanAttribute);
@@ -131,7 +131,7 @@ AutosizeAttribute.prototype.handleMutation = AutosizeDimensionAttribute.prototyp
 
 // Attribute representing the state of the storage partition.
 function PartitionAttribute(webViewImpl) {
-  PartitionAttribute.super_.constructor.call(this, webViewConstants.ATTRIBUTE_PARTITION, webViewImpl);
+  PartitionAttribute.super_.call(this, webViewConstants.ATTRIBUTE_PARTITION, webViewImpl);
   this.validPartitionId = true;
 }
 
@@ -154,7 +154,7 @@ PartitionAttribute.prototype.handleMutation = function(oldValue, newValue) {
 
 // Attribute that handles the location and navigation of the webview.
 function SrcAttribute(webViewImpl) {
-  SrcAttribute.super_.constructor.call(this, webViewConstants.ATTRIBUTE_SRC, webViewImpl);
+  SrcAttribute.super_.call(this, webViewConstants.ATTRIBUTE_SRC, webViewImpl);
   this.setupMutationObserver();
 }
 
@@ -251,21 +251,21 @@ SrcAttribute.prototype.parse = function() {
 
 // Attribute specifies HTTP referrer.
 function HttpReferrerAttribute(webViewImpl) {
-  HttpReferrerAttribute.super_.constructor.call(this, webViewConstants.ATTRIBUTE_HTTPREFERRER, webViewImpl);
+  HttpReferrerAttribute.super_.call(this, webViewConstants.ATTRIBUTE_HTTPREFERRER, webViewImpl);
 }
 
 util.inherits(HttpReferrerAttribute, WebViewAttribute);
 
 // Attribute specifies user agent
 function UserAgentAttribute(webViewImpl) {
-  UserAgentAttribute.super_.constructor.call(this, webViewConstants.ATTRIBUTE_USERAGENT, webViewImpl);
+  UserAgentAttribute.super_.call(this, webViewConstants.ATTRIBUTE_USERAGENT, webViewImpl);
 }
 
 util.inherits(UserAgentAttribute, WebViewAttribute);
 
 // Attribute that set preload script.
 function PreloadAttribute(webViewImpl) {
-  PreloadAttribute.super_.constructor.call(this, webViewConstants.ATTRIBUTE_PRELOAD, webViewImpl);
+  PreloadAttribute.super_.call(this, webViewConstants.ATTRIBUTE_PRELOAD, webViewImpl);
 }
 
 util.inherits(PreloadAttribute, WebViewAttribute);


### PR DESCRIPTION
- [x] Use `[].includes` instead of `[].indexOf` where appropriate
- [x] Remove unused `indexOf` fallback implementation
- [x] Use [ES6 classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) instead of inlined `extend` helper previously provided by CoffeeScript

Refs #4065 

/cc @jlord @zcbenz :eyes: 