### PR TITLE
Fix lint errors in archive.cc

### DIFF
--- a/atom/common/asar/archive.cc
+++ b/atom/common/asar/archive.cc
@@ -130,7 +130,7 @@ Archive::Archive(const base::FilePath& path)
 
 Archive::~Archive() {
 #if defined(OS_WIN)
-   _close(fd_)
+  _close(fd_)
 #endif
 }
 

--- a/atom/common/asar/archive.cc
+++ b/atom/common/asar/archive.cc
@@ -130,7 +130,7 @@ Archive::Archive(const base::FilePath& path)
 
 Archive::~Archive() {
 #if defined(OS_WIN)
-  _close(fd_)
+  _close(fd_);
 #endif
 }
 


### PR DESCRIPTION
- Use 2 space indent instead of 3
- Add `;` to the end of the line

Refs #4118