### PR TITLE
Add API for checking if DWM composition (Aero Glass) is enabled

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -37,6 +37,7 @@
 
 #if defined(OS_WIN)
 #include "base/strings/utf_string_conversions.h"
+#include "ui/base/win/shell.h"
 #endif
 
 using atom::Browser;
@@ -318,6 +319,12 @@ std::string App::GetLocale() {
   return l10n_util::GetApplicationLocale("");
 }
 
+#if defined(OS_WIN)
+bool App::IsAeroGlassEnabled() {
+  return ui::win::IsAeroGlassEnabled();
+}
+#endif
+
 bool App::MakeSingleInstance(
     const ProcessSingleton::NotificationCallback& callback) {
   if (process_singleton_.get())
@@ -361,6 +368,7 @@ mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(
 #if defined(OS_WIN)
       .SetMethod("setUserTasks",
                  base::Bind(&Browser::SetUserTasks, browser))
+      .SetMethod("isAeroGlassEnabled", &App::IsAeroGlassEnabled)
 #endif
       .SetMethod("setPath", &App::SetPath)
       .SetMethod("getPath", &App::GetPath)

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -88,6 +88,10 @@ class App : public AtomBrowserClient::Delegate,
       const ProcessSingleton::NotificationCallback& callback);
   std::string GetLocale();
 
+#if defined(OS_WIN)
+  bool IsAeroGlassEnabled();
+#endif
+
   scoped_ptr<ProcessSingleton> process_singleton_;
 
   DISALLOW_COPY_AND_ASSIGN(App);

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -400,7 +400,7 @@ starts:
 var myWindow = null;
 
 var shouldQuit = app.makeSingleInstance(function(commandLine, workingDirectory) {
-  // Someone tried to run a second instance, we should focus our window
+  // Someone tried to run a second instance, we should focus our window.
   if (myWindow) {
     if (myWindow.isMinimized()) myWindow.restore();
     myWindow.focus();
@@ -423,6 +423,36 @@ app.on('ready', function() {
 * `id` String
 
 Changes the [Application User Model ID][app-user-model-id] to `id`.
+
+### `app.isAeroGlassEnabled()` _Windows_
+
+This method returns `true` if [DWM composition](https://msdn.microsoft.com/en-us/library/windows/desktop/aa969540.aspx)
+(Aero Glass) is enabled, and `false` otherwise. You can use it to determine if
+you should create a transparent window or not (transparent windows won't work
+correctly when DWM composition is disabled).
+
+Usage example:
+
+```js
+let browserOptions = {width: 1000, height: 800};
+
+// Make the window transparent only if the platform supports it.
+if (process.platform !== 'win32' || app.isAeroGlassEnabled()) {
+  browserOptions.transparent = true;
+  browserOptions.frame = false;
+}
+
+// Create the window.
+win = new BrowserWindow(browserOptions);
+
+// Navigate.
+if (browserOptions.transparent) {
+  win.loadURL('file://' + __dirname + '/index.html');
+} else {
+  // No transparency, so we load a fallback that uses basic styles.
+  win.loadURL('file://' + __dirname + '/fallback.html');
+}
+```
 
 ### `app.commandLine.appendSwitch(switch[, value])`
 


### PR DESCRIPTION
Resolves #1020.

For future reference, it is possible to disable DWM on Windows 8+ (some sources mistakenly claim it's only possible in Vista and 7). Instructions are available [here](http://www.overclock.net/t/1441921/windows-8-1-no-dwm-aka-aero-aka-desktop-composition#post_22483531).