### PR TITLE
Add npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "private": true,
   "scripts": {
     "preinstall": "node -e 'process.exit(0)'",
+    "start": "python ./script/start.py",
     "test": "python ./script/test.py"
   }
 }

--- a/script/start.py
+++ b/script/start.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import sys
+
+from lib.util import atom_gyp
+
+
+SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+
+PROJECT_NAME = atom_gyp()['project_name%']
+PRODUCT_NAME = atom_gyp()['product_name%']
+
+
+def main():
+  os.chdir(SOURCE_ROOT)
+
+  config = 'D'
+  if '-R' in sys.argv:
+    config = 'R'
+
+  if sys.platform == 'darwin':
+    electron = os.path.join(SOURCE_ROOT, 'out', config,
+                              '{0}.app'.format(PRODUCT_NAME), 'Contents',
+                              'MacOS', PRODUCT_NAME)
+  elif sys.platform == 'win32':
+    electron = os.path.join(SOURCE_ROOT, 'out', config,
+                              '{0}.exe'.format(PROJECT_NAME))
+  else:
+    electron = os.path.join(SOURCE_ROOT, 'out', config, PROJECT_NAME)
+
+  try:
+    subprocess.check_call([electron] + sys.argv[1:])
+  except KeyboardInterrupt:
+    return -1
+
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
Adds a simple `script/start.py` that is wired up to `npm start`.

Allows you to launch the built version with `npm start` and also pass in args so `npm start -- -v` will print the Electron version.

Defaults to using the debug build.

/cc @jlord @zcbenz 