### PR TITLE
Fix a broken link

### DIFF
--- a/docs/api/synopsis.md
+++ b/docs/api/synopsis.md
@@ -11,7 +11,7 @@ both processes.
 
 The basic rule is: if a module is [GUI][gui] or low-level system related, then
 it should be only available in the main process. You need to be familiar with
-the concept of [main process vs. renderer process][main-process] scripts to be
+the concept of [main process vs. renderer process](../tutorial/quick-start.md#the-main-process) scripts to be
 able to use those modules.
 
 The main process script is just like a normal Node.js script:
@@ -79,6 +79,5 @@ require('electron').hideInternalModules()
 ```
 
 [gui]: https://en.wikipedia.org/wiki/Graphical_user_interface
-[main-process]: ../tutorial/quick-start.md#the-main-process
 [desctructuring-assignment]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment
 [issue-387]: https://github.com/atom/electron/issues/387


### PR DESCRIPTION
The reference-style link uses a relative path, which doesn't work well on the main site http://electron.atom.io/.