### PR TITLE
Improvements in BrowserWindow

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -424,6 +424,22 @@ bool Window::IsMinimizable() {
   return window_->IsMinimizable();
 }
 
+void Window::SetMaximizable(bool maximizable) {
+  window_->SetMaximizable(maximizable);
+}
+
+bool Window::IsMaximizable() {
+  return window_->IsMaximizable();
+}
+
+void Window::SetFullscreenable(bool fullscreenable) {
+  window_->SetFullscreenable(fullscreenable);
+}
+
+bool Window::IsFullscreenable() {
+  return window_->IsFullscreenable();
+}
+
 void Window::SetClosable(bool closable) {
   window_->SetClosable(closable);
 }
@@ -687,6 +703,10 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isMovable", &Window::IsMovable)
       .SetMethod("setMinimizable", &Window::SetMinimizable)
       .SetMethod("isMinimizable", &Window::IsMinimizable)
+      .SetMethod("setMaximizable", &Window::SetMaximizable)
+      .SetMethod("isMaximizable", &Window::IsMaximizable)
+      .SetMethod("setFullscreenable", &Window::SetFullscreenable)
+      .SetMethod("isFullscreenable", &Window::IsFullscreenable)
       .SetMethod("setClosable", &Window::SetClosable)
       .SetMethod("isClosable", &Window::IsClosable)
       .SetMethod("setAlwaysOnTop", &Window::SetAlwaysOnTop)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -408,6 +408,30 @@ bool Window::IsResizable() {
   return window_->IsResizable();
 }
 
+void Window::SetMovable(bool movable) {
+  window_->SetMovable(movable);
+}
+
+bool Window::IsMovable() {
+  return window_->IsMovable();
+}
+
+void Window::SetMinimizable(bool minimizable) {
+  window_->SetMinimizable(minimizable);
+}
+
+bool Window::IsMinimizable() {
+  return window_->IsMinimizable();
+}
+
+void Window::SetClosable(bool closable) {
+  window_->SetClosable(closable);
+}
+
+bool Window::IsClosable() {
+  return window_->IsClosable();
+}
+
 void Window::SetAlwaysOnTop(bool top) {
   window_->SetAlwaysOnTop(top);
 }
@@ -659,6 +683,12 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getMaximumSize", &Window::GetMaximumSize)
       .SetMethod("setResizable", &Window::SetResizable)
       .SetMethod("isResizable", &Window::IsResizable)
+      .SetMethod("setMovable", &Window::SetMovable)
+      .SetMethod("isMovable", &Window::IsMovable)
+      .SetMethod("setMinimizable", &Window::SetMinimizable)
+      .SetMethod("isMinimizable", &Window::IsMinimizable)
+      .SetMethod("setClosable", &Window::SetClosable)
+      .SetMethod("isClosable", &Window::IsClosable)
       .SetMethod("setAlwaysOnTop", &Window::SetAlwaysOnTop)
       .SetMethod("isAlwaysOnTop", &Window::IsAlwaysOnTop)
       .SetMethod("center", &Window::Center)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -106,6 +106,12 @@ class Window : public mate::TrackableObject<Window>,
   std::vector<int> GetMaximumSize();
   void SetResizable(bool resizable);
   bool IsResizable();
+  void SetMovable(bool movable);
+  bool IsMovable();
+  void SetMinimizable(bool minimizable);
+  bool IsMinimizable();
+  void SetClosable(bool closable);
+  bool IsClosable();
   void SetAlwaysOnTop(bool top);
   bool IsAlwaysOnTop();
   void Center();

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -110,6 +110,10 @@ class Window : public mate::TrackableObject<Window>,
   bool IsMovable();
   void SetMinimizable(bool minimizable);
   bool IsMinimizable();
+  void SetMaximizable(bool maximizable);
+  bool IsMaximizable();
+  void SetFullscreenable(bool fullscreenable);
+  bool IsFullscreenable();
   void SetClosable(bool closable);
   bool IsClosable();
   void SetAlwaysOnTop(bool top);

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -128,6 +128,10 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   if (options.Get(options::kClosable, &closable)) {
     SetClosable(closable);
   }
+  bool maximizable;
+  if (options.Get(options::kMaximizable, &maximizable)) {
+    SetMaximizable(maximizable);
+  }
 #endif
   bool top;
   if (options.Get(options::kAlwaysOnTop, &top) && top) {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -120,6 +120,14 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   if (options.Get(options::kResizable, &resizable)) {
     SetResizable(resizable);
   }
+  bool minimizable;
+  if (options.Get(options::kMinimizable, &minimizable)) {
+    SetMinimizable(minimizable);
+  }
+  bool closable;
+  if (options.Get(options::kClosable, &closable)) {
+    SetClosable(closable);
+  }
 #endif
   bool top;
   if (options.Get(options::kAlwaysOnTop, &top) && top) {

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -125,6 +125,12 @@ class NativeWindow : public base::SupportsUserData,
   virtual gfx::Size GetMaximumSize();
   virtual void SetResizable(bool resizable) = 0;
   virtual bool IsResizable() = 0;
+  virtual void SetMovable(bool movable) = 0;
+  virtual bool IsMovable() = 0;
+  virtual void SetMinimizable(bool minimizable) = 0;
+  virtual bool IsMinimizable() = 0;
+  virtual void SetClosable(bool closable) = 0;
+  virtual bool IsClosable() = 0;
   virtual void SetAlwaysOnTop(bool top) = 0;
   virtual bool IsAlwaysOnTop() = 0;
   virtual void Center() = 0;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -129,6 +129,10 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsMovable() = 0;
   virtual void SetMinimizable(bool minimizable) = 0;
   virtual bool IsMinimizable() = 0;
+  virtual void SetMaximizable(bool maximizable) = 0;
+  virtual bool IsMaximizable() = 0;
+  virtual void SetFullscreenable(bool fullscreenable) = 0;
+  virtual bool IsFullscreenable() = 0;
   virtual void SetClosable(bool closable) = 0;
   virtual bool IsClosable() = 0;
   virtual void SetAlwaysOnTop(bool top) = 0;

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -52,6 +52,10 @@ class NativeWindowMac : public NativeWindow {
   bool IsMovable() override;
   void SetMinimizable(bool minimizable) override;
   bool IsMinimizable() override;
+  void SetMaximizable(bool maximizable) override;
+  bool IsMaximizable() override;
+  void SetFullscreenable(bool fullscreenable) override;
+  bool IsFullscreenable() override;
   void SetClosable(bool closable) override;
   bool IsClosable() override;
   void SetAlwaysOnTop(bool top) override;
@@ -106,7 +110,6 @@ class NativeWindowMac : public NativeWindow {
   gfx::Size WindowSizeToContentSize(const gfx::Size& size) override;
   void UpdateDraggableRegions(
       const std::vector<DraggableRegion>& regions) override;
-  void FixZoomButton();
 
   void InstallView();
   void UninstallView();

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -48,6 +48,12 @@ class NativeWindowMac : public NativeWindow {
       const extensions::SizeConstraints& size_constraints) override;
   void SetResizable(bool resizable) override;
   bool IsResizable() override;
+  void SetMovable(bool movable) override;
+  bool IsMovable() override;
+  void SetMinimizable(bool minimizable) override;
+  bool IsMinimizable() override;
+  void SetClosable(bool closable) override;
+  bool IsClosable() override;
   void SetAlwaysOnTop(bool top) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
@@ -100,6 +106,7 @@ class NativeWindowMac : public NativeWindow {
   gfx::Size WindowSizeToContentSize(const gfx::Size& size) override;
   void UpdateDraggableRegions(
       const std::vector<DraggableRegion>& regions) override;
+  void FixZoomButton();
 
   void InstallView();
   void UninstallView();

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -649,13 +649,17 @@ void NativeWindowMac::SetContentSizeConstraints(
 }
 
 void NativeWindowMac::SetResizable(bool resizable) {
+  bool maximizable = IsMaximizable();
   // Change styleMask for frameless causes the window to change size, so we have
   // to explicitly disables that.
   ScopedDisableResize disable_resize;
   if (resizable) {
     [window_ setStyleMask:[window_ styleMask] | NSResizableWindowMask];
   } else {
-    [[window_ standardWindowButton:NSWindowZoomButton] setEnabled:NO];
+    [window_ setStyleMask:[window_ styleMask] & (~NSResizableWindowMask)];
+  }
+  if (!maximizable) {
+    SetMaximizable(false);
   }
 }
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -139,6 +139,7 @@ NativeWindowViews::NativeWindowViews(
   options.Get(options::kResizable, &resizable_);
   options.Get(options::kMovable, &movable_);
   options.Get(options::kMinimizable, &minimizable_);
+  options.Get(options::kMaximizable, &maximizable_);
 #endif
 
   if (enable_larger_than_screen())
@@ -187,9 +188,7 @@ NativeWindowViews::NativeWindowViews(
   window_->Init(params);
 
   bool fullscreen = false;
-  if (options.Get(options::kFullscreen, &fullscreen) && !fullscreen) {
-    maximizable_ = false;
-  }
+  options.Get(options::kFullscreen, &fullscreen);
 
 #if defined(USE_X11)
   // Start monitoring window states.
@@ -245,11 +244,6 @@ NativeWindowViews::NativeWindowViews(
 
   DWORD style = ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE);
   style |= WS_THICKFRAME | WS_CAPTION | WS_MINIMIZEBOX;
-  if (!maximizable_) {
-    style &= (~WS_MAXIMIZEBOX);
-  } else {
-    style |= WS_MAXIMIZEBOX;
-  }
 
   if (transparent()) {
     DWORD ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);
@@ -441,9 +435,8 @@ void NativeWindowViews::SetResizable(bool resizable) {
     DWORD style = ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE);
     if (resizable) {
       style |= WS_THICKFRAME;
-      if (maximizable_) style |= WS_MAXIMIZEBOX;
     } else {
-      style &= ~(WS_THICKFRAME | WS_MAXIMIZEBOX);
+      style &= ~(WS_THICKFRAME);
     }
     ::SetWindowLong(GetAcceleratedWidget(), GWL_STYLE, style);
   }
@@ -503,6 +496,33 @@ bool NativeWindowViews::IsMinimizable() {
 #elif defined(USE_X11)
   return true;
 #endif
+}
+
+void NativeWindowViews::SetMaximizable(bool maximizable) {
+#if defined(OS_WIN)
+  DWORD style = ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE);
+  if (maximizable) {
+    style |= WS_MAXIMIZEBOX;
+  } else {
+    style &= (~WS_MAXIMIZEBOX);
+  }
+  ::SetWindowLong(GetAcceleratedWidget(), GWL_STYLE, style);
+#endif
+}
+
+bool NativeWindowViews::IsMaximizable() {
+#if defined(OS_WIN)
+  return ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_MAXIMIZEBOX;
+#elif defined(USE_X11)
+  return true;
+#endif
+}
+
+void NativeWindowViews::SetFullscreenable(bool maximizable) {
+}
+
+bool NativeWindowViews::IsFullscreenable() {
+  return true;
 }
 
 void NativeWindowViews::SetClosable(bool closable) {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -793,7 +793,7 @@ bool NativeWindowViews::CanMaximize() const {
 }
 
 bool NativeWindowViews::CanMinimize() const {
-#ifdef(OS_WIN)
+#if defined(OS_WIN)
   return minimizable_;
 #elif defined(USE_X11)
   return true;

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -475,7 +475,11 @@ void NativeWindowViews::SetMovable(bool movable) {
 }
 
 bool NativeWindowViews::IsMovable() {
+#if defined(OS_WIN)
   return movable_;
+#elif defined(USE_X11)
+  return true;
+#endif
 }
 
 void NativeWindowViews::SetMinimizable(bool minimizable) {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -126,7 +126,10 @@ NativeWindowViews::NativeWindowViews(
       menu_bar_alt_pressed_(false),
       keyboard_event_handler_(new views::UnhandledKeyboardEventHandler),
       use_content_size_(false),
-      resizable_(true) {
+      resizable_(true),
+      maximizable_(true),
+      movable_(true),
+      minimizable_(true) {
   options.Get(options::kTitle, &title_);
   options.Get(options::kAutoHideMenuBar, &menu_bar_autohide_);
 
@@ -134,6 +137,8 @@ NativeWindowViews::NativeWindowViews(
   // On Windows we rely on the CanResize() to indicate whether window can be
   // resized, and it should be set before window is created.
   options.Get(options::kResizable, &resizable_);
+  options.Get(options::kMovable, &movable_);
+  options.Get(options::kMinimizable, &minimizable_);
 #endif
 
   if (enable_larger_than_screen())
@@ -182,7 +187,9 @@ NativeWindowViews::NativeWindowViews(
   window_->Init(params);
 
   bool fullscreen = false;
-  options.Get(options::kFullscreen, &fullscreen);
+  if (options.Get(options::kFullscreen, &fullscreen) && !fullscreen) {
+    maximizable_ = false;
+  }
 
 #if defined(USE_X11)
   // Start monitoring window states.
@@ -236,22 +243,27 @@ NativeWindowViews::NativeWindowViews(
 
   last_normal_size_ = gfx::Size(widget_size_);
 
-  if (!has_frame()) {
-    // Set Window style so that we get a minimize and maximize animation when
-    // frameless.
-    DWORD frame_style = WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX |
-                        WS_CAPTION;
-    // We should not show a frame for transparent window.
-    if (transparent())
-      frame_style &= ~(WS_THICKFRAME | WS_CAPTION);
-    ::SetWindowLong(GetAcceleratedWidget(), GWL_STYLE, frame_style);
+  DWORD style = ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE);
+  style |= WS_THICKFRAME | WS_CAPTION | WS_MINIMIZEBOX;
+  if (!maximizable_) {
+    style &= (~WS_MAXIMIZEBOX);
+  } else {
+    style |= WS_MAXIMIZEBOX;
   }
 
   if (transparent()) {
-    // Transparent window on Windows has to have WS_EX_COMPOSITED style.
-    LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);
+    DWORD ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);
     ex_style |= WS_EX_COMPOSITED;
     ::SetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE, ex_style);
+
+    if (!has_frame()) {
+      // We should not show a frame for transparent window.
+      style &= ~(WS_THICKFRAME | WS_CAPTION);
+    }
+  }
+
+  if (!transparent() || !has_frame()) {
+    ::SetWindowLong(GetAcceleratedWidget(), GWL_STYLE, style);
   }
 #endif
 
@@ -427,10 +439,12 @@ void NativeWindowViews::SetResizable(bool resizable) {
   // WS_THICKFRAME => Resize handle
   if (!transparent()) {
     DWORD style = ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE);
-    if (resizable)
-      style |= WS_MAXIMIZEBOX | WS_MINIMIZEBOX | WS_THICKFRAME;
-    else
-      style = (style & ~(WS_MAXIMIZEBOX | WS_THICKFRAME)) | WS_MINIMIZEBOX;
+    if (resizable) {
+      style |= WS_THICKFRAME;
+      if (maximizable_) style |= WS_MAXIMIZEBOX;
+    } else {
+      style &= ~(WS_THICKFRAME | WS_MAXIMIZEBOX);
+    }
     ::SetWindowLong(GetAcceleratedWidget(), GWL_STYLE, style);
   }
 #elif defined(USE_X11)
@@ -454,6 +468,64 @@ void NativeWindowViews::SetResizable(bool resizable) {
 
 bool NativeWindowViews::IsResizable() {
   return resizable_;
+}
+
+void NativeWindowViews::SetMovable(bool movable) {
+  movable_ = movable;
+}
+
+bool NativeWindowViews::IsMovable() {
+  return movable_;
+}
+
+void NativeWindowViews::SetMinimizable(bool minimizable) {
+#if defined(OS_WIN)
+  if (!transparent()) {
+    DWORD style = ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE);
+    if (minimizable)
+      style |= WS_MINIMIZEBOX;
+    else
+      style &= (~WS_MINIMIZEBOX);
+    ::SetWindowLong(GetAcceleratedWidget(), GWL_STYLE, style);
+  }
+#endif
+
+  minimizable_ = minimizable;
+}
+
+bool NativeWindowViews::IsMinimizable() {
+#if defined(OS_WIN)
+  return ::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_MINIMIZEBOX;
+#elif defined(USE_X11)
+  return true;
+#endif
+}
+
+void NativeWindowViews::SetClosable(bool closable) {
+#if defined(OS_WIN)
+  HMENU menu = GetSystemMenu(GetAcceleratedWidget(), false);
+  if (closable) {
+    EnableMenuItem(menu, SC_CLOSE, MF_BYCOMMAND | MF_ENABLED);
+  } else {
+    EnableMenuItem(menu, SC_CLOSE, MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
+  }
+#endif
+}
+
+bool NativeWindowViews::IsClosable() {
+#if defined(OS_WIN)
+  HMENU menu = GetSystemMenu(GetAcceleratedWidget(), false);
+  MENUITEMINFO info;
+  memset(&info, 0, sizeof(info));
+  info.cbSize = sizeof(info);
+  info.fMask = MIIM_STATE;
+  if (!GetMenuItemInfo(menu, SC_CLOSE, false, &info)) {
+    return false;
+  }
+  return !(info.fState & MFS_DISABLED);
+#elif defined(USE_X11)
+  return true;
+#endif
 }
 
 void NativeWindowViews::SetAlwaysOnTop(bool top) {
@@ -717,7 +789,11 @@ bool NativeWindowViews::CanMaximize() const {
 }
 
 bool NativeWindowViews::CanMinimize() const {
+#ifdef (OS_WIN)
+  return minimizable_;
+#elif defined(USE_X11)
   return true;
+#endif
 }
 
 base::string16 NativeWindowViews::GetWindowTitle() const {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -789,7 +789,7 @@ bool NativeWindowViews::CanMaximize() const {
 }
 
 bool NativeWindowViews::CanMinimize() const {
-#ifdef (OS_WIN)
+#ifdef(OS_WIN)
   return minimizable_;
 #elif defined(USE_X11)
   return true;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -72,6 +72,10 @@ class NativeWindowViews : public NativeWindow,
   bool IsMovable() override;
   void SetMinimizable(bool minimizable) override;
   bool IsMinimizable() override;
+  void SetMaximizable(bool maximizable) override;
+  bool IsMaximizable() override;
+  void SetFullscreenable(bool fullscreenable) override;
+  bool IsFullscreenable() override;
   void SetClosable(bool closable) override;
   bool IsClosable() override;
   void SetAlwaysOnTop(bool top) override;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -68,6 +68,12 @@ class NativeWindowViews : public NativeWindow,
       const extensions::SizeConstraints& size_constraints) override;
   void SetResizable(bool resizable) override;
   bool IsResizable() override;
+  void SetMovable(bool movable) override;
+  bool IsMovable() override;
+  void SetMinimizable(bool minimizable) override;
+  bool IsMinimizable() override;
+  void SetClosable(bool closable) override;
+  bool IsClosable() override;
   void SetAlwaysOnTop(bool top) override;
   bool IsAlwaysOnTop() override;
   void Center() override;
@@ -197,6 +203,9 @@ class NativeWindowViews : public NativeWindow,
 
   bool use_content_size_;
   bool resizable_;
+  bool maximizable_;
+  bool movable_;
+  bool minimizable_;
   std::string title_;
   gfx::Size widget_size_;
 

--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -89,10 +89,19 @@ bool NativeWindowViews::PreHandleMSG(
       if (HIWORD(w_param) == THBN_CLICKED)
         return taskbar_host_.HandleThumbarButtonEvent(LOWORD(w_param));
       return false;
+
     case WM_SIZE:
       // Handle window state change.
       HandleSizeEvent(w_param, l_param);
       return false;
+
+    case WM_MOVING: {
+      if (!movable_) {
+        ::GetWindowRect(GetAcceleratedWidget(), (LPRECT)l_param);
+      }
+      return false;
+    }
+
     default:
       return false;
   }

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -8,24 +8,26 @@ namespace atom {
 
 namespace options {
 
-const char kTitle[]       = "title";
-const char kIcon[]        = "icon";
-const char kFrame[]       = "frame";
-const char kShow[]        = "show";
-const char kCenter[]      = "center";
-const char kX[]           = "x";
-const char kY[]           = "y";
-const char kWidth[]       = "width";
-const char kHeight[]      = "height";
-const char kMinWidth[]    = "minWidth";
-const char kMinHeight[]   = "minHeight";
-const char kMaxWidth[]    = "maxWidth";
-const char kMaxHeight[]   = "maxHeight";
-const char kResizable[]   = "resizable";
-const char kMovable[]     = "movable";
-const char kMinimizable[] = "minimizable";
-const char kClosable[]    = "closable";
-const char kFullscreen[]  = "fullscreen";
+const char kTitle[]          = "title";
+const char kIcon[]           = "icon";
+const char kFrame[]          = "frame";
+const char kShow[]           = "show";
+const char kCenter[]         = "center";
+const char kX[]              = "x";
+const char kY[]              = "y";
+const char kWidth[]          = "width";
+const char kHeight[]         = "height";
+const char kMinWidth[]       = "minWidth";
+const char kMinHeight[]      = "minHeight";
+const char kMaxWidth[]       = "maxWidth";
+const char kMaxHeight[]      = "maxHeight";
+const char kResizable[]      = "resizable";
+const char kMovable[]        = "movable";
+const char kMinimizable[]    = "minimizable";
+const char kMaximizable[]    = "maximizable";
+const char kFullscreenable[] = "fullscreenable";
+const char kClosable[]       = "closable";
+const char kFullscreen[]     = "fullscreen";
 
 // Whether the window should show in taskbar.
 const char kSkipTaskbar[] = "skipTaskbar";

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -8,22 +8,24 @@ namespace atom {
 
 namespace options {
 
-const char kTitle[]      = "title";
-const char kIcon[]       = "icon";
-const char kFrame[]      = "frame";
-const char kShow[]       = "show";
-const char kCenter[]     = "center";
-const char kX[]          = "x";
-const char kY[]          = "y";
-const char kWidth[]      = "width";
-const char kHeight[]     = "height";
-const char kMinWidth[]   = "minWidth";
-const char kMinHeight[]  = "minHeight";
-const char kMaxWidth[]   = "maxWidth";
-const char kMaxHeight[]  = "maxHeight";
-const char kResizable[]  = "resizable";
-const char kMovable[]    = "movable";
-const char kFullscreen[] = "fullscreen";
+const char kTitle[]       = "title";
+const char kIcon[]        = "icon";
+const char kFrame[]       = "frame";
+const char kShow[]        = "show";
+const char kCenter[]      = "center";
+const char kX[]           = "x";
+const char kY[]           = "y";
+const char kWidth[]       = "width";
+const char kHeight[]      = "height";
+const char kMinWidth[]    = "minWidth";
+const char kMinHeight[]   = "minHeight";
+const char kMaxWidth[]    = "maxWidth";
+const char kMaxHeight[]   = "maxHeight";
+const char kResizable[]   = "resizable";
+const char kMovable[]     = "movable";
+const char kMinimizable[] = "minimizable";
+const char kClosable[]    = "closable";
+const char kFullscreen[]  = "fullscreen";
 
 // Whether the window should show in taskbar.
 const char kSkipTaskbar[] = "skipTaskbar";

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -25,6 +25,8 @@ extern const char kMaxHeight[];
 extern const char kResizable[];
 extern const char kMovable[];
 extern const char kMinimizable[];
+extern const char kMaximizable[];
+extern const char kFullscreenable[];
 extern const char kClosable[];
 extern const char kFullscreen[];
 extern const char kSkipTaskbar[];

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -24,6 +24,8 @@ extern const char kMaxWidth[];
 extern const char kMaxHeight[];
 extern const char kResizable[];
 extern const char kMovable[];
+extern const char kMinimizable[];
+extern const char kClosable[];
 extern const char kFullscreen[];
 extern const char kSkipTaskbar[];
 extern const char kKiosk[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -47,13 +47,18 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `maxWidth` Integer - Window's maximum width. Default is no limit.
   * `maxHeight` Integer - Window's maximum height. Default is no limit.
   * `resizable` Boolean - Whether window is resizable. Default is `true`.
-  * `movable` Boolean - Whether window is movable. This is only implemented
-    on OS X. Default is `true`.
+  * `movable` Boolean - Whether window is movable. This is not implemented
+    on Linux. Default is `true`.
+  * `minimizable` Boolean - Whether window is minimizable. This is not
+    implemented on Linux. Default is `true`.
+  * `closable` Boolean - Whether window is closable. This is not implemented
+    on Linux. Default is `true`.
   * `alwaysOnTop` Boolean - Whether the window should always stay on top of
     other windows. Default is `false`.
   * `fullscreen` Boolean - Whether the window should show in fullscreen. When
-    set to `false` the fullscreen button will be hidden or disabled on OS X.
-    Default is `false`.
+    explicity set to `false` the fullscreen button will be hidden or disabled
+    on OS X, or the maximize button will be disabled on Windows. Default is
+    `false`.
   * `skipTaskbar` Boolean - Whether to show the window in taskbar. Default is
     `false`.
   * `kiosk` Boolean - The kiosk mode. Default is `false`.
@@ -522,6 +527,40 @@ Sets whether the window can be manually resized by user.
 ### `win.isResizable()`
 
 Returns whether the window can be manually resized by user.
+
+### `win.setMovable(movable)` _OS X_ _Windows_
+
+* `movable` Boolean
+
+Sets whether the window can be moved by user. On Linux does nothing.
+
+### `win.isMovable()` _OS X_ _Windows_
+
+Returns whether the window can be moved by user. On Linux always returns
+`true`.
+
+### `win.setMinimizable(minimizable)` _OS X_ _Windows_
+
+* `minimizable` Boolean
+
+Sets whether the window can be manually minimized by user. On Linux does
+nothing.
+
+### `win.isMinimizable()` _OS X_ _Windows_
+
+Returns whether the window can be manually minimized by user. On Linux always
+returns `true`.
+
+### `win.setClosable(closable)` _OS X_ _Windows_
+
+* `closable` Boolean
+
+Sets whether the window can be manually closed by user. On Linux does nothing.
+
+### `win.isClosable()` _OS X_ _Windows_
+
+Returns whether the window can be manually closed by user. On Linux always
+returns `true`.
 
 ### `win.setAlwaysOnTop(flag)`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -51,6 +51,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     on Linux. Default is `true`.
   * `minimizable` Boolean - Whether window is minimizable. This is not
     implemented on Linux. Default is `true`.
+  * `maximizable` Boolean - Whether window is maximizable. This is not
+    implemented on Linux. Default is `true`.
   * `closable` Boolean - Whether window is closable. This is not implemented
     on Linux. Default is `true`.
   * `alwaysOnTop` Boolean - Whether the window should always stay on top of
@@ -59,6 +61,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     explicity set to `false` the fullscreen button will be hidden or disabled
     on OS X, or the maximize button will be disabled on Windows. Default is
     `false`.
+  * `fullscreenable` Boolean - Whether the maximize/zoom button on OS X should
+    toggle full screen mode or maximize window. Default is `true`.
   * `skipTaskbar` Boolean - Whether to show the window in taskbar. Default is
     `false`.
   * `kiosk` Boolean - The kiosk mode. Default is `false`.
@@ -550,6 +554,30 @@ nothing.
 
 Returns whether the window can be manually minimized by user. On Linux always
 returns `true`.
+
+### `win.setMaximizable(maximizable)` _OS X_ _Windows_
+
+* `maximizable` Boolean
+
+Sets whether the window can be manually maximized by user. On Linux does
+nothing.
+
+### `win.isMaximizable()` _OS X_ _Windows_
+
+Returns whether the window can be manually maximized by user. On Linux always
+returns `true`.
+
+### `win.setFullscreenable(fullscreenable)` _OS X_
+
+* `fullscreenable` Boolean
+
+Sets whether the maximize/zoom window button toggles fullscreen mode or
+maximizes the window. On Windows and Linux does nothing.
+
+### `win.isFullscreenable()` _OS X_
+
+Returns whether the maximize/zoom window button toggles fullscreen mode or
+maximizes the window. On Windows and Linux always returns `true`.
 
 ### `win.setClosable(closable)` _OS X_ _Windows_
 


### PR DESCRIPTION
* `movable` option supported on Windows
* added methods `setMovable`, `isMovable`
* added options `minimizable`, `closable` and corresponding methods `setMinimizable`, `isMinimizable`, `setClosable`, `isClosable`. Implemented on Windows and OS X. This options controls whether specific window button and feature should be disabled or enabled.
* On Windows implemented similar to OS X behaviour when `fullscreen` option is set to `false`. In this case the maximize button will be disabled.
* Fixed a bug on OS X when `resizable` is set to `false` but the zoom button was not disabled when window is created
* Fixed a bug on OS X when if you do `win.setResizable(false); win.setResizable(true); win.setResizable(false)`, the zoom button was not disabled after the second `setResizable(false)` call