### PR TITLE
Fix error calling desktopCapturer.getSources twice

### DIFF
--- a/atom/browser/lib/desktop-capturer.js
+++ b/atom/browser/lib/desktop-capturer.js
@@ -59,7 +59,7 @@ desktopCapturer.emit = function(event, name, sources) {
     request = requestsQueue[i];
     if (deepEqual(handledRequest.options, request.options)) {
       if ((ref1 = request.webContents) != null) {
-        ref1.send("ATOM_RENDERER_DESKTOP_CAPTURER_RESULT_" + request.id, errorMessage, result);
+        ref1.send("ATOM_RENDERER_DESKTOP_CAPTURER_RESULT_" + request.id, result);
       }
     } else {
       unhandledRequestsQueue.push(request);

--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -12,7 +12,7 @@ describe('desktopCapturer', function() {
     });
   });
 
-  it('does not throw an error when called twice (regression)', function(done) {
+  it('does not throw an error when called more than once (regression)', function(done) {
     var callCount = 0;
     var callback = function (error, sources) {
       callCount++;

--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -11,4 +11,17 @@ describe('desktopCapturer', function() {
       done();
     });
   });
+
+  it('does not throw an error when called twice (regression)', function(done) {
+    var callCount = 0;
+    var callback = function(error, sources) {
+      callCount++;
+      assert.equal(error, null);
+      assert.notEqual(sources.length, 0);
+      if (callCount === 2) done();
+    }
+
+    desktopCapturer.getSources({types: ['window', 'screen']}, callback);
+    desktopCapturer.getSources({types: ['window', 'screen']}, callback);
+  })
 });

--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -14,7 +14,7 @@ describe('desktopCapturer', function() {
 
   it('does not throw an error when called twice (regression)', function(done) {
     var callCount = 0;
-    var callback = function(error, sources) {
+    var callback = function (error, sources) {
       callCount++;
       assert.equal(error, null);
       assert.notEqual(sources.length, 0);

--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -1,17 +1,14 @@
-var assert, desktopCapturer;
-
-assert = require('assert');
-
-desktopCapturer = require('electron').desktopCapturer;
+const assert = require('assert');
+const desktopCapturer = require('electron').desktopCapturer;
 
 describe('desktopCapturer', function() {
-  return it('should return a non-empty array of sources', function(done) {
-    return desktopCapturer.getSources({
+  it('should return a non-empty array of sources', function(done) {
+    desktopCapturer.getSources({
       types: ['window', 'screen']
     }, function(error, sources) {
       assert.equal(error, null);
       assert.notEqual(sources.length, 0);
-      return done();
+      done();
     });
   });
 });


### PR DESCRIPTION
There was a leftover reference to an undefined `errorMessage` variable that would throw an uncaught browser process exception when `desktopCapturer.getSources()` was called more than once from the render process.

Refs #3727