### PR TITLE
Support backgroundColor for window on mac

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -551,4 +551,27 @@ void NativeWindow::OnCapturePageDone(const CapturePageCallback& callback,
   callback.Run(bitmap);
 }
 
+SkColor NativeWindow::ParseHexColor(const std::string& name) {
+  SkColor result = 0xFF000000;
+  unsigned value = 0;
+  auto color = name.substr(1);
+  unsigned length = color.size();
+  if (length != 3 && length != 6)
+    return result;
+  for (unsigned i = 0; i < length; ++i) {
+    if (!base::IsHexDigit(color[i]))
+      return result;
+    value <<= 4;
+    value |= (color[i] < 'A' ? color[i] - '0' : (color[i] - 'A' + 10) & 0xF);
+  }
+  if (length == 6) {
+    result |= value;
+    return result;
+  }
+  result |= (value & 0xF00) << 12 | (value & 0xF00) << 8
+      | (value & 0xF0) << 8 | (value & 0xF0) << 4
+      | (value & 0xF) << 4 | (value & 0xF);
+  return result;
+}
+
 }  // namespace atom

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -265,6 +265,9 @@ class NativeWindow : public base::SupportsUserData,
   void BeforeUnloadDialogCancelled() override;
   bool OnMessageReceived(const IPC::Message& message) override;
 
+  // Parse hex color like "#FFF" or "#EFEFEF"
+  SkColor ParseHexColor(const std::string& name);
+
  private:
   // Schedule a notification unresponsive event.
   void ScheduleUnresponsiveEvent(int ms);

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -418,7 +418,7 @@ NativeWindowMac::NativeWindowMac(
   if (transparent()) {
     // Make window has transparent background.
     [window_ setOpaque:NO];
-    [window_ setHasShadow:NO];
+    // Setting the background color to clear will also hide the shadow.
     [window_ setBackgroundColor:[NSColor clearColor]];
   }
 
@@ -706,6 +706,12 @@ bool NativeWindowMac::IsKiosk() {
 }
 
 void NativeWindowMac::SetBackgroundColor(const std::string& color_name) {
+  SkColor background_color = NativeWindow::ParseHexColor(color_name);
+  NSColor *color = [NSColor colorWithCalibratedRed:SkColorGetR(background_color)
+    green:SkColorGetG(background_color)
+    blue:SkColorGetB(background_color)
+    alpha:1.0];
+  [window_ setBackgroundColor:color];
 }
 
 void NativeWindowMac::SetRepresentedFilename(const std::string& filename) {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -73,29 +73,6 @@ bool IsAltModifier(const content::NativeWebKeyboardEvent& event) {
          (modifiers == (Modifiers::AltKey | Modifiers::IsRight));
 }
 
-SkColor ParseHexColor(const std::string& name) {
-  SkColor result = 0xFF000000;
-  unsigned value = 0;
-  auto color = name.substr(1);
-  unsigned length = color.size();
-  if (length != 3 && length != 6)
-    return result;
-  for (unsigned i = 0; i < length; ++i) {
-    if (!base::IsHexDigit(color[i]))
-      return result;
-    value <<= 4;
-    value |= (color[i] < 'A' ? color[i] - '0' : (color[i] - 'A' + 10) & 0xF);
-  }
-  if (length == 6) {
-    result |= value;
-    return result;
-  }
-  result |= (value & 0xF00) << 12 | (value & 0xF00) << 8
-      | (value & 0xF0) << 8 | (value & 0xF0) << 4
-      | (value & 0xF) << 4 | (value & 0xF);
-  return result;
-}
-
 class NativeWindowClientView : public views::ClientView {
  public:
   NativeWindowClientView(views::Widget* widget,
@@ -519,7 +496,7 @@ bool NativeWindowViews::IsKiosk() {
 
 void NativeWindowViews::SetBackgroundColor(const std::string& color_name) {
   // web views' background color.
-  SkColor background_color = ParseHexColor(color_name);
+  SkColor background_color = NativeWindow::ParseHexColor(color_name);
   set_background(views::Background::CreateSolidBackground(background_color));
 
 #if defined(OS_WIN)

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -74,8 +74,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `enableLargerThanScreen` Boolean - Enable the window to be resized larger
     than screen. Default is `false`.
   * `backgroundColor` String - Window's background color as Hexadecimal value,
-    like `#66CD00` or `#FFF`. This is only implemented on Linux and Windows.
-    Default is `#000` (black).
+    like `#66CD00` or `#FFF`. Default is `#000` (black) for Linux and Windows,
+    `#FFF` for Mac (or clear if transparent).
   * `darkTheme` Boolean - Forces using dark theme for the window, only works on
     some GTK+3 desktop environments. Default is `false`.
   * `transparent` Boolean - Makes the window [transparent](frameless-window.md).


### PR DESCRIPTION
Supports backgroundColor for window on mac, which is necessary to support shadows on transparent windows.

Should be fully backwards compatible since the default clearColor for transparent window causes the shadow to not be visible.

I duplicated ParseHexColor from `native_window_views.cc`, is there a particular place you might want to put it instead?

Thanks.