### PR TITLE
browser: add font related settings to webpreferences

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -151,6 +151,28 @@ void WebContentsPreferences::OverrideWebkitPrefs(
     prefs->allow_displaying_insecure_content = b;
   if (self->web_preferences_.GetBoolean("allowRunningInsecureContent", &b))
     prefs->allow_running_insecure_content = b;
+  const base::DictionaryValue* fonts = nullptr;
+  if (self->web_preferences_.GetDictionary("defaultFontFamily", &fonts)) {
+    base::string16 font;
+    if (fonts->GetString("standard", &font))
+      prefs->standard_font_family_map[content::kCommonScript] = font;
+    if (fonts->GetString("serif", &font))
+      prefs->serif_font_family_map[content::kCommonScript] = font;
+    if (fonts->GetString("sansSerif", &font))
+      prefs->sans_serif_font_family_map[content::kCommonScript] = font;
+    if (fonts->GetString("monospace", &font))
+      prefs->fixed_font_family_map[content::kCommonScript] = font;
+  }
+  int size;
+  if (self->web_preferences_.GetInteger("defaultFontSize", &size))
+    prefs->default_font_size = size;
+  if (self->web_preferences_.GetInteger("defaultMonospaceFontSize", &size))
+    prefs->default_fixed_font_size = size;
+  if (self->web_preferences_.GetInteger("minimumFontSize", &size))
+    prefs->minimum_font_size = size;
+  std::string encoding;
+  if (self->web_preferences_.GetString("defaultEncoding", &encoding))
+    prefs->default_encoding = encoding;
 }
 
 }  // namespace atom

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -160,6 +160,15 @@ The `webPreferences` option is an object that can have following properties:
   `CSSVariables,KeyboardEventKey`. The full list of supported feature strings
   can be found in the [setFeatureEnabledFromString][blink-feature-string]
   function.
+* `defaultFontFamily` Object - Sets the default font for the font-family.
+  * `standard` String - Defaults to `Times New Roman`.
+  * `serif` String - Defaults to `Times New Roman`.
+  * `sansSerif` String - Defaults to `Arial`.
+  * `monospace` String - Defaults to `Courier New`.
+* `defaultFontSize` Integer - Defaults to `16`.
+* `defaultMonospaceFontSize` Integer - Defaults to `13`.
+* `minimumFontSize` Integer - Defaults to `0`.
+* `defaultEncoding` String - Defaults to `ISO-8859-1`.
 
 ## Events
 


### PR DESCRIPTION
For #4132 

Brings available config from `chorme://settings/fonts`