### PR TITLE
browser: fix crash when switching to sibling menu from submenus

### DIFF
--- a/atom/browser/ui/views/menu_delegate.cc
+++ b/atom/browser/ui/views/menu_delegate.cc
@@ -105,24 +105,17 @@ views::MenuItemView* MenuDelegate::GetSiblingMenu(
   ui::MenuModel* model;
   if (menu_bar_->GetMenuButtonFromScreenPoint(screen_point, &model, &button) &&
       button->tag() != id_) {
-    // Switch to sibling menu on next tick, otherwise crash may happen.
+    DCHECK(menu_runner_->IsRunning());
+    menu_runner_->Cancel();
+    // After canceling the menu, we need to wait until next tick
+    // so we are out of nested message loop.
     content::BrowserThread::PostTask(
         content::BrowserThread::UI, FROM_HERE,
-        base::Bind(&MenuDelegate::SwitchToSiblingMenu,
-                   base::Unretained(this), button));
+        base::Bind(base::IgnoreResult(&views::MenuButton::Activate),
+                   base::Unretained(button)));
   }
 
   return nullptr;
-}
-
-void MenuDelegate::SwitchToSiblingMenu(views::MenuButton* button) {
-  menu_runner_->Cancel();
-  // After canceling the menu, we need to wait until next tick so we are out of
-  // nested message loop.
-  content::BrowserThread::PostTask(
-      content::BrowserThread::UI, FROM_HERE,
-      base::Bind(base::IgnoreResult(&views::MenuButton::Activate),
-                 base::Unretained(button)));
 }
 
 }  // namespace atom

--- a/atom/browser/ui/views/menu_delegate.h
+++ b/atom/browser/ui/views/menu_delegate.h
@@ -50,9 +50,6 @@ class MenuDelegate : public views::MenuDelegate {
       views::MenuButton** button) override;
 
  private:
-  // Close this menu and run the menu of |button|.
-  void SwitchToSiblingMenu(views::MenuButton* button);
-
   MenuBar* menu_bar_;
   int id_;
   scoped_ptr<views::MenuDelegate> adapter_;


### PR DESCRIPTION
Fixes #4103 

Cancel the menu in the same tick, otherwise it will be reset.