### PR TITLE
Run cpplint on utility folder

### DIFF
--- a/atom/utility/atom_content_utility_client.h
+++ b/atom/utility/atom_content_utility_client.h
@@ -55,4 +55,4 @@ class AtomContentUtilityClient : public content::ContentUtilityClient {
 
 }  // namespace atom
 
-#endif  // ATOM_UTILITY_ATOM_CONTENT_UTILITY_CLIENT_H_ 
+#endif  // ATOM_UTILITY_ATOM_CONTENT_UTILITY_CLIENT_H_

--- a/script/cpplint.py
+++ b/script/cpplint.py
@@ -29,7 +29,7 @@ SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
 def main():
   os.chdir(SOURCE_ROOT)
-  files = list_files(['app', 'browser', 'common', 'renderer'],
+  files = list_files(['app', 'browser', 'common', 'renderer', 'utility'],
                      ['*.cc', '*.h'])
   call_cpplint(list(set(files) - set(IGNORE_FILES)))
 


### PR DESCRIPTION
I noticed this folder wasn't being linted and `atom/utility/atom_content_utility_client.h` had some trailing whitespace in it.