### PR TITLE
Enable more eslint rules

### DIFF
--- a/atom/browser/api/lib/app.js
+++ b/atom/browser/api/lib/app.js
@@ -60,9 +60,8 @@ var fn = function(name) {
     return webContents.emit.apply(webContents, [name, event].concat(slice.call(args)));
   });
 };
-var i, len, name;
+var i, len;
 for (i = 0, len = ref1.length; i < len; i++) {
-  name = ref1[i];
   fn(ref1[i]);
 }
 

--- a/atom/browser/api/lib/auto-updater/squirrel-update-win.js
+++ b/atom/browser/api/lib/auto-updater/squirrel-update-win.js
@@ -13,7 +13,7 @@ const exeName = path.basename(process.execPath);
 // Spawn a command and invoke the callback when it completes with an error
 // and the output from standard out.
 var spawnUpdate = function(args, detached, callback) {
-  var error, error1, errorEmitted, spawnedProcess, stderr, stdout;
+  var error, errorEmitted, spawnedProcess, stderr, stdout;
   try {
     spawnedProcess = spawn(updateExe, args, {
       detached: detached
@@ -58,23 +58,22 @@ var spawnUpdate = function(args, detached, callback) {
 };
 
 // Start an instance of the installed app.
-exports.processStart = function(callback) {
+exports.processStart = function() {
   return spawnUpdate(['--processStart', exeName], true, function() {});
 };
 
 // Download the releases specified by the URL and write new results to stdout.
 exports.download = function(updateURL, callback) {
   return spawnUpdate(['--download', updateURL], false, function(error, stdout) {
-    var error1, json, ref, ref1, update;
+    var json, ref, ref1, update;
     if (error != null) {
       return callback(error);
     }
     try {
-
       // Last line of output is the JSON details about the releases
       json = stdout.trim().split('\n').pop();
       update = (ref = JSON.parse(json)) != null ? (ref1 = ref.releasesToApply) != null ? typeof ref1.pop === "function" ? ref1.pop() : void 0 : void 0 : void 0;
-    } catch (error1) {
+    } catch (jsonError) {
       return callback("Invalid result:\n" + stdout);
     }
     return callback(null, update);
@@ -90,11 +89,10 @@ exports.update = function(updateURL, callback) {
 
 // Is the Update.exe installed with the current application?
 exports.supported = function() {
-  var error1;
   try {
     fs.accessSync(updateExe, fs.R_OK);
     return true;
-  } catch (error1) {
+  } catch (error) {
     return false;
   }
 };

--- a/atom/browser/api/lib/browser-window.js
+++ b/atom/browser/api/lib/browser-window.js
@@ -56,7 +56,7 @@ BrowserWindow.prototype._init = function() {
 
   // Change window title to page title.
   this.webContents.on('page-title-updated', (function(_this) {
-    return function(event, title, explicitSet) {
+    return function(event, title) {
       _this.emit('page-title-updated', event, title);
       if (!event.defaultPrevented) {
         return _this.setTitle(title);

--- a/atom/browser/api/lib/dialog.js
+++ b/atom/browser/api/lib/dialog.js
@@ -5,7 +5,6 @@ const v8Util = process.atomBinding('v8_util');
 
 var slice = [].slice;
 var includes = [].includes;
-var indexOf = [].indexOf;
 
 var fileDialogProperties = {
   openFile: 1 << 0,

--- a/atom/browser/api/lib/menu-item.js
+++ b/atom/browser/api/lib/menu-item.js
@@ -1,6 +1,4 @@
-var MenuItem, methodInBrowserWindow, nextCommandId, rolesMap, v8Util;
-
-v8Util = process.atomBinding('v8_util');
+var MenuItem, methodInBrowserWindow, nextCommandId, rolesMap;
 
 nextCommandId = 0;
 

--- a/atom/browser/api/lib/menu.js
+++ b/atom/browser/api/lib/menu.js
@@ -210,7 +210,7 @@ Menu.prototype.insert = function(pos, item) {
           return v8Util.getHiddenValue(item, 'checked');
         },
         set: (function(_this) {
-          return function(val) {
+          return function() {
             var j, len, otherItem, ref1;
             ref1 = _this.groupsMap[item.groupId];
             for (j = 0, len = ref1.length; j < len; j++) {

--- a/atom/browser/api/lib/web-contents.js
+++ b/atom/browser/api/lib/web-contents.js
@@ -3,7 +3,6 @@
 const EventEmitter = require('events').EventEmitter;
 const deprecate = require('electron').deprecate;
 const ipcMain = require('electron').ipcMain;
-const session = require('electron').session;
 const NavigationController = require('electron').NavigationController;
 const Menu = require('electron').Menu;
 
@@ -62,7 +61,7 @@ const webFrameMethods = [
   'insertText',
   'setZoomFactor',
   'setZoomLevel',
-  'setZoomLevelLimits',
+  'setZoomLevelLimits'
 ];
 
 let wrapWebContents = function(webContents) {

--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -144,23 +144,29 @@ app.once('ready', function() {
       submenu: [
         {
           label: 'Learn More',
-          click: function() { shell.openExternal('http://electron.atom.io') }
+          click: function() {
+            shell.openExternal('http://electron.atom.io');
+          }
         },
         {
           label: 'Documentation',
           click: function() {
             shell.openExternal(
               `https://github.com/atom/electron/tree/v${process.versions.electron}/docs#readme`
-            )
+            );
           }
         },
         {
           label: 'Community Discussions',
-          click: function() { shell.openExternal('https://discuss.atom.io/c/electron') }
+          click: function() {
+            shell.openExternal('https://discuss.atom.io/c/electron');
+          }
         },
         {
           label: 'Search Issues',
-          click: function() { shell.openExternal('https://github.com/atom/electron/issues') }
+          click: function() {
+            shell.openExternal('https://github.com/atom/electron/issues');
+          }
         }
       ]
     },

--- a/atom/browser/lib/chrome-extension.js
+++ b/atom/browser/lib/chrome-extension.js
@@ -50,25 +50,24 @@ var loadedExtensions = null;
 var loadedExtensionsPath = null;
 
 app.on('will-quit', function() {
-  var e, error1, error2;
   try {
     loadedExtensions = Object.keys(extensionInfoMap).map(function(key) {
       return extensionInfoMap[key].srcDirectory;
     });
     try {
       fs.mkdirSync(path.dirname(loadedExtensionsPath));
-    } catch (error1) {
-      e = error1;
+    } catch (error) {
+      // Ignore error
     }
     return fs.writeFileSync(loadedExtensionsPath, JSON.stringify(loadedExtensions));
-  } catch (error2) {
-    e = error2;
+  } catch (error) {
+    // Ignore error
   }
 });
 
 // We can not use protocol or BrowserWindow until app is ready.
 app.once('ready', function() {
-  var BrowserWindow, chromeExtensionHandler, e, error1, i, init, len, protocol, srcDirectory;
+  var BrowserWindow, chromeExtensionHandler, i, init, len, protocol, srcDirectory;
   protocol = electron.protocol, BrowserWindow = electron.BrowserWindow;
 
   // Load persistented extensions.
@@ -84,8 +83,8 @@ app.once('ready', function() {
       srcDirectory = loadedExtensions[i];
       getExtensionInfoFromPath(srcDirectory);
     }
-  } catch (error1) {
-    e = error1;
+  } catch (error) {
+    // Ignore error
   }
 
   // The chrome-extension: can map a extension URL request to real file path.

--- a/atom/browser/lib/guest-view-manager.js
+++ b/atom/browser/lib/guest-view-manager.js
@@ -19,7 +19,7 @@ var moveLastToFirst = function(list) {
 };
 
 // Generate guestInstanceId.
-var getNextInstanceId = function(webContents) {
+var getNextInstanceId = function() {
   return ++nextInstanceId;
 };
 
@@ -109,8 +109,7 @@ var createGuest = function(embedder, params) {
   // Dispatch events to embedder.
   fn = function(event) {
     return guest.on(event, function() {
-      var _, args;
-      _ = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
+      var args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
       return embedder.send.apply(embedder, ["ATOM_SHELL_GUEST_VIEW_INTERNAL_DISPATCH_EVENT-" + guest.viewInstanceId, event].concat(slice.call(args)));
     });
   };
@@ -128,8 +127,7 @@ var createGuest = function(embedder, params) {
 
   // Autosize.
   guest.on('size-changed', function() {
-    var _, args;
-    _ = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
+    var args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
     return embedder.send.apply(embedder, ["ATOM_SHELL_GUEST_VIEW_INTERNAL_SIZE_CHANGED-" + guest.viewInstanceId].concat(slice.call(args)));
   });
   return id;

--- a/atom/browser/lib/guest-window-manager.js
+++ b/atom/browser/lib/guest-window-manager.js
@@ -1,8 +1,6 @@
 const ipcMain = require('electron').ipcMain;
 const BrowserWindow = require('electron').BrowserWindow;
 
-const v8Util = process.atomBinding('v8_util');
-
 var hasProp = {}.hasOwnProperty;
 var slice = [].slice;
 var frameToGuest = {};
@@ -102,8 +100,8 @@ ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', function(event, guest
 });
 
 ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', function() {
-  var args, event, guestId, method, ref1;
-  event = arguments[0], guestId = arguments[1], method = arguments[2], args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
+  var args, guestId, method, ref1;
+  guestId = arguments[1], method = arguments[2], args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
   return (ref1 = BrowserWindow.fromId(guestId)) != null ? ref1[method].apply(ref1, args) : void 0;
 });
 
@@ -120,7 +118,7 @@ ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', function(event,
 });
 
 ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', function() {
-  var args, event, guestId, method, ref1, ref2;
-  event = arguments[0], guestId = arguments[1], method = arguments[2], args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
+  var args, guestId, method, ref1, ref2;
+  guestId = arguments[1], method = arguments[2], args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
   return (ref1 = BrowserWindow.fromId(guestId)) != null ? (ref2 = ref1.webContents) != null ? ref2[method].apply(ref2, args) : void 0 : void 0;
 });

--- a/atom/browser/lib/rpc-server.js
+++ b/atom/browser/lib/rpc-server.js
@@ -200,7 +200,7 @@ var callFunction = function(event, func, caller, args) {
     // them with the function name so it's easier to trace things like
     // `Error processing argument -1.`
     funcName = (ref = func.name) != null ? ref : "anonymous";
-    throw new Error("Could not call remote function `" + funcName + "`. Check that the function signature is correct. Underlying error: " + e.message);
+    throw new Error("Could not call remote function `" + funcName + "`. Check that the function signature is correct. Underlying error: " + error.message);
   }
 };
 

--- a/atom/browser/lib/rpc-server.js
+++ b/atom/browser/lib/rpc-server.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const path = require('path');
 const electron = require('electron');
 const ipcMain = electron.ipcMain;
 const objectsRegistry = require('./objects-registry');
@@ -183,7 +182,7 @@ var unwrapArgs = function(sender, args) {
 // Call a function and send reply asynchronously if it's a an asynchronous
 // style function and the caller didn't pass a callback.
 var callFunction = function(event, func, caller, args) {
-  var e, error1, funcMarkedAsync, funcName, funcPassedCallback, ref, ret;
+  var funcMarkedAsync, funcName, funcPassedCallback, ref, ret;
   funcMarkedAsync = v8Util.getHiddenValue(func, 'asynchronous');
   funcPassedCallback = typeof args[args.length - 1] === 'function';
   try {
@@ -196,9 +195,7 @@ var callFunction = function(event, func, caller, args) {
       ret = func.apply(caller, args);
       return event.returnValue = valueToMeta(event.sender, ret, true);
     }
-  } catch (error1) {
-    e = error1;
-
+  } catch (error) {
     // Catch functions thrown further down in function invocation and wrap
     // them with the function name so it's easier to trace things like
     // `Error processing argument -1.`
@@ -213,42 +210,34 @@ process.on('ATOM_BROWSER_RELEASE_RENDER_VIEW', function(id) {
 });
 
 ipcMain.on('ATOM_BROWSER_REQUIRE', function(event, module) {
-  var e, error1;
   try {
     return event.returnValue = valueToMeta(event.sender, process.mainModule.require(module));
-  } catch (error1) {
-    e = error1;
-    return event.returnValue = exceptionToMeta(e);
+  } catch (error) {
+    return event.returnValue = exceptionToMeta(error);
   }
 });
 
 ipcMain.on('ATOM_BROWSER_GET_BUILTIN', function(event, module) {
-  var e, error1;
   try {
     return event.returnValue = valueToMeta(event.sender, electron[module]);
-  } catch (error1) {
-    e = error1;
-    return event.returnValue = exceptionToMeta(e);
+  } catch (error) {
+    return event.returnValue = exceptionToMeta(error);
   }
 });
 
 ipcMain.on('ATOM_BROWSER_GLOBAL', function(event, name) {
-  var e, error1;
   try {
     return event.returnValue = valueToMeta(event.sender, global[name]);
-  } catch (error1) {
-    e = error1;
-    return event.returnValue = exceptionToMeta(e);
+  } catch (error) {
+    return event.returnValue = exceptionToMeta(error);
   }
 });
 
 ipcMain.on('ATOM_BROWSER_CURRENT_WINDOW', function(event) {
-  var e, error1;
   try {
     return event.returnValue = valueToMeta(event.sender, event.sender.getOwnerBrowserWindow());
-  } catch (error1) {
-    e = error1;
-    return event.returnValue = exceptionToMeta(e);
+  } catch (error) {
+    return event.returnValue = exceptionToMeta(error);
   }
 });
 
@@ -257,7 +246,7 @@ ipcMain.on('ATOM_BROWSER_CURRENT_WEB_CONTENTS', function(event) {
 });
 
 ipcMain.on('ATOM_BROWSER_CONSTRUCTOR', function(event, id, args) {
-  var constructor, e, error1, obj;
+  var constructor, obj;
   try {
     args = unwrapArgs(event.sender, args);
     constructor = objectsRegistry.get(id);
@@ -266,26 +255,24 @@ ipcMain.on('ATOM_BROWSER_CONSTRUCTOR', function(event, id, args) {
     // http://stackoverflow.com/questions/1606797/use-of-apply-with-new-operator-is-this-possible
     obj = new (Function.prototype.bind.apply(constructor, [null].concat(args)));
     return event.returnValue = valueToMeta(event.sender, obj);
-  } catch (error1) {
-    e = error1;
-    return event.returnValue = exceptionToMeta(e);
+  } catch (error) {
+    return event.returnValue = exceptionToMeta(error);
   }
 });
 
 ipcMain.on('ATOM_BROWSER_FUNCTION_CALL', function(event, id, args) {
-  var e, error1, func;
+  var func;
   try {
     args = unwrapArgs(event.sender, args);
     func = objectsRegistry.get(id);
     return callFunction(event, func, global, args);
-  } catch (error1) {
-    e = error1;
-    return event.returnValue = exceptionToMeta(e);
+  } catch (error) {
+    return event.returnValue = exceptionToMeta(error);
   }
 });
 
 ipcMain.on('ATOM_BROWSER_MEMBER_CONSTRUCTOR', function(event, id, method, args) {
-  var constructor, e, error1, obj;
+  var constructor, obj;
   try {
     args = unwrapArgs(event.sender, args);
     constructor = objectsRegistry.get(id)[method];
@@ -293,44 +280,40 @@ ipcMain.on('ATOM_BROWSER_MEMBER_CONSTRUCTOR', function(event, id, method, args) 
     // Call new with array of arguments.
     obj = new (Function.prototype.bind.apply(constructor, [null].concat(args)));
     return event.returnValue = valueToMeta(event.sender, obj);
-  } catch (error1) {
-    e = error1;
-    return event.returnValue = exceptionToMeta(e);
+  } catch (error) {
+    return event.returnValue = exceptionToMeta(error);
   }
 });
 
 ipcMain.on('ATOM_BROWSER_MEMBER_CALL', function(event, id, method, args) {
-  var e, error1, obj;
+  var obj;
   try {
     args = unwrapArgs(event.sender, args);
     obj = objectsRegistry.get(id);
     return callFunction(event, obj[method], obj, args);
-  } catch (error1) {
-    e = error1;
-    return event.returnValue = exceptionToMeta(e);
+  } catch (error) {
+    return event.returnValue = exceptionToMeta(error);
   }
 });
 
 ipcMain.on('ATOM_BROWSER_MEMBER_SET', function(event, id, name, value) {
-  var e, error1, obj;
+  var obj;
   try {
     obj = objectsRegistry.get(id);
     obj[name] = value;
     return event.returnValue = null;
-  } catch (error1) {
-    e = error1;
-    return event.returnValue = exceptionToMeta(e);
+  } catch (error) {
+    return event.returnValue = exceptionToMeta(error);
   }
 });
 
 ipcMain.on('ATOM_BROWSER_MEMBER_GET', function(event, id, name) {
-  var e, error1, obj;
+  var obj;
   try {
     obj = objectsRegistry.get(id);
     return event.returnValue = valueToMeta(event.sender, obj[name]);
-  } catch (error1) {
-    e = error1;
-    return event.returnValue = exceptionToMeta(e);
+  } catch (error) {
+    return event.returnValue = exceptionToMeta(error);
   }
 });
 
@@ -339,25 +322,23 @@ ipcMain.on('ATOM_BROWSER_DEREFERENCE', function(event, id) {
 });
 
 ipcMain.on('ATOM_BROWSER_GUEST_WEB_CONTENTS', function(event, guestInstanceId) {
-  var e, error1, guestViewManager;
+  var guestViewManager;
   try {
     guestViewManager = require('./guest-view-manager');
     return event.returnValue = valueToMeta(event.sender, guestViewManager.getGuest(guestInstanceId));
-  } catch (error1) {
-    e = error1;
-    return event.returnValue = exceptionToMeta(e);
+  } catch (error) {
+    return event.returnValue = exceptionToMeta(error);
   }
 });
 
 ipcMain.on('ATOM_BROWSER_ASYNC_CALL_TO_GUEST_VIEW', function() {
-  var args, e, error1, event, guest, guestInstanceId, guestViewManager, method;
+  var args, event, guest, guestInstanceId, guestViewManager, method;
   event = arguments[0], guestInstanceId = arguments[1], method = arguments[2], args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
   try {
     guestViewManager = require('./guest-view-manager');
     guest = guestViewManager.getGuest(guestInstanceId);
     return guest[method].apply(guest, args);
-  } catch (error1) {
-    e = error1;
-    return event.returnValue = exceptionToMeta(e);
+  } catch (error) {
+    return event.returnValue = exceptionToMeta(error);
   }
 });

--- a/atom/common/api/lib/callbacks-registry.js
+++ b/atom/common/api/lib/callbacks-registry.js
@@ -12,7 +12,7 @@ class CallbacksRegistry {
 
   add(callback) {
     // The callback is already added.
-    var filenameAndLine, id, location, match, ref, regexp, stackString, x;
+    var filenameAndLine, id, location, match, ref, regexp, stackString;
     id = v8Util.getHiddenValue(callback, 'callbackId');
     if (id != null) {
       return id;
@@ -24,14 +24,15 @@ class CallbacksRegistry {
     regexp = /at (.*)/gi;
     stackString = (new Error).stack;
     while ((match = regexp.exec(stackString)) !== null) {
-      x = match[0], location = match[1];
+      location = match[1];
       if (location.indexOf('(native)') !== -1) {
         continue;
       }
       if (location.indexOf('atom.asar') !== -1) {
         continue;
       }
-      ref = /([^\/^\)]*)\)?$/gi.exec(location), x = ref[0], filenameAndLine = ref[1];
+      ref = /([^\/^\)]*)\)?$/gi.exec(location);
+      filenameAndLine = ref[1];
       break;
     }
     this.callbacks[id] = callback;

--- a/atom/common/api/lib/callbacks-registry.js
+++ b/atom/common/api/lib/callbacks-registry.js
@@ -63,4 +63,4 @@ class CallbacksRegistry {
   }
 }
 
-module.exports = CallbacksRegistry
+module.exports = CallbacksRegistry;

--- a/atom/common/api/lib/crash-reporter.js
+++ b/atom/common/api/lib/crash-reporter.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const spawn = require('child_process').spawn;

--- a/atom/common/lib/asar.js
+++ b/atom/common/lib/asar.js
@@ -203,7 +203,7 @@
 
   // Override fs APIs.
   exports.wrapFsWithAsar = function(fs) {
-    var exists, existsSync, internalModuleReadFile, internalModuleStat, lstat, lstatSync, mkdir, mkdirSync, open, openSync, readFile, readFileSync, readdir, readdirSync, realpath, realpathSync, stat, statSync, statSyncNoException;
+    var exists, existsSync, internalModuleReadFile, internalModuleStat, lstat, lstatSync, mkdir, mkdirSync, readFile, readFileSync, readdir, readdirSync, realpath, realpathSync, stat, statSync, statSyncNoException;
     lstatSync = fs.lstatSync;
     fs.lstatSync = function(p) {
       var archive, asarPath, filePath, isAsar, ref, stats;
@@ -242,8 +242,7 @@
     };
     statSync = fs.statSync;
     fs.statSync = function(p) {
-      var asarPath, filePath, isAsar, ref;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      var isAsar = splitPath(p)[0];
       if (!isAsar) {
         return statSync(p);
       }
@@ -253,8 +252,7 @@
     };
     stat = fs.stat;
     fs.stat = function(p, callback) {
-      var asarPath, filePath, isAsar, ref;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      var isAsar = splitPath(p)[0];
       if (!isAsar) {
         return stat(p, callback);
       }
@@ -352,7 +350,6 @@
       }
       return archive.stat(filePath) !== false;
     };
-    open = fs.open;
     readFile = fs.readFile;
     fs.readFile = function(p, options, callback) {
       var archive, asarPath, buffer, encoding, fd, filePath, info, isAsar, realPath, ref;
@@ -402,10 +399,8 @@
         return callback(error, encoding ? buffer.toString(encoding) : buffer);
       });
     };
-    openSync = fs.openSync;
     readFileSync = fs.readFileSync;
     fs.readFileSync = function(p, opts) {
-
       // this allows v8 to optimize this function
       var archive, asarPath, buffer, encoding, fd, filePath, info, isAsar, options, realPath, ref;
       options = opts;
@@ -557,11 +552,11 @@
     if (process.platform === 'win32') {
       mkdir = fs.mkdir;
       fs.mkdir = function(p, mode, callback) {
-        var asarPath, filePath, isAsar, ref;
+        var filePath, isAsar, ref;
         if (typeof mode === 'function') {
           callback = mode;
         }
-        ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+        ref = splitPath(p), isAsar = ref[0], filePath = ref[2];
         if (isAsar && filePath.length) {
           return notDirError(callback);
         }
@@ -569,8 +564,8 @@
       };
       mkdirSync = fs.mkdirSync;
       fs.mkdirSync = function(p, mode) {
-        var asarPath, filePath, isAsar, ref;
-        ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+        var filePath, isAsar, ref;
+        ref = splitPath(p), isAsar = ref[0], filePath = ref[2];
         if (isAsar && filePath.length) {
           notDirError();
         }

--- a/atom/common/lib/asar.js
+++ b/atom/common/lib/asar.js
@@ -1,587 +1,587 @@
 (function () {
-const asar = process.binding('atom_common_asar');
-const child_process = require('child_process');
-const path = require('path');
-const util = require('util');
+  const asar = process.binding('atom_common_asar');
+  const child_process = require('child_process');
+  const path = require('path');
+  const util = require('util');
 
-var hasProp = {}.hasOwnProperty;
+  var hasProp = {}.hasOwnProperty;
 
-// Cache asar archive objects.
-var cachedArchives = {};
+  // Cache asar archive objects.
+  var cachedArchives = {};
 
-var getOrCreateArchive = function(p) {
-  var archive;
-  archive = cachedArchives[p];
-  if (archive != null) {
-    return archive;
-  }
-  archive = asar.createArchive(p);
-  if (!archive) {
-    return false;
-  }
-  return cachedArchives[p] = archive;
-};
-
-// Clean cache on quit.
-process.on('exit', function() {
-  var archive, p, results;
-  results = [];
-  for (p in cachedArchives) {
-    if (!hasProp.call(cachedArchives, p)) continue;
+  var getOrCreateArchive = function(p) {
+    var archive;
     archive = cachedArchives[p];
-    results.push(archive.destroy());
-  }
-  return results;
-});
-
-// Separate asar package's path from full path.
-var splitPath = function(p) {
-  var index;
-
-  // shortcut to disable asar.
-  if (process.noAsar) {
-    return [false];
-  }
-
-  if (typeof p !== 'string') {
-    return [false];
-  }
-  if (p.substr(-5) === '.asar') {
-    return [true, p, ''];
-  }
-  p = path.normalize(p);
-  index = p.lastIndexOf(".asar" + path.sep);
-  if (index === -1) {
-    return [false];
-  }
-  return [true, p.substr(0, index + 5), p.substr(index + 6)];
-};
-
-// Convert asar archive's Stats object to fs's Stats object.
-var nextInode = 0;
-
-var uid = process.getuid != null ? process.getuid() : 0;
-
-var gid = process.getgid != null ? process.getgid() : 0;
-
-var fakeTime = new Date();
-
-var asarStatsToFsStats = function(stats) {
-  return {
-    dev: 1,
-    ino: ++nextInode,
-    mode: 33188,
-    nlink: 1,
-    uid: uid,
-    gid: gid,
-    rdev: 0,
-    atime: stats.atime || fakeTime,
-    birthtime: stats.birthtime || fakeTime,
-    mtime: stats.mtime || fakeTime,
-    ctime: stats.ctime || fakeTime,
-    size: stats.size,
-    isFile: function() {
-      return stats.isFile;
-    },
-    isDirectory: function() {
-      return stats.isDirectory;
-    },
-    isSymbolicLink: function() {
-      return stats.isLink;
-    },
-    isBlockDevice: function() {
-      return false;
-    },
-    isCharacterDevice: function() {
-      return false;
-    },
-    isFIFO: function() {
-      return false;
-    },
-    isSocket: function() {
-      return false;
+    if (archive != null) {
+      return archive;
     }
-  };
-};
-
-// Create a ENOENT error.
-var notFoundError = function(asarPath, filePath, callback) {
-  var error;
-  error = new Error("ENOENT, " + filePath + " not found in " + asarPath);
-  error.code = "ENOENT";
-  error.errno = -2;
-  if (typeof callback !== 'function') {
-    throw error;
-  }
-  return process.nextTick(function() {
-    return callback(error);
-  });
-};
-
-// Create a ENOTDIR error.
-var notDirError = function(callback) {
-  var error;
-  error = new Error('ENOTDIR, not a directory');
-  error.code = 'ENOTDIR';
-  error.errno = -20;
-  if (typeof callback !== 'function') {
-    throw error;
-  }
-  return process.nextTick(function() {
-    return callback(error);
-  });
-};
-
-// Create invalid archive error.
-var invalidArchiveError = function(asarPath, callback) {
-  var error;
-  error = new Error("Invalid package " + asarPath);
-  if (typeof callback !== 'function') {
-    throw error;
-  }
-  return process.nextTick(function() {
-    return callback(error);
-  });
-};
-
-// Override APIs that rely on passing file path instead of content to C++.
-var overrideAPISync = function(module, name, arg) {
-  var old;
-  if (arg == null) {
-    arg = 0;
-  }
-  old = module[name];
-  return module[name] = function() {
-    var archive, asarPath, filePath, isAsar, newPath, p, ref;
-    p = arguments[arg];
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return old.apply(this, arguments);
-    }
-    archive = getOrCreateArchive(asarPath);
+    archive = asar.createArchive(p);
     if (!archive) {
-      invalidArchiveError(asarPath);
+      return false;
     }
-    newPath = archive.copyFileOut(filePath);
-    if (!newPath) {
-      notFoundError(asarPath, filePath);
-    }
-    arguments[arg] = newPath;
-    return old.apply(this, arguments);
+    return cachedArchives[p] = archive;
   };
-};
 
-var overrideAPI = function(module, name, arg) {
-  var old;
-  if (arg == null) {
-    arg = 0;
-  }
-  old = module[name];
-  return module[name] = function() {
-    var archive, asarPath, callback, filePath, isAsar, newPath, p, ref;
-    p = arguments[arg];
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return old.apply(this, arguments);
+  // Clean cache on quit.
+  process.on('exit', function() {
+    var archive, p, results;
+    results = [];
+    for (p in cachedArchives) {
+      if (!hasProp.call(cachedArchives, p)) continue;
+      archive = cachedArchives[p];
+      results.push(archive.destroy());
     }
-    callback = arguments[arguments.length - 1];
+    return results;
+  });
+
+  // Separate asar package's path from full path.
+  var splitPath = function(p) {
+    var index;
+
+    // shortcut to disable asar.
+    if (process.noAsar) {
+      return [false];
+    }
+
+    if (typeof p !== 'string') {
+      return [false];
+    }
+    if (p.substr(-5) === '.asar') {
+      return [true, p, ''];
+    }
+    p = path.normalize(p);
+    index = p.lastIndexOf(".asar" + path.sep);
+    if (index === -1) {
+      return [false];
+    }
+    return [true, p.substr(0, index + 5), p.substr(index + 6)];
+  };
+
+  // Convert asar archive's Stats object to fs's Stats object.
+  var nextInode = 0;
+
+  var uid = process.getuid != null ? process.getuid() : 0;
+
+  var gid = process.getgid != null ? process.getgid() : 0;
+
+  var fakeTime = new Date();
+
+  var asarStatsToFsStats = function(stats) {
+    return {
+      dev: 1,
+      ino: ++nextInode,
+      mode: 33188,
+      nlink: 1,
+      uid: uid,
+      gid: gid,
+      rdev: 0,
+      atime: stats.atime || fakeTime,
+      birthtime: stats.birthtime || fakeTime,
+      mtime: stats.mtime || fakeTime,
+      ctime: stats.ctime || fakeTime,
+      size: stats.size,
+      isFile: function() {
+        return stats.isFile;
+      },
+      isDirectory: function() {
+        return stats.isDirectory;
+      },
+      isSymbolicLink: function() {
+        return stats.isLink;
+      },
+      isBlockDevice: function() {
+        return false;
+      },
+      isCharacterDevice: function() {
+        return false;
+      },
+      isFIFO: function() {
+        return false;
+      },
+      isSocket: function() {
+        return false;
+      }
+    };
+  };
+
+  // Create a ENOENT error.
+  var notFoundError = function(asarPath, filePath, callback) {
+    var error;
+    error = new Error("ENOENT, " + filePath + " not found in " + asarPath);
+    error.code = "ENOENT";
+    error.errno = -2;
     if (typeof callback !== 'function') {
-      return overrideAPISync(module, name, arg);
-    }
-    archive = getOrCreateArchive(asarPath);
-    if (!archive) {
-      return invalidArchiveError(asarPath, callback);
-    }
-    newPath = archive.copyFileOut(filePath);
-    if (!newPath) {
-      return notFoundError(asarPath, filePath, callback);
-    }
-    arguments[arg] = newPath;
-    return old.apply(this, arguments);
-  };
-};
-
-// Override fs APIs.
-exports.wrapFsWithAsar = function(fs) {
-  var exists, existsSync, internalModuleReadFile, internalModuleStat, lstat, lstatSync, mkdir, mkdirSync, open, openSync, readFile, readFileSync, readdir, readdirSync, realpath, realpathSync, stat, statSync, statSyncNoException;
-  lstatSync = fs.lstatSync;
-  fs.lstatSync = function(p) {
-    var archive, asarPath, filePath, isAsar, ref, stats;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return lstatSync(p);
-    }
-    archive = getOrCreateArchive(asarPath);
-    if (!archive) {
-      invalidArchiveError(asarPath);
-    }
-    stats = archive.stat(filePath);
-    if (!stats) {
-      notFoundError(asarPath, filePath);
-    }
-    return asarStatsToFsStats(stats);
-  };
-  lstat = fs.lstat;
-  fs.lstat = function(p, callback) {
-    var archive, asarPath, filePath, isAsar, ref, stats;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return lstat(p, callback);
-    }
-    archive = getOrCreateArchive(asarPath);
-    if (!archive) {
-      return invalidArchiveError(asarPath, callback);
-    }
-    stats = getOrCreateArchive(asarPath).stat(filePath);
-    if (!stats) {
-      return notFoundError(asarPath, filePath, callback);
+      throw error;
     }
     return process.nextTick(function() {
-      return callback(null, asarStatsToFsStats(stats));
+      return callback(error);
     });
   };
-  statSync = fs.statSync;
-  fs.statSync = function(p) {
-    var asarPath, filePath, isAsar, ref;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return statSync(p);
-    }
 
-    // Do not distinguish links for now.
-    return fs.lstatSync(p);
-  };
-  stat = fs.stat;
-  fs.stat = function(p, callback) {
-    var asarPath, filePath, isAsar, ref;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return stat(p, callback);
+  // Create a ENOTDIR error.
+  var notDirError = function(callback) {
+    var error;
+    error = new Error('ENOTDIR, not a directory');
+    error.code = 'ENOTDIR';
+    error.errno = -20;
+    if (typeof callback !== 'function') {
+      throw error;
     }
-
-    // Do not distinguish links for now.
     return process.nextTick(function() {
-      return fs.lstat(p, callback);
+      return callback(error);
     });
   };
-  statSyncNoException = fs.statSyncNoException;
-  fs.statSyncNoException = function(p) {
-    var archive, asarPath, filePath, isAsar, ref, stats;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return statSyncNoException(p);
+
+  // Create invalid archive error.
+  var invalidArchiveError = function(asarPath, callback) {
+    var error;
+    error = new Error("Invalid package " + asarPath);
+    if (typeof callback !== 'function') {
+      throw error;
     }
-    archive = getOrCreateArchive(asarPath);
-    if (!archive) {
-      return false;
-    }
-    stats = archive.stat(filePath);
-    if (!stats) {
-      return false;
-    }
-    return asarStatsToFsStats(stats);
+    return process.nextTick(function() {
+      return callback(error);
+    });
   };
-  realpathSync = fs.realpathSync;
-  fs.realpathSync = function(p) {
-    var archive, asarPath, filePath, isAsar, real, ref;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return realpathSync.apply(this, arguments);
+
+  // Override APIs that rely on passing file path instead of content to C++.
+  var overrideAPISync = function(module, name, arg) {
+    var old;
+    if (arg == null) {
+      arg = 0;
     }
-    archive = getOrCreateArchive(asarPath);
-    if (!archive) {
-      invalidArchiveError(asarPath);
-    }
-    real = archive.realpath(filePath);
-    if (real === false) {
-      notFoundError(asarPath, filePath);
-    }
-    return path.join(realpathSync(asarPath), real);
-  };
-  realpath = fs.realpath;
-  fs.realpath = function(p, cache, callback) {
-    var archive, asarPath, filePath, isAsar, real, ref;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return realpath.apply(this, arguments);
-    }
-    if (typeof cache === 'function') {
-      callback = cache;
-      cache = void 0;
-    }
-    archive = getOrCreateArchive(asarPath);
-    if (!archive) {
-      return invalidArchiveError(asarPath, callback);
-    }
-    real = archive.realpath(filePath);
-    if (real === false) {
-      return notFoundError(asarPath, filePath, callback);
-    }
-    return realpath(asarPath, function(err, p) {
-      if (err) {
-        return callback(err);
+    old = module[name];
+    return module[name] = function() {
+      var archive, asarPath, filePath, isAsar, newPath, p, ref;
+      p = arguments[arg];
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return old.apply(this, arguments);
       }
-      return callback(null, path.join(p, real));
-    });
+      archive = getOrCreateArchive(asarPath);
+      if (!archive) {
+        invalidArchiveError(asarPath);
+      }
+      newPath = archive.copyFileOut(filePath);
+      if (!newPath) {
+        notFoundError(asarPath, filePath);
+      }
+      arguments[arg] = newPath;
+      return old.apply(this, arguments);
+    };
   };
-  exists = fs.exists;
-  fs.exists = function(p, callback) {
-    var archive, asarPath, filePath, isAsar, ref;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return exists(p, callback);
+
+  var overrideAPI = function(module, name, arg) {
+    var old;
+    if (arg == null) {
+      arg = 0;
     }
-    archive = getOrCreateArchive(asarPath);
-    if (!archive) {
-      return invalidArchiveError(asarPath, callback);
-    }
-    return process.nextTick(function() {
-      return callback(archive.stat(filePath) !== false);
-    });
+    old = module[name];
+    return module[name] = function() {
+      var archive, asarPath, callback, filePath, isAsar, newPath, p, ref;
+      p = arguments[arg];
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return old.apply(this, arguments);
+      }
+      callback = arguments[arguments.length - 1];
+      if (typeof callback !== 'function') {
+        return overrideAPISync(module, name, arg);
+      }
+      archive = getOrCreateArchive(asarPath);
+      if (!archive) {
+        return invalidArchiveError(asarPath, callback);
+      }
+      newPath = archive.copyFileOut(filePath);
+      if (!newPath) {
+        return notFoundError(asarPath, filePath, callback);
+      }
+      arguments[arg] = newPath;
+      return old.apply(this, arguments);
+    };
   };
-  existsSync = fs.existsSync;
-  fs.existsSync = function(p) {
-    var archive, asarPath, filePath, isAsar, ref;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return existsSync(p);
-    }
-    archive = getOrCreateArchive(asarPath);
-    if (!archive) {
-      return false;
-    }
-    return archive.stat(filePath) !== false;
-  };
-  open = fs.open;
-  readFile = fs.readFile;
-  fs.readFile = function(p, options, callback) {
-    var archive, asarPath, buffer, encoding, fd, filePath, info, isAsar, realPath, ref;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return readFile.apply(this, arguments);
-    }
-    if (typeof options === 'function') {
-      callback = options;
-      options = void 0;
-    }
-    archive = getOrCreateArchive(asarPath);
-    if (!archive) {
-      return invalidArchiveError(asarPath, callback);
-    }
-    info = archive.getFileInfo(filePath);
-    if (!info) {
-      return notFoundError(asarPath, filePath, callback);
-    }
-    if (info.size === 0) {
+
+  // Override fs APIs.
+  exports.wrapFsWithAsar = function(fs) {
+    var exists, existsSync, internalModuleReadFile, internalModuleStat, lstat, lstatSync, mkdir, mkdirSync, open, openSync, readFile, readFileSync, readdir, readdirSync, realpath, realpathSync, stat, statSync, statSyncNoException;
+    lstatSync = fs.lstatSync;
+    fs.lstatSync = function(p) {
+      var archive, asarPath, filePath, isAsar, ref, stats;
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return lstatSync(p);
+      }
+      archive = getOrCreateArchive(asarPath);
+      if (!archive) {
+        invalidArchiveError(asarPath);
+      }
+      stats = archive.stat(filePath);
+      if (!stats) {
+        notFoundError(asarPath, filePath);
+      }
+      return asarStatsToFsStats(stats);
+    };
+    lstat = fs.lstat;
+    fs.lstat = function(p, callback) {
+      var archive, asarPath, filePath, isAsar, ref, stats;
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return lstat(p, callback);
+      }
+      archive = getOrCreateArchive(asarPath);
+      if (!archive) {
+        return invalidArchiveError(asarPath, callback);
+      }
+      stats = getOrCreateArchive(asarPath).stat(filePath);
+      if (!stats) {
+        return notFoundError(asarPath, filePath, callback);
+      }
       return process.nextTick(function() {
-        return callback(null, new Buffer(0));
+        return callback(null, asarStatsToFsStats(stats));
       });
-    }
-    if (info.unpacked) {
-      realPath = archive.copyFileOut(filePath);
-      return fs.readFile(realPath, options, callback);
-    }
-    if (!options) {
-      options = {
-        encoding: null
-      };
-    } else if (util.isString(options)) {
-      options = {
-        encoding: options
-      };
-    } else if (!util.isObject(options)) {
-      throw new TypeError('Bad arguments');
-    }
-    encoding = options.encoding;
-    buffer = new Buffer(info.size);
-    fd = archive.getFd();
-    if (!(fd >= 0)) {
-      return notFoundError(asarPath, filePath, callback);
-    }
-    return fs.read(fd, buffer, 0, info.size, info.offset, function(error) {
-      return callback(error, encoding ? buffer.toString(encoding) : buffer);
-    });
-  };
-  openSync = fs.openSync;
-  readFileSync = fs.readFileSync;
-  fs.readFileSync = function(p, opts) {
+    };
+    statSync = fs.statSync;
+    fs.statSync = function(p) {
+      var asarPath, filePath, isAsar, ref;
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return statSync(p);
+      }
 
-    // this allows v8 to optimize this function
-    var archive, asarPath, buffer, encoding, fd, filePath, info, isAsar, options, realPath, ref;
-    options = opts;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return readFileSync.apply(this, arguments);
-    }
-    archive = getOrCreateArchive(asarPath);
-    if (!archive) {
-      invalidArchiveError(asarPath);
-    }
-    info = archive.getFileInfo(filePath);
-    if (!info) {
-      notFoundError(asarPath, filePath);
-    }
-    if (info.size === 0) {
-      if (options) {
-        return '';
+      // Do not distinguish links for now.
+      return fs.lstatSync(p);
+    };
+    stat = fs.stat;
+    fs.stat = function(p, callback) {
+      var asarPath, filePath, isAsar, ref;
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return stat(p, callback);
+      }
+
+      // Do not distinguish links for now.
+      return process.nextTick(function() {
+        return fs.lstat(p, callback);
+      });
+    };
+    statSyncNoException = fs.statSyncNoException;
+    fs.statSyncNoException = function(p) {
+      var archive, asarPath, filePath, isAsar, ref, stats;
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return statSyncNoException(p);
+      }
+      archive = getOrCreateArchive(asarPath);
+      if (!archive) {
+        return false;
+      }
+      stats = archive.stat(filePath);
+      if (!stats) {
+        return false;
+      }
+      return asarStatsToFsStats(stats);
+    };
+    realpathSync = fs.realpathSync;
+    fs.realpathSync = function(p) {
+      var archive, asarPath, filePath, isAsar, real, ref;
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return realpathSync.apply(this, arguments);
+      }
+      archive = getOrCreateArchive(asarPath);
+      if (!archive) {
+        invalidArchiveError(asarPath);
+      }
+      real = archive.realpath(filePath);
+      if (real === false) {
+        notFoundError(asarPath, filePath);
+      }
+      return path.join(realpathSync(asarPath), real);
+    };
+    realpath = fs.realpath;
+    fs.realpath = function(p, cache, callback) {
+      var archive, asarPath, filePath, isAsar, real, ref;
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return realpath.apply(this, arguments);
+      }
+      if (typeof cache === 'function') {
+        callback = cache;
+        cache = void 0;
+      }
+      archive = getOrCreateArchive(asarPath);
+      if (!archive) {
+        return invalidArchiveError(asarPath, callback);
+      }
+      real = archive.realpath(filePath);
+      if (real === false) {
+        return notFoundError(asarPath, filePath, callback);
+      }
+      return realpath(asarPath, function(err, p) {
+        if (err) {
+          return callback(err);
+        }
+        return callback(null, path.join(p, real));
+      });
+    };
+    exists = fs.exists;
+    fs.exists = function(p, callback) {
+      var archive, asarPath, filePath, isAsar, ref;
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return exists(p, callback);
+      }
+      archive = getOrCreateArchive(asarPath);
+      if (!archive) {
+        return invalidArchiveError(asarPath, callback);
+      }
+      return process.nextTick(function() {
+        return callback(archive.stat(filePath) !== false);
+      });
+    };
+    existsSync = fs.existsSync;
+    fs.existsSync = function(p) {
+      var archive, asarPath, filePath, isAsar, ref;
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return existsSync(p);
+      }
+      archive = getOrCreateArchive(asarPath);
+      if (!archive) {
+        return false;
+      }
+      return archive.stat(filePath) !== false;
+    };
+    open = fs.open;
+    readFile = fs.readFile;
+    fs.readFile = function(p, options, callback) {
+      var archive, asarPath, buffer, encoding, fd, filePath, info, isAsar, realPath, ref;
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return readFile.apply(this, arguments);
+      }
+      if (typeof options === 'function') {
+        callback = options;
+        options = void 0;
+      }
+      archive = getOrCreateArchive(asarPath);
+      if (!archive) {
+        return invalidArchiveError(asarPath, callback);
+      }
+      info = archive.getFileInfo(filePath);
+      if (!info) {
+        return notFoundError(asarPath, filePath, callback);
+      }
+      if (info.size === 0) {
+        return process.nextTick(function() {
+          return callback(null, new Buffer(0));
+        });
+      }
+      if (info.unpacked) {
+        realPath = archive.copyFileOut(filePath);
+        return fs.readFile(realPath, options, callback);
+      }
+      if (!options) {
+        options = {
+          encoding: null
+        };
+      } else if (util.isString(options)) {
+        options = {
+          encoding: options
+        };
+      } else if (!util.isObject(options)) {
+        throw new TypeError('Bad arguments');
+      }
+      encoding = options.encoding;
+      buffer = new Buffer(info.size);
+      fd = archive.getFd();
+      if (!(fd >= 0)) {
+        return notFoundError(asarPath, filePath, callback);
+      }
+      return fs.read(fd, buffer, 0, info.size, info.offset, function(error) {
+        return callback(error, encoding ? buffer.toString(encoding) : buffer);
+      });
+    };
+    openSync = fs.openSync;
+    readFileSync = fs.readFileSync;
+    fs.readFileSync = function(p, opts) {
+
+      // this allows v8 to optimize this function
+      var archive, asarPath, buffer, encoding, fd, filePath, info, isAsar, options, realPath, ref;
+      options = opts;
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return readFileSync.apply(this, arguments);
+      }
+      archive = getOrCreateArchive(asarPath);
+      if (!archive) {
+        invalidArchiveError(asarPath);
+      }
+      info = archive.getFileInfo(filePath);
+      if (!info) {
+        notFoundError(asarPath, filePath);
+      }
+      if (info.size === 0) {
+        if (options) {
+          return '';
+        } else {
+          return new Buffer(0);
+        }
+      }
+      if (info.unpacked) {
+        realPath = archive.copyFileOut(filePath);
+        return fs.readFileSync(realPath, options);
+      }
+      if (!options) {
+        options = {
+          encoding: null
+        };
+      } else if (util.isString(options)) {
+        options = {
+          encoding: options
+        };
+      } else if (!util.isObject(options)) {
+        throw new TypeError('Bad arguments');
+      }
+      encoding = options.encoding;
+      buffer = new Buffer(info.size);
+      fd = archive.getFd();
+      if (!(fd >= 0)) {
+        notFoundError(asarPath, filePath);
+      }
+      fs.readSync(fd, buffer, 0, info.size, info.offset);
+      if (encoding) {
+        return buffer.toString(encoding);
       } else {
-        return new Buffer(0);
+        return buffer;
       }
-    }
-    if (info.unpacked) {
-      realPath = archive.copyFileOut(filePath);
-      return fs.readFileSync(realPath, options);
-    }
-    if (!options) {
-      options = {
-        encoding: null
-      };
-    } else if (util.isString(options)) {
-      options = {
-        encoding: options
-      };
-    } else if (!util.isObject(options)) {
-      throw new TypeError('Bad arguments');
-    }
-    encoding = options.encoding;
-    buffer = new Buffer(info.size);
-    fd = archive.getFd();
-    if (!(fd >= 0)) {
-      notFoundError(asarPath, filePath);
-    }
-    fs.readSync(fd, buffer, 0, info.size, info.offset);
-    if (encoding) {
-      return buffer.toString(encoding);
-    } else {
-      return buffer;
-    }
-  };
-  readdir = fs.readdir;
-  fs.readdir = function(p, callback) {
-    var archive, asarPath, filePath, files, isAsar, ref;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return readdir.apply(this, arguments);
-    }
-    archive = getOrCreateArchive(asarPath);
-    if (!archive) {
-      return invalidArchiveError(asarPath, callback);
-    }
-    files = archive.readdir(filePath);
-    if (!files) {
-      return notFoundError(asarPath, filePath, callback);
-    }
-    return process.nextTick(function() {
-      return callback(null, files);
-    });
-  };
-  readdirSync = fs.readdirSync;
-  fs.readdirSync = function(p) {
-    var archive, asarPath, filePath, files, isAsar, ref;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return readdirSync.apply(this, arguments);
-    }
-    archive = getOrCreateArchive(asarPath);
-    if (!archive) {
-      invalidArchiveError(asarPath);
-    }
-    files = archive.readdir(filePath);
-    if (!files) {
-      notFoundError(asarPath, filePath);
-    }
-    return files;
-  };
-  internalModuleReadFile = process.binding('fs').internalModuleReadFile;
-  process.binding('fs').internalModuleReadFile = function(p) {
-    var archive, asarPath, buffer, fd, filePath, info, isAsar, realPath, ref;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return internalModuleReadFile(p);
-    }
-    archive = getOrCreateArchive(asarPath);
-    if (!archive) {
-      return void 0;
-    }
-    info = archive.getFileInfo(filePath);
-    if (!info) {
-      return void 0;
-    }
-    if (info.size === 0) {
-      return '';
-    }
-    if (info.unpacked) {
-      realPath = archive.copyFileOut(filePath);
-      return fs.readFileSync(realPath, {
-        encoding: 'utf8'
+    };
+    readdir = fs.readdir;
+    fs.readdir = function(p, callback) {
+      var archive, asarPath, filePath, files, isAsar, ref;
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return readdir.apply(this, arguments);
+      }
+      archive = getOrCreateArchive(asarPath);
+      if (!archive) {
+        return invalidArchiveError(asarPath, callback);
+      }
+      files = archive.readdir(filePath);
+      if (!files) {
+        return notFoundError(asarPath, filePath, callback);
+      }
+      return process.nextTick(function() {
+        return callback(null, files);
       });
-    }
-    buffer = new Buffer(info.size);
-    fd = archive.getFd();
-    if (!(fd >= 0)) {
-      return void 0;
-    }
-    fs.readSync(fd, buffer, 0, info.size, info.offset);
-    return buffer.toString('utf8');
-  };
-  internalModuleStat = process.binding('fs').internalModuleStat;
-  process.binding('fs').internalModuleStat = function(p) {
-    var archive, asarPath, filePath, isAsar, ref, stats;
-    ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-    if (!isAsar) {
-      return internalModuleStat(p);
-    }
-    archive = getOrCreateArchive(asarPath);
-
-    // -ENOENT
-    if (!archive) {
-      return -34;
-    }
-    stats = archive.stat(filePath);
-
-    // -ENOENT
-    if (!stats) {
-      return -34;
-    }
-    if (stats.isDirectory) {
-      return 1;
-    } else {
-      return 0;
-    }
-  };
-
-  // Calling mkdir for directory inside asar archive should throw ENOTDIR
-  // error, but on Windows it throws ENOENT.
-  // This is to work around the recursive looping bug of mkdirp since it is
-  // widely used.
-  if (process.platform === 'win32') {
-    mkdir = fs.mkdir;
-    fs.mkdir = function(p, mode, callback) {
-      var asarPath, filePath, isAsar, ref;
-      if (typeof mode === 'function') {
-        callback = mode;
-      }
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-      if (isAsar && filePath.length) {
-        return notDirError(callback);
-      }
-      return mkdir(p, mode, callback);
     };
-    mkdirSync = fs.mkdirSync;
-    fs.mkdirSync = function(p, mode) {
-      var asarPath, filePath, isAsar, ref;
+    readdirSync = fs.readdirSync;
+    fs.readdirSync = function(p) {
+      var archive, asarPath, filePath, files, isAsar, ref;
       ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
-      if (isAsar && filePath.length) {
-        notDirError();
+      if (!isAsar) {
+        return readdirSync.apply(this, arguments);
       }
-      return mkdirSync(p, mode);
+      archive = getOrCreateArchive(asarPath);
+      if (!archive) {
+        invalidArchiveError(asarPath);
+      }
+      files = archive.readdir(filePath);
+      if (!files) {
+        notFoundError(asarPath, filePath);
+      }
+      return files;
     };
-  }
-  overrideAPI(fs, 'open');
-  overrideAPI(child_process, 'execFile');
-  overrideAPISync(process, 'dlopen', 1);
-  overrideAPISync(require('module')._extensions, '.node', 1);
-  overrideAPISync(fs, 'openSync');
-  return overrideAPISync(child_process, 'execFileSync');
-};
+    internalModuleReadFile = process.binding('fs').internalModuleReadFile;
+    process.binding('fs').internalModuleReadFile = function(p) {
+      var archive, asarPath, buffer, fd, filePath, info, isAsar, realPath, ref;
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return internalModuleReadFile(p);
+      }
+      archive = getOrCreateArchive(asarPath);
+      if (!archive) {
+        return void 0;
+      }
+      info = archive.getFileInfo(filePath);
+      if (!info) {
+        return void 0;
+      }
+      if (info.size === 0) {
+        return '';
+      }
+      if (info.unpacked) {
+        realPath = archive.copyFileOut(filePath);
+        return fs.readFileSync(realPath, {
+          encoding: 'utf8'
+        });
+      }
+      buffer = new Buffer(info.size);
+      fd = archive.getFd();
+      if (!(fd >= 0)) {
+        return void 0;
+      }
+      fs.readSync(fd, buffer, 0, info.size, info.offset);
+      return buffer.toString('utf8');
+    };
+    internalModuleStat = process.binding('fs').internalModuleStat;
+    process.binding('fs').internalModuleStat = function(p) {
+      var archive, asarPath, filePath, isAsar, ref, stats;
+      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      if (!isAsar) {
+        return internalModuleStat(p);
+      }
+      archive = getOrCreateArchive(asarPath);
+
+      // -ENOENT
+      if (!archive) {
+        return -34;
+      }
+      stats = archive.stat(filePath);
+
+      // -ENOENT
+      if (!stats) {
+        return -34;
+      }
+      if (stats.isDirectory) {
+        return 1;
+      } else {
+        return 0;
+      }
+    };
+
+    // Calling mkdir for directory inside asar archive should throw ENOTDIR
+    // error, but on Windows it throws ENOENT.
+    // This is to work around the recursive looping bug of mkdirp since it is
+    // widely used.
+    if (process.platform === 'win32') {
+      mkdir = fs.mkdir;
+      fs.mkdir = function(p, mode, callback) {
+        var asarPath, filePath, isAsar, ref;
+        if (typeof mode === 'function') {
+          callback = mode;
+        }
+        ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+        if (isAsar && filePath.length) {
+          return notDirError(callback);
+        }
+        return mkdir(p, mode, callback);
+      };
+      mkdirSync = fs.mkdirSync;
+      fs.mkdirSync = function(p, mode) {
+        var asarPath, filePath, isAsar, ref;
+        ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+        if (isAsar && filePath.length) {
+          notDirError();
+        }
+        return mkdirSync(p, mode);
+      };
+    }
+    overrideAPI(fs, 'open');
+    overrideAPI(child_process, 'execFile');
+    overrideAPISync(process, 'dlopen', 1);
+    overrideAPISync(require('module')._extensions, '.node', 1);
+    overrideAPISync(fs, 'openSync');
+    return overrideAPISync(child_process, 'execFileSync');
+  };
 })()

--- a/atom/common/lib/asar.js
+++ b/atom/common/lib/asar.js
@@ -579,4 +579,4 @@
     overrideAPISync(fs, 'openSync');
     return overrideAPISync(child_process, 'execFileSync');
   };
-})()
+})();

--- a/atom/common/lib/asar_init.js
+++ b/atom/common/lib/asar_init.js
@@ -1,8 +1,5 @@
 (function () {
   return function(process, require, asarSource) {
-    var createArchive, source;
-    createArchive = process.binding('atom_common_asar').createArchive;
-
     // Make asar.coffee accessible via "require".
     process.binding('natives').ATOM_SHELL_ASAR = asarSource;
 
@@ -10,7 +7,7 @@
     require('ATOM_SHELL_ASAR').wrapFsWithAsar(require('fs'));
 
     // Make graceful-fs work with asar.
-    source = process.binding('natives');
+    var source = process.binding('natives');
     source['original-fs'] = source.fs;
     return source['fs'] = "var src = '(function (exports, require, module, __filename, __dirname) { ' +\n          process.binding('natives')['original-fs'] +\n          ' });';\nvar vm = require('vm');\nvar fn = vm.runInThisContext(src, { filename: 'fs.js' });\nfn(exports, require, module);\nvar asar = require('ATOM_SHELL_ASAR');\nasar.wrapFsWithAsar(exports);";
   };

--- a/atom/common/lib/asar_init.js
+++ b/atom/common/lib/asar_init.js
@@ -1,17 +1,17 @@
 (function () {
-return function(process, require, asarSource) {
-  var createArchive, source;
-  createArchive = process.binding('atom_common_asar').createArchive;
+  return function(process, require, asarSource) {
+    var createArchive, source;
+    createArchive = process.binding('atom_common_asar').createArchive;
 
-  // Make asar.coffee accessible via "require".
-  process.binding('natives').ATOM_SHELL_ASAR = asarSource;
+    // Make asar.coffee accessible via "require".
+    process.binding('natives').ATOM_SHELL_ASAR = asarSource;
 
-  // Monkey-patch the fs module.
-  require('ATOM_SHELL_ASAR').wrapFsWithAsar(require('fs'));
+    // Monkey-patch the fs module.
+    require('ATOM_SHELL_ASAR').wrapFsWithAsar(require('fs'));
 
-  // Make graceful-fs work with asar.
-  source = process.binding('natives');
-  source['original-fs'] = source.fs;
-  return source['fs'] = "var src = '(function (exports, require, module, __filename, __dirname) { ' +\n          process.binding('natives')['original-fs'] +\n          ' });';\nvar vm = require('vm');\nvar fn = vm.runInThisContext(src, { filename: 'fs.js' });\nfn(exports, require, module);\nvar asar = require('ATOM_SHELL_ASAR');\nasar.wrapFsWithAsar(exports);";
-};
+    // Make graceful-fs work with asar.
+    source = process.binding('natives');
+    source['original-fs'] = source.fs;
+    return source['fs'] = "var src = '(function (exports, require, module, __filename, __dirname) { ' +\n          process.binding('natives')['original-fs'] +\n          ' });';\nvar vm = require('vm');\nvar fn = vm.runInThisContext(src, { filename: 'fs.js' });\nfn(exports, require, module);\nvar asar = require('ATOM_SHELL_ASAR');\nasar.wrapFsWithAsar(exports);";
+  };
 })()

--- a/atom/common/lib/asar_init.js
+++ b/atom/common/lib/asar_init.js
@@ -11,4 +11,4 @@
     source['original-fs'] = source.fs;
     return source['fs'] = "var src = '(function (exports, require, module, __filename, __dirname) { ' +\n          process.binding('natives')['original-fs'] +\n          ' });';\nvar vm = require('vm');\nvar fn = vm.runInThisContext(src, { filename: 'fs.js' });\nfn(exports, require, module);\nvar asar = require('ATOM_SHELL_ASAR');\nasar.wrapFsWithAsar(exports);";
   };
-})()
+})();

--- a/atom/common/lib/init.js
+++ b/atom/common/lib/init.js
@@ -6,7 +6,7 @@ process.atomBinding = function(name) {
   try {
     return process.binding("atom_" + process.type + "_" + name);
   } catch (error) {
-    if (/No such module/.test(e.message)) {
+    if (/No such module/.test(error.message)) {
       return process.binding("atom_common_" + name);
     }
   }

--- a/atom/common/lib/init.js
+++ b/atom/common/lib/init.js
@@ -1,14 +1,11 @@
-const fs = require('fs');
 const path = require('path');
 const timers = require('timers');
 const Module = require('module');
 
 process.atomBinding = function(name) {
-  var e, error;
   try {
     return process.binding("atom_" + process.type + "_" + name);
   } catch (error) {
-    e = error;
     if (/No such module/.test(e.message)) {
       return process.binding("atom_common_" + name);
     }

--- a/atom/renderer/api/lib/ipc-renderer.js
+++ b/atom/renderer/api/lib/ipc-renderer.js
@@ -1,4 +1,3 @@
-const EventEmitter = require('events').EventEmitter;
 const binding = process.atomBinding('ipc');
 const v8Util = process.atomBinding('v8_util');
 

--- a/atom/renderer/api/lib/ipc.js
+++ b/atom/renderer/api/lib/ipc.js
@@ -11,7 +11,7 @@ deprecate.warn('ipc module', 'require("electron").ipcRenderer');
 var ipc = new EventEmitter;
 
 ipcRenderer.emit = function() {
-  var channel = arguments[0]
+  var channel = arguments[0];
   var args = 3 <= arguments.length ? slice.call(arguments, 2) : [];
   ipc.emit.apply(ipc, [channel].concat(slice.call(args)));
   return EventEmitter.prototype.emit.apply(ipcRenderer, arguments);

--- a/atom/renderer/api/lib/ipc.js
+++ b/atom/renderer/api/lib/ipc.js
@@ -11,8 +11,8 @@ deprecate.warn('ipc module', 'require("electron").ipcRenderer');
 var ipc = new EventEmitter;
 
 ipcRenderer.emit = function() {
-  var args, channel, event;
-  channel = arguments[0], event = arguments[1], args = 3 <= arguments.length ? slice.call(arguments, 2) : [];
+  var channel = arguments[0]
+  var args = 3 <= arguments.length ? slice.call(arguments, 2) : [];
   ipc.emit.apply(ipc, [channel].concat(slice.call(args)));
   return EventEmitter.prototype.emit.apply(ipcRenderer, arguments);
 };

--- a/atom/renderer/api/lib/remote.js
+++ b/atom/renderer/api/lib/remote.js
@@ -111,7 +111,6 @@ var metaToValue = function(meta) {
       return new Date(meta.value);
     case 'exception':
       throw new Error(meta.message + "\n" + meta.stack);
-      break;
     default:
       if (meta.type === 'function') {
         // A shadow class to represent the remote function object.

--- a/atom/renderer/api/lib/remote.js
+++ b/atom/renderer/api/lib/remote.js
@@ -87,7 +87,7 @@ var wrapArgs = function(args, visited) {
 
 // Convert meta data from browser into real value.
 var metaToValue = function(meta) {
-  var RemoteFunction, el, i, j, len, len1, member, ref1, ref2, results, ret;
+  var el, i, j, len, len1, member, ref1, ref2, results, ret;
   switch (meta.type) {
     case 'value':
       return meta.value;
@@ -114,7 +114,7 @@ var metaToValue = function(meta) {
     default:
       if (meta.type === 'function') {
         // A shadow class to represent the remote function object.
-        ret = RemoteFunction = (function() {
+        ret = (function() {
           function RemoteFunction() {
             var obj;
             if (this.constructor === RemoteFunction) {
@@ -189,8 +189,7 @@ var metaToPlainObject = function(meta) {
 // This function's content should not be inlined into metaToValue, otherwise V8
 // may consider it circular reference.
 var createRemoteMemberFunction = function(metaId, name) {
-  var RemoteMemberFunction;
-  return RemoteMemberFunction = (function() {
+  return (function() {
     function RemoteMemberFunction() {
       var ret;
       if (this.constructor === RemoteMemberFunction) {

--- a/atom/renderer/lib/init.js
+++ b/atom/renderer/lib/init.js
@@ -2,18 +2,14 @@
 
 const events = require('events');
 const path = require('path');
-const url = require('url');
 const Module = require('module');
-
 
 // We modified the original process.argv to let node.js load the
 // atom-renderer.js, we need to restore it here.
 process.argv.splice(1, 1);
 
-
 // Clear search paths.
 require(path.resolve(__dirname, '..', '..', 'common', 'lib', 'reset-search-paths'));
-
 
 // Import common settings.
 require(path.resolve(__dirname, '..', '..', 'common', 'lib', 'init'));

--- a/atom/renderer/lib/inspector.js
+++ b/atom/renderer/lib/inspector.js
@@ -43,7 +43,7 @@ var convertToMenuTemplate = function(items) {
   return template;
 };
 
-var createMenu = function(x, y, items, document) {
+var createMenu = function(x, y, items) {
   const remote = require('electron').remote;
   const Menu = remote.Menu;
   const menu = Menu.buildFromTemplate(convertToMenuTemplate(items));

--- a/atom/renderer/lib/web-view/guest-view-internal.js
+++ b/atom/renderer/lib/web-view/guest-view-internal.js
@@ -62,21 +62,21 @@ var dispatchEvent = function() {
 module.exports = {
   registerEvents: function(webView, viewInstanceId) {
     ipcRenderer.on("ATOM_SHELL_GUEST_VIEW_INTERNAL_DISPATCH_EVENT-" + viewInstanceId, function() {
-      var args, event, eventName;
-      event = arguments[0], eventName = arguments[1], args = 3 <= arguments.length ? slice.call(arguments, 2) : [];
+      var eventName = arguments[1];
+      var args = 3 <= arguments.length ? slice.call(arguments, 2) : [];
       return dispatchEvent.apply(null, [webView, eventName, eventName].concat(slice.call(args)));
     });
     ipcRenderer.on("ATOM_SHELL_GUEST_VIEW_INTERNAL_IPC_MESSAGE-" + viewInstanceId, function() {
-      var args, channel, domEvent, event;
-      event = arguments[0], channel = arguments[1], args = 3 <= arguments.length ? slice.call(arguments, 2) : [];
-      domEvent = new Event('ipc-message');
+      var channel = arguments[1];
+      var args = 3 <= arguments.length ? slice.call(arguments, 2) : [];
+      var domEvent = new Event('ipc-message');
       domEvent.channel = channel;
       domEvent.args = slice.call(args);
       return webView.dispatchEvent(domEvent);
     });
     return ipcRenderer.on("ATOM_SHELL_GUEST_VIEW_INTERNAL_SIZE_CHANGED-" + viewInstanceId, function() {
-      var args, domEvent, event, f, i, j, len, ref1;
-      event = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
+      var args, domEvent, f, i, j, len, ref1;
+      args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
       domEvent = new Event('size-changed');
       ref1 = ['oldWidth', 'oldHeight', 'newWidth', 'newHeight'];
       for (i = j = 0, len = ref1.length; j < len; i = ++j) {

--- a/atom/renderer/lib/web-view/web-view-attributes.js
+++ b/atom/renderer/lib/web-view/web-view-attributes.js
@@ -87,7 +87,7 @@ class AllowTransparencyAttribute extends BooleanAttribute {
     super(webViewConstants.ATTRIBUTE_ALLOWTRANSPARENCY, webViewImpl);
   }
 
-  handleMutation(oldValue, newValue) {
+  handleMutation() {
     if (!this.webViewImpl.guestInstanceId) {
       return;
     }
@@ -105,7 +105,7 @@ class AutosizeDimensionAttribute extends WebViewAttribute {
     return parseInt(this.webViewImpl.webviewNode.getAttribute(this.name)) || 0;
   }
 
-  handleMutation(oldValue, newValue) {
+  handleMutation() {
     if (!this.webViewImpl.guestInstanceId) {
       return;
     }

--- a/atom/renderer/lib/web-view/web-view.js
+++ b/atom/renderer/lib/web-view/web-view.js
@@ -41,7 +41,7 @@ var WebViewImpl = (function() {
     // Subscribe to host's zoom level changes.
     this.onZoomLevelChanged = (zoomLevel) => {
       this.webviewNode.setZoomLevel(zoomLevel);
-    }
+    };
     webFrame.on('zoom-level-changed', this.onZoomLevelChanged);
   }
 

--- a/atom/renderer/lib/web-view/web-view.js
+++ b/atom/renderer/lib/web-view/web-view.js
@@ -93,15 +93,13 @@ var WebViewImpl = (function() {
       this.webviewNode.setAttribute('tabIndex', -1);
     }
     this.webviewNode.addEventListener('focus', (function(_this) {
-      return function(e) {
-
+      return function() {
         // Focus the BrowserPlugin when the <webview> takes focus.
         return _this.browserPluginNode.focus();
       };
     })(this));
     return this.webviewNode.addEventListener('blur', (function(_this) {
-      return function(e) {
-
+      return function() {
         // Blur the BrowserPlugin when the <webview> loses focus.
         return _this.browserPluginNode.blur();
       };
@@ -138,12 +136,11 @@ var WebViewImpl = (function() {
   };
 
   WebViewImpl.prototype.onSizeChanged = function(webViewEvent) {
-    var height, maxHeight, maxWidth, minHeight, minWidth, newHeight, newWidth, node, width;
+    var maxHeight, maxWidth, minHeight, minWidth, newHeight, newWidth, node, width;
     newWidth = webViewEvent.newWidth;
     newHeight = webViewEvent.newHeight;
     node = this.webviewNode;
     width = node.offsetWidth;
-    height = node.offsetHeight;
 
     // Check the current bounds to make sure we do not resize <webview>
     // outside of current constraints.
@@ -296,8 +293,7 @@ var registerBrowserPluginElement = function() {
   };
   proto.attachedCallback = function() {
     // Load the plugin immediately.
-    var unused;
-    return unused = this.nonExistentAttribute;
+    return this.nonExistentAttribute;
   };
   WebViewImpl.BrowserPlugin = webFrame.registerEmbedderCustomElement('browserplugin', {
     "extends": 'object',

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "private": true,
   "scripts": {
-    "lint": "python ./script/eslint.py",
+    "lint": "python ./script/eslint.py && python ./script/cpplint.py",
     "preinstall": "node -e 'process.exit(0)'",
     "start": "python ./script/start.py",
     "test": "python ./script/test.py"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "private": true,
   "scripts": {
+    "lint": "python ./script/eslint.py",
     "preinstall": "node -e 'process.exit(0)'",
     "start": "python ./script/start.py",
     "test": "python ./script/test.py"

--- a/script/eslintrc-base.json
+++ b/script/eslintrc-base.json
@@ -18,7 +18,7 @@
     "comma-dangle": 0,
     "linebreak-style": 0,
     "no-console": 0,
-    "no-undef": 0,
+    "no-undef": 2,
     "no-unused-vars": 2
   },
   "env": {

--- a/script/eslintrc-base.json
+++ b/script/eslintrc-base.json
@@ -19,7 +19,6 @@
     "linebreak-style": 0,
     "no-console": 0,
     "no-undef": 0,
-    "no-unreachable": 0,
     "no-unused-vars": 0
   },
   "env": {

--- a/script/eslintrc-base.json
+++ b/script/eslintrc-base.json
@@ -12,7 +12,7 @@
       "single"
     ],
     "semi": [
-      0,
+      2,
       "always"
     ],
     "comma-dangle": 0,

--- a/script/eslintrc-base.json
+++ b/script/eslintrc-base.json
@@ -1,7 +1,7 @@
 {
   "rules": {
     "indent": [
-      0,
+      2,
       2,
       {
         "SwitchCase": 1

--- a/script/eslintrc-base.json
+++ b/script/eslintrc-base.json
@@ -26,5 +26,10 @@
     "node": true,
     "browser": true
   },
-  "extends": "eslint:recommended"
+  "extends": "eslint:recommended",
+  "globals": {
+    "DevToolsAPI": false,
+    "InspectorFrontendHost": false,
+    "WebInspector": false
+  }
 }

--- a/script/eslintrc-base.json
+++ b/script/eslintrc-base.json
@@ -19,7 +19,7 @@
     "linebreak-style": 0,
     "no-console": 0,
     "no-undef": 0,
-    "no-unused-vars": 0
+    "no-unused-vars": 2
   },
   "env": {
     "es6": true,

--- a/script/eslintrc-base.json
+++ b/script/eslintrc-base.json
@@ -30,6 +30,7 @@
   "globals": {
     "DevToolsAPI": false,
     "InspectorFrontendHost": false,
-    "WebInspector": false
+    "WebInspector": false,
+    "WebView": false
   }
 }

--- a/script/eslintrc-spec.json
+++ b/script/eslintrc-spec.json
@@ -1,7 +1,4 @@
 {
-  "rules": {
-    "no-empty": 0
-  },
   "env": {
     "jquery": true,
     "mocha": true

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1,22 +1,15 @@
-var BrowserWindow, assert, fs, http, ipcMain, isCI, os, path, ref, ref1, remote, screen, url;
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 
-assert = require('assert');
+const remote = require('electron').remote;
+const screen = require('electron').screen;
 
-fs = require('fs');
+const ipcMain = remote.require('electron').ipcMain;
+const BrowserWindow = remote.require('electron').BrowserWindow;
 
-path = require('path');
-
-http = require('http');
-
-url = require('url');
-
-os = require('os');
-
-ref = require('electron'), remote = ref.remote, screen = ref.screen;
-
-ref1 = remote.require('electron'), ipcMain = ref1.ipcMain, BrowserWindow = ref1.BrowserWindow;
-
-isCI = remote.getGlobal('isCi');
+const isCI = remote.getGlobal('isCi');
 
 describe('browser-window module', function() {
   var fixtures, w;

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -470,6 +470,7 @@ describe('browser-window module', function() {
         fs.rmdirSync(path.join(savePageDir, 'save_page_files'));
         fs.rmdirSync(savePageDir);
       } catch (e) {
+        // Ignore error
       }
     });
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -41,7 +41,7 @@ describe('crash-reporter module', function() {
       var form;
       server.close();
       form = new multiparty.Form();
-      return form.parse(req, function(error, fields, files) {
+      return form.parse(req, function(error, fields) {
         if (called) {
           return;
         }

--- a/spec/api-desktop-capturer-spec.js
+++ b/spec/api-desktop-capturer-spec.js
@@ -19,9 +19,9 @@ describe('desktopCapturer', function() {
       assert.equal(error, null);
       assert.notEqual(sources.length, 0);
       if (callCount === 2) done();
-    }
+    };
 
     desktopCapturer.getSources({types: ['window', 'screen']}, callback);
     desktopCapturer.getSources({types: ['window', 'screen']}, callback);
-  })
+  });
 });

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -84,12 +84,10 @@ describe('ipc module', function() {
     return it('can be used as promise in each side', function(done) {
       var promise;
       promise = remote.require(path.join(fixtures, 'module', 'promise.js'));
-      return promise.twicePromise(Promise.resolve(1234)).then((function(_this) {
-        return function(value) {
-          assert.equal(value, 2468);
-          return done();
-        };
-      })(this));
+      return promise.twicePromise(Promise.resolve(1234)).then(function(value) {
+        assert.equal(value, 2468);
+        return done();
+      });
     });
   });
   describe('ipc.sender.send', function() {

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -1,16 +1,9 @@
-var assert, http, path, protocol, qs, remote;
-
-assert = require('assert');
-
-http = require('http');
-
-path = require('path');
-
-qs = require('querystring');
-
-remote = require('electron').remote;
-
-protocol = remote.require('electron').protocol;
+const assert = require('assert');
+const http = require('http');
+const path = require('path');
+const qs = require('querystring');
+const remote = require('electron').remote;
+const protocol = remote.require('electron').protocol;
 
 describe('protocol module', function() {
   var postData, protocolName, text;
@@ -44,11 +37,10 @@ describe('protocol module', function() {
     it('does not crash when handler is called twice', function(done) {
       var doubleHandler;
       doubleHandler = function(request, callback) {
-        var error1;
         try {
           callback(text);
           return callback();
-        } catch (error1) {
+        } catch (error) {
           // Ignore error
         }
       };
@@ -75,10 +67,10 @@ describe('protocol module', function() {
         }
         return $.ajax({
           url: protocolName + "://fake-host",
-          success: function(data) {
+          success: function() {
             return done('request succeeded but it should not');
           },
-          error: function(xhr, errorType, error) {
+          error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
             return done();
           }
@@ -175,7 +167,7 @@ describe('protocol module', function() {
         }
         return $.ajax({
           url: protocolName + "://fake-host",
-          success: function(data, statux, request) {
+          success: function(data) {
             assert.equal(data, text);
             return done();
           },
@@ -196,10 +188,10 @@ describe('protocol module', function() {
         }
         return $.ajax({
           url: protocolName + "://fake-host",
-          success: function(data) {
+          success: function() {
             return done('request succeeded but it should not');
           },
-          error: function(xhr, errorType, error) {
+          error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
             return done();
           }
@@ -267,7 +259,7 @@ describe('protocol module', function() {
         }
         return $.ajax({
           url: protocolName + "://fake-host",
-          success: function(data, statux, request) {
+          success: function(data) {
             assert.equal(data, text);
             return done();
           },
@@ -288,10 +280,10 @@ describe('protocol module', function() {
         }
         return $.ajax({
           url: protocolName + "://fake-host",
-          success: function(data) {
+          success: function() {
             return done('request succeeded but it should not');
           },
-          error: function(xhr, errorType, error) {
+          error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
             return done();
           }
@@ -361,7 +353,7 @@ describe('protocol module', function() {
         }
         return $.ajax({
           url: protocolName + "://fake-host",
-          success: function(data, statux, request) {
+          success: function(data) {
             assert.equal(data, String(fileContent));
             return done();
           },
@@ -404,10 +396,10 @@ describe('protocol module', function() {
         }
         return $.ajax({
           url: protocolName + "://fake-host",
-          success: function(data) {
+          success: function() {
             return done('request succeeded but it should not');
           },
-          error: function(xhr, errorType, error) {
+          error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
             return done();
           }
@@ -425,10 +417,10 @@ describe('protocol module', function() {
         }
         return $.ajax({
           url: protocolName + "://fake-host",
-          success: function(data) {
+          success: function() {
             return done('request succeeded but it should not');
           },
-          error: function(xhr, errorType, error) {
+          error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
             return done();
           }
@@ -483,10 +475,10 @@ describe('protocol module', function() {
         }
         return $.ajax({
           url: protocolName + "://fake-host",
-          success: function(data) {
+          success: function() {
             return done('request succeeded but it should not');
           },
-          error: function(xhr, errorType, error) {
+          error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
             return done();
           }
@@ -504,10 +496,10 @@ describe('protocol module', function() {
         }
         return $.ajax({
           url: protocolName + "://fake-host",
-          success: function(data) {
+          success: function() {
             return done('request succeeded but it should not');
           },
-          error: function(xhr, errorType, error) {
+          error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
             return done();
           }
@@ -584,11 +576,10 @@ describe('protocol module', function() {
     it('does not crash when handler is called twice', function(done) {
       var doubleHandler;
       doubleHandler = function(request, callback) {
-        var error1;
         try {
           callback(text);
           return callback();
-        } catch (error1) {
+        } catch (error) {
           // Ignore error
         }
       };
@@ -618,10 +609,10 @@ describe('protocol module', function() {
         }
         return $.ajax({
           url: 'http://fake-host',
-          success: function(data) {
+          success: function() {
             return done('request succeeded but it should not');
           },
-          error: function(xhr, errorType, error) {
+          error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
             return done();
           }

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -49,7 +49,7 @@ describe('protocol module', function() {
           callback(text);
           return callback();
         } catch (error1) {
-
+          // Ignore error
         }
       };
       return protocol.registerStringProtocol(protocolName, doubleHandler, function(error) {
@@ -589,7 +589,7 @@ describe('protocol module', function() {
           callback(text);
           return callback();
         } catch (error1) {
-
+          // Ignore error
         }
       };
       return protocol.interceptStringProtocol('http', doubleHandler, function(error) {

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -1,16 +1,14 @@
-var BrowserWindow, app, assert, fs, http, ipcMain, ipcRenderer, path, ref, remote, session;
+const assert = require('assert');
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
 
-assert = require('assert');
+const ipcRenderer = require('electron').ipcRenderer;
+const remote = require('electron').remote;
 
-http = require('http');
-
-path = require('path');
-
-fs = require('fs');
-
-ref = require('electron'), ipcRenderer = ref.ipcRenderer, remote = ref.remote;
-
-app = remote.app, ipcMain = remote.ipcMain, session = remote.session, BrowserWindow = remote.BrowserWindow;
+const ipcMain = remote.ipcMain;
+const session = remote.session;
+const BrowserWindow = remote.BrowserWindow;
 
 describe('session module', function() {
   var fixtures, url, w;

--- a/spec/api-web-request-spec.js
+++ b/spec/api-web-request-spec.js
@@ -1,12 +1,7 @@
-var assert, http, remote, session;
-
-assert = require('assert');
-
-http = require('http');
-
-remote = require('electron').remote;
-
-session = remote.session;
+const assert = require('assert');
+const http = require('http');
+const remote = require('electron').remote;
+const session = remote.session;
 
 describe('webRequest module', function() {
   var defaultURL, server, ses;
@@ -44,10 +39,10 @@ describe('webRequest module', function() {
       });
       return $.ajax({
         url: defaultURL,
-        success: function(data) {
+        success: function() {
           return done('unexpected success');
         },
-        error: function(xhr, errorType, error) {
+        error: function() {
           return done();
         }
       });
@@ -68,15 +63,15 @@ describe('webRequest module', function() {
           assert.equal(data, '/nofilter/test');
           return $.ajax({
             url: defaultURL + "filter/test",
-            success: function(data) {
+            success: function() {
               return done('unexpected success');
             },
-            error: function(xhr, errorType, error) {
+            error: function() {
               return done();
             }
           });
         },
-        error: function(xhr, errorType, error) {
+        error: function(xhr, errorType) {
           return done(errorType);
         }
       });
@@ -96,7 +91,7 @@ describe('webRequest module', function() {
           assert.equal(data, '/');
           return done();
         },
-        error: function(xhr, errorType, error) {
+        error: function(xhr, errorType) {
           return done(errorType);
         }
       });
@@ -117,7 +112,7 @@ describe('webRequest module', function() {
           assert.equal(data, '/redirect');
           return done();
         },
-        error: function(xhr, errorType, error) {
+        error: function(xhr, errorType) {
           return done(errorType);
         }
       });
@@ -138,7 +133,7 @@ describe('webRequest module', function() {
           assert.equal(data, '/');
           return done();
         },
-        error: function(xhr, errorType, error) {
+        error: function(xhr, errorType) {
           return done(errorType);
         }
       });
@@ -154,11 +149,11 @@ describe('webRequest module', function() {
       });
       return $.ajax({
         url: defaultURL,
-        success: function(data, textStatus, request) {
+        success: function(data) {
           assert.equal(data, '/header/received');
           return done();
         },
-        error: function(xhr, errorType, error) {
+        error: function(xhr, errorType) {
           return done(errorType);
         }
       });
@@ -179,7 +174,7 @@ describe('webRequest module', function() {
       });
       return $.ajax({
         url: defaultURL,
-        error: function(xhr, errorType, error) {
+        error: function(xhr, errorType) {
           return done(errorType);
         }
       });
@@ -199,7 +194,7 @@ describe('webRequest module', function() {
           assert.equal(data, '/');
           return done();
         },
-        error: function(xhr, errorType, error) {
+        error: function(xhr, errorType) {
           return done(errorType);
         }
       });
@@ -222,7 +217,7 @@ describe('webRequest module', function() {
           assert.equal(data, '/');
           return done();
         },
-        error: function(xhr, errorType, error) {
+        error: function(xhr, errorType) {
           return done(errorType);
         }
       });
@@ -243,7 +238,7 @@ describe('webRequest module', function() {
           assert.equal(data, '/');
           return done();
         },
-        error: function(xhr, errorType, error) {
+        error: function(xhr, errorType) {
           return done(errorType);
         }
       });
@@ -259,7 +254,7 @@ describe('webRequest module', function() {
           assert.equal(data, '/');
           return done();
         },
-        error: function(xhr, errorType, error) {
+        error: function(xhr, errorType) {
           return done(errorType);
         }
       });
@@ -283,7 +278,7 @@ describe('webRequest module', function() {
           assert.equal(data, '/');
           return done();
         },
-        error: function(xhr, errorType, error) {
+        error: function(xhr, errorType) {
           return done(errorType);
         }
       });
@@ -314,11 +309,11 @@ describe('webRequest module', function() {
       });
       return $.ajax({
         url: defaultURL,
-        success: function(data, status, xhr) {
+        success: function(data) {
           assert.equal(data, '/redirect');
           return done();
         },
-        error: function(xhr, errorType, error) {
+        error: function(xhr, errorType) {
           return done(errorType);
         }
       });
@@ -336,11 +331,11 @@ describe('webRequest module', function() {
       });
       return $.ajax({
         url: defaultURL,
-        success: function(data, status, xhr) {
+        success: function(data) {
           assert.equal(data, '/');
           return done();
         },
-        error: function(xhr, errorType, error) {
+        error: function(xhr, errorType) {
           return done(errorType);
         }
       });
@@ -363,7 +358,7 @@ describe('webRequest module', function() {
       });
       return $.ajax({
         url: defaultURL,
-        success: function(data) {
+        success: function() {
           return done('unexpected success');
         }
       });

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -1,16 +1,13 @@
-var BrowserWindow, assert, child_process, fs, ipcMain, nativeImage, path, ref, ref1, remote;
+const assert = require('assert');
+const child_process = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
-assert = require('assert');
+const nativeImage = require('electron').nativeImage;
+const remote = require('electron').remote;
 
-child_process = require('child_process');
-
-fs = require('fs');
-
-path = require('path');
-
-ref = require('electron'), nativeImage = ref.nativeImage, remote = ref.remote;
-
-ref1 = remote.require('electron'), ipcMain = ref1.ipcMain, BrowserWindow = ref1.BrowserWindow;
+const ipcMain = remote.require('electron').ipcMain;
+const BrowserWindow = remote.require('electron').BrowserWindow;
 
 describe('asar package', function() {
   var fixtures;
@@ -18,12 +15,11 @@ describe('asar package', function() {
   describe('node api', function() {
     describe('fs.readFileSync', function() {
       it('does not leak fd', function() {
-        var i, j, results;
-        results = [];
-        for (i = j = 1; j <= 10000; i = ++j) {
-          results.push(fs.readFileSync(path.join(process.resourcesPath, 'atom.asar', 'renderer', 'api', 'lib', 'ipc.js')));
+        var readCalls = 1;
+        while(readCalls <= 10000) {
+          fs.readFileSync(path.join(process.resourcesPath, 'atom.asar', 'renderer', 'api', 'lib', 'ipc.js'));
+          readCalls++;
         }
-        return results;
       });
       it('reads a normal file', function() {
         var file1, file2, file3;
@@ -117,7 +113,7 @@ describe('asar package', function() {
       return it('throws ENOENT error when can not find file', function(done) {
         var p;
         p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
-        return fs.readFile(p, function(err, content) {
+        return fs.readFile(p, function(err) {
           assert.equal(err.code, 'ENOENT');
           return done();
         });
@@ -221,9 +217,8 @@ describe('asar package', function() {
         return fs.lstat(p + '/', done);
       });
       it('returns information of root', function(done) {
-        var p, stats;
-        p = path.join(fixtures, 'asar', 'a.asar');
-        return stats = fs.lstat(p, function(err, stats) {
+        var p = path.join(fixtures, 'asar', 'a.asar');
+        fs.lstat(p, function(err, stats) {
           assert.equal(err, null);
           assert.equal(stats.isFile(), false);
           assert.equal(stats.isDirectory(), true);
@@ -233,9 +228,8 @@ describe('asar package', function() {
         });
       });
       it('returns information of a normal file', function(done) {
-        var p, stats;
-        p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'file1');
-        return stats = fs.lstat(p, function(err, stats) {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'file1');
+        fs.lstat(p, function(err, stats) {
           assert.equal(err, null);
           assert.equal(stats.isFile(), true);
           assert.equal(stats.isDirectory(), false);
@@ -245,9 +239,8 @@ describe('asar package', function() {
         });
       });
       it('returns information of a normal directory', function(done) {
-        var p, stats;
-        p = path.join(fixtures, 'asar', 'a.asar', 'dir1');
-        return stats = fs.lstat(p, function(err, stats) {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'dir1');
+        fs.lstat(p, function(err, stats) {
           assert.equal(err, null);
           assert.equal(stats.isFile(), false);
           assert.equal(stats.isDirectory(), true);
@@ -257,9 +250,8 @@ describe('asar package', function() {
         });
       });
       it('returns information of a linked file', function(done) {
-        var p, stats;
-        p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link1');
-        return stats = fs.lstat(p, function(err, stats) {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link1');
+        fs.lstat(p, function(err, stats) {
           assert.equal(err, null);
           assert.equal(stats.isFile(), false);
           assert.equal(stats.isDirectory(), false);
@@ -269,9 +261,8 @@ describe('asar package', function() {
         });
       });
       it('returns information of a linked directory', function(done) {
-        var p, stats;
-        p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2');
-        return stats = fs.lstat(p, function(err, stats) {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2');
+        fs.lstat(p, function(err, stats) {
           assert.equal(err, null);
           assert.equal(stats.isFile(), false);
           assert.equal(stats.isDirectory(), false);
@@ -281,9 +272,8 @@ describe('asar package', function() {
         });
       });
       return it('throws ENOENT error when can not find file', function(done) {
-        var p, stats;
-        p = path.join(fixtures, 'asar', 'a.asar', 'file4');
-        return stats = fs.lstat(p, function(err, stats) {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'file4');
+        fs.lstat(p, function(err) {
           assert.equal(err.code, 'ENOENT');
           return done();
         });
@@ -390,7 +380,7 @@ describe('asar package', function() {
         var p, parent;
         parent = fs.realpathSync(path.join(fixtures, 'asar'));
         p = path.join('a.asar', 'not-exist');
-        return fs.realpath(path.join(parent, p), function(err, stats) {
+        return fs.realpath(path.join(parent, p), function(err) {
           assert.equal(err.code, 'ENOENT');
           return done();
         });
@@ -426,27 +416,24 @@ describe('asar package', function() {
     });
     describe('fs.readdir', function() {
       it('reads dirs from root', function(done) {
-        var dirs, p;
-        p = path.join(fixtures, 'asar', 'a.asar');
-        return dirs = fs.readdir(p, function(err, dirs) {
+        var p = path.join(fixtures, 'asar', 'a.asar');
+        fs.readdir(p, function(err, dirs) {
           assert.equal(err, null);
           assert.deepEqual(dirs, ['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
           return done();
         });
       });
       it('reads dirs from a normal dir', function(done) {
-        var dirs, p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'dir1');
-        return dirs = fs.readdir(p, function(err, dirs) {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'dir1');
+        fs.readdir(p, function(err, dirs) {
           assert.equal(err, null);
           assert.deepEqual(dirs, ['file1', 'file2', 'file3', 'link1', 'link2']);
           return done();
         });
       });
       it('reads dirs from a linked dir', function(done) {
-        var dirs, p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2');
-        return dirs = fs.readdir(p, function(err, dirs) {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2');
+        fs.readdir(p, function(err, dirs) {
           assert.equal(err, null);
           assert.deepEqual(dirs, ['file1', 'file2', 'file3', 'link1', 'link2']);
           return done();
@@ -455,7 +442,7 @@ describe('asar package', function() {
       return it('throws ENOENT error when can not find file', function(done) {
         var p;
         p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
-        return fs.readdir(p, function(err, stats) {
+        return fs.readdir(p, function(err) {
           assert.equal(err.code, 'ENOENT');
           return done();
         });
@@ -504,7 +491,7 @@ describe('asar package', function() {
       return it('throws ENOENT error when can not find file', function(done) {
         var p;
         p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
-        return fs.open(p, 'r', function(err, stats) {
+        return fs.open(p, 'r', function(err) {
           assert.equal(err.code, 'ENOENT');
           return done();
         });
@@ -559,8 +546,7 @@ describe('asar package', function() {
       ref2 = require('child_process'), execFile = ref2.execFile, execFileSync = ref2.execFileSync;
       echo = path.join(fixtures, 'asar', 'echo.asar', 'echo');
       it('executes binaries', function(done) {
-        var child;
-        return child = execFile(echo, ['test'], function(error, stdout) {
+        execFile(echo, ['test'], function(error, stdout) {
           assert.equal(error, null);
           assert.equal(stdout, 'test\n');
           return done();

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -1,18 +1,11 @@
-var BrowserWindow, assert, http, https, path, ref, remote, session, ws;
+const assert = require('assert');
+const http = require('http');
+const path = require('path');
+const ws = require('ws');
+const remote = require('electron').remote;
 
-assert = require('assert');
-
-http = require('http');
-
-https = require('https');
-
-path = require('path');
-
-ws = require('ws');
-
-remote = require('electron').remote;
-
-ref = remote.require('electron'), BrowserWindow = ref.BrowserWindow, session = ref.session;
+const BrowserWindow = remote.require('electron').BrowserWindow;
+const session = remote.require('electron').session;
 
 describe('chromium feature', function() {
   var fixtures, listener;
@@ -310,8 +303,7 @@ describe('chromium feature', function() {
     return it('has user agent', function(done) {
       server = http.createServer();
       return server.listen(0, '127.0.0.1', function() {
-        var port, websocket;
-        port = server.address().port;
+        var port = server.address().port;
         wss = new WebSocketServer({
           server: server
         });
@@ -323,7 +315,7 @@ describe('chromium feature', function() {
             return done('user agent is empty');
           }
         });
-        return websocket = new WebSocket("ws://127.0.0.1:" + port);
+        new WebSocket("ws://127.0.0.1:" + port);
       });
     });
   });

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -1,12 +1,6 @@
-var assert, fs, path, temp;
-
-assert = require('assert');
-
-fs = require('fs');
-
-path = require('path');
-
-temp = require('temp');
+const assert = require('assert');
+const path = require('path');
+const temp = require('temp');
 
 describe('third-party module', function() {
   var fixtures;

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const child_process = require('child_process');
+const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const remote = require('electron').remote;

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -1,16 +1,8 @@
-var assert, child_process, fs, os, path, remote;
-
-assert = require('assert');
-
-child_process = require('child_process');
-
-fs = require('fs');
-
-path = require('path');
-
-os = require('os');
-
-remote = require('electron').remote;
+const assert = require('assert');
+const child_process = require('child_process');
+const path = require('path');
+const os = require('os');
+const remote = require('electron').remote;
 
 describe('node feature', function() {
   var fixtures;
@@ -103,7 +95,7 @@ describe('node feature', function() {
         error = new Error('boo!');
         lsts = process.listeners('uncaughtException');
         process.removeAllListeners('uncaughtException');
-        process.on('uncaughtException', function(err) {
+        process.on('uncaughtException', function() {
           var i, len, lst;
           process.removeAllListeners('uncaughtException');
           for (i = 0, len = lsts.length; i < len; i++) {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -31,8 +31,7 @@ describe('<webview> tag', function() {
       return document.body.appendChild(webview);
     });
     return it('navigates to new page when changed', function(done) {
-      var listener;
-      listener = function(e) {
+      var listener = function() {
         webview.src = "file://" + fixtures + "/pages/b.html";
         webview.addEventListener('console-message', function(e) {
           assert.equal(e.message, 'b');
@@ -74,11 +73,9 @@ describe('<webview> tag', function() {
     });
     if (process.platform !== 'win32' || process.execPath.toLowerCase().indexOf('\\out\\d\\') === -1) {
       return it('loads native modules when navigation happens', function(done) {
-        var listener;
-        listener = function(e) {
-          var listener2;
+        var listener = function() {
           webview.removeEventListener('did-finish-load', listener);
-          listener2 = function(e) {
+          var listener2 = function(e) {
             assert.equal(e.message, 'function');
             return done();
           };
@@ -123,7 +120,7 @@ describe('<webview> tag', function() {
         webview.removeEventListener('ipc-message', listener);
         return done();
       };
-      listener2 = function(e) {
+      listener2 = function() {
         webview.send('ping', message);
         return webview.removeEventListener('did-finish-load', listener2);
       };
@@ -459,7 +456,7 @@ describe('<webview> tag', function() {
         webview.removeEventListener('ipc-message', listener);
         return done();
       };
-      listener2 = function(e) {
+      listener2 = function() {
         webview.reload();
         return webview.removeEventListener('did-finish-load', listener2);
       };
@@ -520,7 +517,7 @@ describe('<webview> tag', function() {
   describe('dom-ready event', function() {
     return it('emits when document is loaded', function(done) {
       var server;
-      server = http.createServer(function(req) {});
+      server = http.createServer(function() {});
       return server.listen(0, '127.0.0.1', function() {
         var port;
         port = server.address().port;
@@ -538,11 +535,11 @@ describe('<webview> tag', function() {
     }
     return it('should support user gesture', function(done) {
       var listener, listener2;
-      listener = function(e) {
+      listener = function() {
         webview.removeEventListener('enter-html-full-screen', listener);
         return done();
       };
-      listener2 = function(e) {
+      listener2 = function() {
         var jsScript;
         jsScript = 'document.getElementsByTagName("video")[0].webkitRequestFullScreen()';
         webview.executeJavaScript(jsScript, true);
@@ -618,7 +615,7 @@ describe('<webview> tag', function() {
           return done();
         }
       };
-      listener2 = function(e) {
+      listener2 = function() {
         return requestId = webview.findInPage("virtual");
       };
       webview.addEventListener('found-in-page', listener);
@@ -629,7 +626,7 @@ describe('<webview> tag', function() {
   });
   return xdescribe('did-change-theme-color event', function() {
     return it('emits when theme color changes', function(done) {
-      webview.addEventListener('did-change-theme-color', function(e) {
+      webview.addEventListener('did-change-theme-color', function() {
         return done();
       });
       webview.src = "file://" + fixtures + "/pages/theme-color.html";


### PR DESCRIPTION
Enables the following eslint rules by default and removes instances violating them from the codebase:

- [2 space indentation](http://eslint.org/docs/rules/indent.html)
- [Consistent semicolon usage](http://eslint.org/docs/rules/semi.html)
- [No using undeclared variables](http://eslint.org/docs/rules/no-undef.html)
- [No unused variables](http://eslint.org/docs/rules/no-unused-vars.html)

Refs #4065 