### PR TITLE
browser: change location of default download dir

### DIFF
--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -19,11 +19,13 @@
 #include "atom/common/options_switches.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"
+#include "base/path_service.h"
 #include "base/prefs/pref_registry_simple.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "base/threading/sequenced_worker_pool.h"
 #include "base/threading/worker_pool.h"
+#include "chrome/common/chrome_paths.h"
 #include "chrome/common/pref_names.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/common/url_constants.h"
@@ -180,8 +182,10 @@ net::SSLConfigService* AtomBrowserContext::CreateSSLConfigService() {
 void AtomBrowserContext::RegisterPrefs(PrefRegistrySimple* pref_registry) {
   pref_registry->RegisterFilePathPref(prefs::kSelectFileLastDirectory,
                                       base::FilePath());
+  base::FilePath download_dir;
+  PathService::Get(chrome::DIR_DEFAULT_DOWNLOADS, &download_dir);
   pref_registry->RegisterFilePathPref(prefs::kDownloadDefaultDirectory,
-                                      base::FilePath());
+                                      download_dir);
 }
 
 bool AtomBrowserContext::AllowNTLMCredentialsForDomain(const GURL& origin) {

--- a/atom/browser/atom_download_manager_delegate.cc
+++ b/atom/browser/atom_download_manager_delegate.cc
@@ -125,11 +125,6 @@ bool AtomDownloadManagerDelegate::DetermineDownloadTarget(
       download_manager_->GetBrowserContext());
   base::FilePath default_download_path = browser_context->prefs()->GetFilePath(
       prefs::kDownloadDefaultDirectory);
-  // If users didn't set download path, use 'Downloads' directory by default.
-  if (default_download_path.empty()) {
-    auto path = download_manager_->GetBrowserContext()->GetPath();
-    default_download_path = path.Append(FILE_PATH_LITERAL("Downloads"));
-  }
 
   CreateDownloadPathCallback download_path_callback =
       base::Bind(&AtomDownloadManagerDelegate::OnDownloadPathGenerated,


### PR DESCRIPTION
Fixes #4141 

Uses the users' download directory instead of the applications data location. 