### PR TITLE
Expose loadURL for the webview tag.

### DIFF
--- a/atom/renderer/lib/web-view/web-view.js
+++ b/atom/renderer/lib/web-view/web-view.js
@@ -350,6 +350,7 @@ var registerWebViewElement = function() {
   // Public-facing API methods.
   methods = [
     'getURL',
+    'loadURL',
     'getTitle',
     'isLoading',
     'isWaitingForResponse',

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -171,6 +171,17 @@ webview.addEventListener("dom-ready", function() {
 });
 ```
 
+### `<webview>.loadURL(url[, options])`
+
+* `url` URL
+* `options` Object (optional), properties:
+  * `httpReferrer` String - A HTTP Referrer url.
+  * `userAgent` String - A user agent originating the request.
+  * `extraHeaders` String - Extra headers separated by "\n"
+
+Loads the `url` in the webview, the `url` must contain the protocol prefix,
+e.g. the `http://` or `file://`.
+
 ### `<webview>.getURL()`
 
 Returns URL of guest page.


### PR DESCRIPTION
This PR fixes https://github.com/atom/electron/issues/4101, by making `loadURL` available on `webview`.