### PR TITLE
:memo: Use correct shortcut for 'Hide Others' menu item example

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -169,7 +169,7 @@ if (process.platform == 'darwin') {
       },
       {
         label: 'Hide Others',
-        accelerator: 'Command+Shift+H',
+        accelerator: 'Command+Alt+H',
         role: 'hideothers'
       },
       {


### PR DESCRIPTION
As per https://support.apple.com/en-gb/HT201236, the correct keyboard shortcut
for hiding all but the current window is Command-Option(Alt)-H.