### PR TITLE
Use Alt in OS X 'Hide Others' menu item accelerator 

### DIFF
--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -198,7 +198,7 @@ app.once('ready', function() {
         },
         {
           label: 'Hide Others',
-          accelerator: 'Command+Shift+H',
+          accelerator: 'Command+Alt+H',
           role: 'hideothers'
         },
         {


### PR DESCRIPTION
This updates the accelerator in 'Hide Others' menu item to use `Alt` rather than `Shift` per https://support.apple.com/en-gb/HT201236 + https://github.com/atom/electron/pull/4188 :pizza: 

cc @kevinsawicki 