### PR TITLE
Menu.popup: specify positioning item (OS X)

### DIFF
--- a/atom/browser/api/atom_api_menu.h
+++ b/atom/browser/api/atom_api_menu.h
@@ -52,7 +52,8 @@ class Menu : public mate::TrackableObject<Menu>,
   void MenuWillShow(ui::SimpleMenuModel* source) override;
 
   virtual void Popup(Window* window) = 0;
-  virtual void PopupAt(Window* window, int x, int y) = 0;
+  virtual void PopupAt(Window* window, int x, int y,
+      int positioningItem = 0) = 0;
 
   scoped_ptr<AtomMenuModel> model_;
   Menu* parent_;

--- a/atom/browser/api/atom_api_menu_mac.h
+++ b/atom/browser/api/atom_api_menu_mac.h
@@ -20,7 +20,7 @@ class MenuMac : public Menu {
   MenuMac();
 
   void Popup(Window* window) override;
-  void PopupAt(Window* window, int x, int y) override;
+  void PopupAt(Window* window, int x, int y, int positioningItem = 0) override;
 
   base::scoped_nsobject<AtomMenuController> menu_controller_;
 

--- a/atom/browser/api/atom_api_menu_mac.mm
+++ b/atom/browser/api/atom_api_menu_mac.mm
@@ -50,7 +50,7 @@ void MenuMac::Popup(Window* window) {
                    forView:web_contents->GetContentNativeView()];
 }
 
-void MenuMac::PopupAt(Window* window, int x, int y) {
+void MenuMac::PopupAt(Window* window, int x, int y, int positioningItem) {
   NativeWindow* native_window = window->window();
   if (!native_window)
     return;
@@ -64,7 +64,13 @@ void MenuMac::PopupAt(Window* window, int x, int y) {
   NSView* view = web_contents->GetContentNativeView();
 
   // Show the menu.
-  [menu popUpMenuPositioningItem:[menu itemAtIndex:0]
+  if (positioningItem >= [menu numberOfItems]) {
+    positioningItem = [menu numberOfItems] - 1;
+  }
+  if (positioningItem < 0) {
+    positioningItem = 0;
+  }
+  [menu popUpMenuPositioningItem:[menu itemAtIndex:positioningItem]
                       atLocation:NSMakePoint(x, [view frame].size.height - y)
                           inView:view];
 }

--- a/atom/browser/api/atom_api_menu_views.cc
+++ b/atom/browser/api/atom_api_menu_views.cc
@@ -20,7 +20,7 @@ void MenuViews::Popup(Window* window) {
   PopupAtPoint(window, gfx::Screen::GetNativeScreen()->GetCursorScreenPoint());
 }
 
-void MenuViews::PopupAt(Window* window, int x, int y) {
+void MenuViews::PopupAt(Window* window, int x, int y, int positioningItem) {
   NativeWindow* native_window = static_cast<NativeWindow*>(window->window());
   if (!native_window)
     return;

--- a/atom/browser/api/atom_api_menu_views.h
+++ b/atom/browser/api/atom_api_menu_views.h
@@ -18,7 +18,7 @@ class MenuViews : public Menu {
 
  protected:
   void Popup(Window* window) override;
-  void PopupAt(Window* window, int x, int y) override;
+  void PopupAt(Window* window, int x, int y, int positioningItem = 0) override;
 
  private:
   void PopupAtPoint(Window* window, const gfx::Point& point);

--- a/atom/browser/api/lib/menu.js
+++ b/atom/browser/api/lib/menu.js
@@ -158,7 +158,7 @@ Menu.prototype._init = function() {
   };
 };
 
-Menu.prototype.popup = function(window, x, y) {
+Menu.prototype.popup = function(window, x, y, positioningItem) {
   if ((window != null ? window.constructor : void 0) !== BrowserWindow) {
     // Shift.
     y = x;
@@ -166,7 +166,7 @@ Menu.prototype.popup = function(window, x, y) {
     window = BrowserWindow.getFocusedWindow();
   }
   if ((x != null) && (y != null)) {
-    return this._popupAt(window, x, y);
+    return this._popupAt(window, x, y, positioningItem || 0);
   } else {
     return this._popup(window);
   }

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -237,15 +237,18 @@ Generally, the `template` is just an array of `options` for constructing a
 You can also attach other fields to the element of the `template` and they
 will become properties of the constructed menu items.
 
-### `Menu.popup([browserWindow, x, y])`
+### `Menu.popup([browserWindow, x, y, positioningItem])`
 
 * `browserWindow` BrowserWindow (optional)
 * `x` Number (optional)
 * `y` Number (**required** if `x` is used)
+* `positioningItem` Number (optional) _OS X_
 
 Pops up this menu as a context menu in the `browserWindow`. You
 can optionally provide a `x,y` coordinate to place the menu at, otherwise it
-will be placed at the current mouse cursor position.
+will be placed at the current mouse cursor position. `positioningItem` is the
+index of the menu item to be positioned under the mouse cursor at the specified
+coordinates (only supported on OS X).
 
 ### `Menu.append(menuItem)`
 


### PR DESCRIPTION
Added `positioningItem` parameter to the `popup` method.