### PR TITLE
Support alpha in backgroundColor of BrowserWindow

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -552,11 +552,11 @@ void NativeWindow::OnCapturePageDone(const CapturePageCallback& callback,
 }
 
 SkColor NativeWindow::ParseHexColor(const std::string& name) {
-  SkColor result = 0xFF000000;
-  unsigned value = 0;
   auto color = name.substr(1);
   unsigned length = color.size();
-  if (length != 3 && length != 6)
+  SkColor result = (length != 8 ? 0xFF000000 : 0x00000000);
+  unsigned value = 0;
+  if (length != 3 && length != 6 && length != 8)
     return result;
   for (unsigned i = 0; i < length; ++i) {
     if (!base::IsHexDigit(color[i]))
@@ -564,7 +564,7 @@ SkColor NativeWindow::ParseHexColor(const std::string& name) {
     value <<= 4;
     value |= (color[i] < 'A' ? color[i] - '0' : (color[i] - 'A' + 10) & 0xF);
   }
-  if (length == 6) {
+  if (length == 6 || length == 8) {
     result |= value;
     return result;
   }

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -710,7 +710,7 @@ void NativeWindowMac::SetBackgroundColor(const std::string& color_name) {
   NSColor *color = [NSColor colorWithCalibratedRed:SkColorGetR(background_color)
     green:SkColorGetG(background_color)
     blue:SkColorGetB(background_color)
-    alpha:1.0];
+    alpha:SkColorGetA(background_color)/255.0f];
   [window_ setBackgroundColor:color];
 }
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -74,8 +74,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `enableLargerThanScreen` Boolean - Enable the window to be resized larger
     than screen. Default is `false`.
   * `backgroundColor` String - Window's background color as Hexadecimal value,
-    like `#66CD00` or `#FFF`. Default is `#000` (black) for Linux and Windows,
-    `#FFF` for Mac (or clear if transparent).
+    like `#66CD00` or `#FFF` or `#80FFFFFF` (alpha is supported). Default is
+    `#000` (black) for Linux and Windows, `#FFF` for Mac (or clear if
+    transparent).
   * `darkTheme` Boolean - Forces using dark theme for the window, only works on
     some GTK+3 desktop environments. Default is `false`.
   * `transparent` Boolean - Makes the window [transparent](frameless-window.md).


### PR DESCRIPTION
Now values like `#80FF0000` (red with 50% opacity) will work.