### PR TITLE
Added hasShadow option to BrowserWindow on OS X

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -462,6 +462,14 @@ void Window::SetBackgroundColor(const std::string& color_name) {
   window_->SetBackgroundColor(color_name);
 }
 
+void Window::SetHasShadow(bool has_shadow) {
+  window_->SetHasShadow(has_shadow);
+}
+
+bool Window::HasShadow() {
+  return window_->HasShadow();
+}
+
 void Window::FocusOnWebView() {
   window_->FocusOnWebView();
 }
@@ -671,6 +679,8 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setKiosk", &Window::SetKiosk)
       .SetMethod("isKiosk", &Window::IsKiosk)
       .SetMethod("setBackgroundColor", &Window::SetBackgroundColor)
+      .SetMethod("setHasShadow", &Window::SetHasShadow)
+      .SetMethod("hasShadow", &Window::HasShadow)
       .SetMethod("setRepresentedFilename", &Window::SetRepresentedFilename)
       .SetMethod("getRepresentedFilename", &Window::GetRepresentedFilename)
       .SetMethod("setDocumentEdited", &Window::SetDocumentEdited)

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -118,6 +118,8 @@ class Window : public mate::TrackableObject<Window>,
   void SetKiosk(bool kiosk);
   bool IsKiosk();
   void SetBackgroundColor(const std::string& color_name);
+  void SetHasShadow(bool has_shadow);
+  bool HasShadow();
   void FocusOnWebView();
   void BlurWebView();
   bool IsWebViewFocused();

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -551,6 +551,13 @@ void NativeWindow::OnCapturePageDone(const CapturePageCallback& callback,
   callback.Run(bitmap);
 }
 
+void NativeWindow::SetHasShadow(bool has_shadow) {
+}
+
+bool NativeWindow::HasShadow() {
+  return true;
+}
+
 SkColor NativeWindow::ParseHexColor(const std::string& name) {
   SkColor result = 0xFF000000;
   unsigned value = 0;

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -135,6 +135,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetKiosk(bool kiosk) = 0;
   virtual bool IsKiosk() = 0;
   virtual void SetBackgroundColor(const std::string& color_name) = 0;
+  virtual void SetHasShadow(bool has_shadow);
+  virtual bool HasShadow();
   virtual void SetRepresentedFilename(const std::string& filename);
   virtual std::string GetRepresentedFilename();
   virtual void SetDocumentEdited(bool edited);

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -58,6 +58,8 @@ class NativeWindowMac : public NativeWindow {
   void SetKiosk(bool kiosk) override;
   bool IsKiosk() override;
   void SetBackgroundColor(const std::string& color_name) override;
+  void SetHasShadow(bool has_shadow) override;
+  bool HasShadow() override;
   void SetRepresentedFilename(const std::string& filename) override;
   std::string GetRepresentedFilename() override;
   void SetDocumentEdited(bool edited) override;

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -435,6 +435,12 @@ NativeWindowMac::NativeWindowMac(
   if (!has_frame())
     [window_ setOpaque:NO];
 
+  bool has_shadow = true;
+  options.Get(options::kHasShadow, &has_shadow);
+  if (!has_shadow) {
+    SetHasShadow(false);
+  }
+
   // We will manage window's lifetime ourselves.
   [window_ setReleasedWhenClosed:NO];
 
@@ -712,6 +718,14 @@ void NativeWindowMac::SetBackgroundColor(const std::string& color_name) {
     blue:SkColorGetB(background_color)
     alpha:1.0];
   [window_ setBackgroundColor:color];
+}
+
+void NativeWindowMac::SetHasShadow(bool has_shadow) {
+  [window_ setHasShadow:has_shadow];
+}
+
+bool NativeWindowMac::HasShadow() {
+  return [window_ hasShadow];
 }
 
 void NativeWindowMac::SetRepresentedFilename(const std::string& filename) {

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -68,6 +68,9 @@ const char kStandardWindow[] = "standardWindow";
 // Default browser window background color.
 const char kBackgroundColor[] = "backgroundColor";
 
+// Whether the window should have a shadow.
+const char kHasShadow[] = "hasShadow";
+
 // The WebPreferences.
 const char kWebPreferences[] = "webPreferences";
 

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -39,6 +39,7 @@ extern const char kType[];
 extern const char kDisableAutoHideCursor[];
 extern const char kStandardWindow[];
 extern const char kBackgroundColor[];
+extern const char kHasShadow[];
 extern const char kWebPreferences[];
 
 // WebPreferences.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -77,7 +77,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     like `#66CD00` or `#FFF`. Default is `#000` (black) for Linux and Windows,
     `#FFF` for Mac (or clear if transparent).
   * `hasShadow` Boolean - Whether window should have a shadow. This is only
-    implemented on OS X.
+    implemented on OS X. Default is `true`.
   * `darkTheme` Boolean - Forces using dark theme for the window, only works on
     some GTK+3 desktop environments. Default is `false`.
   * `transparent` Boolean - Makes the window [transparent](frameless-window.md).

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -76,6 +76,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `backgroundColor` String - Window's background color as Hexadecimal value,
     like `#66CD00` or `#FFF`. Default is `#000` (black) for Linux and Windows,
     `#FFF` for Mac (or clear if transparent).
+  * `hasShadow` Boolean - Whether window should have a shadow. This is only
+    implemented on OS X.
   * `darkTheme` Boolean - Forces using dark theme for the window, only works on
     some GTK+3 desktop environments. Default is `false`.
   * `transparent` Boolean - Makes the window [transparent](frameless-window.md).
@@ -710,6 +712,17 @@ screen readers
 Sets a 16px overlay onto the current taskbar icon, usually used to convey some
 sort of application status or to passively notify the user.
 
+### `win.setHasShadow(hasShadow)` _OS X_
+
+* `hasShadow` (Boolean)
+
+Sets whether the window should have a shadow. On Windows and Linux does
+nothing.
+
+### `win.hasShadow()` _OS X_
+
+Returns whether the window has a shadow. On Windows and Linux always returns
+`true`.
 
 ### `win.setThumbarButtons(buttons)` _Windows 7+_
 


### PR DESCRIPTION
Added `hasShadow` option and `setHasShadow` and `hasShadow` methods to `BrowserWindow` on OS X.