### PR TITLE
Autoupdate: Fixed crash after update is downloaded on windows

### DIFF
--- a/atom/browser/api/lib/auto-updater/auto-updater-win.js
+++ b/atom/browser/api/lib/auto-updater/auto-updater-win.js
@@ -2,7 +2,6 @@
 
 const app = require('electron').app;
 const EventEmitter = require('events').EventEmitter;
-const url = require('url');
 const squirrelUpdate = require('./squirrel-update-win');
 
 class AutoUpdater extends EventEmitter {

--- a/atom/browser/api/lib/auto-updater/auto-updater-win.js
+++ b/atom/browser/api/lib/auto-updater/auto-updater-win.js
@@ -45,8 +45,7 @@ class AutoUpdater extends EventEmitter {
 
           // Following information is not available on Windows, so fake them.
           date = new Date;
-          url = _this.updateURL;
-          return _this.emit('update-downloaded', {}, releaseNotes, version, date, url, function() {
+          return _this.emit('update-downloaded', {}, releaseNotes, version, date, _this.updateURL, function() {
             return _this.quitAndInstall();
           });
         });


### PR DESCRIPTION
After an update is downloaded the following TypeError occurs:
```
TypeError: Assignment to constant variable.
  at atom.asar\\browser\\api\\lib\\auto-updater\\auto-updater-win.js:48:15
  at ChildProcess.<anonymous> (atom.asar\\browser\\api\\lib\\auto-updater\\squirrel-update-win.js:56:12)
  at emitTwo (events.js:87:13)
  at ChildProcess.emit (events.js:172:7)
  at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
```
This PR prevents this by passing the referenced variable rather than attempt to change a const