### PR TITLE
Revert "renderer: dont fork the process when there is server redirect"

### DIFF
--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -173,7 +173,7 @@ bool AtomRendererClient::ShouldFork(blink::WebLocalFrame* frame,
   // the OpenURLFromTab is triggered, which means form posting would not work,
   // we should solve this by patching Chromium in future.
   *send_referrer = true;
-  return http_method == "GET" && !is_server_redirect;
+  return http_method == "GET";
 }
 
 content::BrowserPluginDelegate* AtomRendererClient::CreateBrowserPluginDelegate(


### PR DESCRIPTION
This reverts #3918, fixes #4025, and unfortunately reopens #3471.

The root problem is: we want to restart renderer process for every navigation, but for certain types of navigations we can not do that. Hopefully this will be solved once [PlzNavigate](https://groups.google.com/a/chromium.org/forum/#!msg/chromium-dev/FmWJ4d7oBCc/6ippzjoKDwAJ) gets landed.