### PR TITLE
:apple: Add 'Hide' to App API for OS X only

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -356,6 +356,7 @@ mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(
       .SetMethod("quit", base::Bind(&Browser::Quit, browser))
       .SetMethod("exit", base::Bind(&Browser::Exit, browser))
       .SetMethod("focus", base::Bind(&Browser::Focus, browser))
+      .SetMethod("hide", base::Bind(&Browser::Hide, browser))
       .SetMethod("getVersion", base::Bind(&Browser::GetVersion, browser))
       .SetMethod("setVersion", base::Bind(&Browser::SetVersion, browser))
       .SetMethod("getName", base::Bind(&Browser::GetName, browser))

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -369,6 +369,7 @@ mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(
                  base::Bind(&Browser::SetAppUserModelID, browser))
 #if defined(OS_MACOSX)
       .SetMethod("hide", base::Bind(&Browser::Hide, browser))
+      .SetMethod("show", base::Bind(&Browser::Show, browser))
 #endif
 #if defined(OS_WIN)
       .SetMethod("setUserTasks",

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -356,7 +356,6 @@ mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(
       .SetMethod("quit", base::Bind(&Browser::Quit, browser))
       .SetMethod("exit", base::Bind(&Browser::Exit, browser))
       .SetMethod("focus", base::Bind(&Browser::Focus, browser))
-      .SetMethod("hide", base::Bind(&Browser::Hide, browser))
       .SetMethod("getVersion", base::Bind(&Browser::GetVersion, browser))
       .SetMethod("setVersion", base::Bind(&Browser::SetVersion, browser))
       .SetMethod("getName", base::Bind(&Browser::GetName, browser))
@@ -368,6 +367,9 @@ mate::ObjectTemplateBuilder App::GetObjectTemplateBuilder(
                  base::Bind(&Browser::ClearRecentDocuments, browser))
       .SetMethod("setAppUserModelId",
                  base::Bind(&Browser::SetAppUserModelID, browser))
+#if defined(OS_MACOSX)
+      .SetMethod("hide", base::Bind(&Browser::Hide, browser))
+#endif
 #if defined(OS_WIN)
       .SetMethod("setUserTasks",
                  base::Bind(&Browser::SetUserTasks, browser))

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -80,6 +80,9 @@ class Browser : public WindowListObserver {
   // Hide the application.
   void Hide();
 
+  // Show the application.
+  void Show();
+
   // Bounce the dock icon.
   enum BounceType {
     BOUNCE_CRITICAL = 0,

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -55,6 +55,9 @@ class Browser : public WindowListObserver {
   // Focus the application.
   void Focus();
 
+  // Focus the application.
+  void Hide();
+
   // Returns the version of the executable (or bundle).
   std::string GetVersion() const;
 

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -55,9 +55,6 @@ class Browser : public WindowListObserver {
   // Focus the application.
   void Focus();
 
-  // Focus the application.
-  void Hide();
-
   // Returns the version of the executable (or bundle).
   std::string GetVersion() const;
 
@@ -80,6 +77,9 @@ class Browser : public WindowListObserver {
   void SetAppUserModelID(const base::string16& name);
 
 #if defined(OS_MACOSX)
+  // Hide the application.
+  void Hide();
+
   // Bounce the dock icon.
   enum BounceType {
     BOUNCE_CRITICAL = 0,

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -18,6 +18,10 @@ void Browser::Focus() {
   [[AtomApplication sharedApplication] activateIgnoringOtherApps:YES];
 }
 
+void Browser::Hide() {
+  [[AtomApplication sharedApplication] hide:nil];
+}
+
 void Browser::AddRecentDocument(const base::FilePath& path) {
   NSString* path_string = base::mac::FilePathToNSString(path);
   if (!path_string)

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -22,6 +22,10 @@ void Browser::Hide() {
   [[AtomApplication sharedApplication] hide:nil];
 }
 
+void Browser::Show() {
+  [[AtomApplication sharedApplication] unhide:nil];
+}
+
 void Browser::AddRecentDocument(const base::FilePath& path) {
   NSString* path_string = base::mac::FilePathToNSString(path);
   if (!path_string)

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -248,6 +248,10 @@ returning `false` in the `beforeunload` event handler.
 
 Hides all application windows without minimising them.
 
+### `app.show()` _OS X_
+
+Shows application windows after they were hidden. Does not automatically focus them.
+
 ### `app.exit(exitCode)`
 
 * `exitCode` Integer

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -244,6 +244,10 @@ This method guarantees that all `beforeunload` and `unload` event handlers are
 correctly executed. It is possible that a window cancels the quitting by
 returning `false` in the `beforeunload` event handler.
 
+### `app.hide()` _OS X_
+
+Hides all application windows without minimising them.
+
 ### `app.exit(exitCode)`
 
 * `exitCode` Integer


### PR DESCRIPTION
When creating a popover window via global hotkey, you might want to return focus to the previous app after closing all windows.

For example:
http://stackoverflow.com/questions/22081215/return-focus-to-previous-apps-window-after-makekeyandorderfront

Without app.hide(), you need to interact (click on the window or cmd-tab away and back) to refocus.
![without-hide](https://cloud.githubusercontent.com/assets/147663/12679196/25d2d8ba-c6a3-11e5-98d5-b920ae6df03d.gif)

With app.hide(), you can return focus directly (gif says "hide before quit", should be "hide before close"):
![with-hide](https://cloud.githubusercontent.com/assets/147663/12679242/575a26c2-c6a3-11e5-85be-60d0d098732e.gif)

I don't think there's an equivalent for Linux or Windows so I've only done this for OS X and tagged it as such in the docs.