### PR TITLE
Don't use ES6 class for auto updater

### DIFF
--- a/atom/browser/api/lib/auto-updater/auto-updater-win.js
+++ b/atom/browser/api/lib/auto-updater/auto-updater-win.js
@@ -4,59 +4,59 @@ const app = require('electron').app;
 const EventEmitter = require('events').EventEmitter;
 const squirrelUpdate = require('./squirrel-update-win');
 
-class AutoUpdater extends EventEmitter {
-  constructor() {
-    super();
-  }
+function AutoUpdater() {
+  EventEmitter.call(this)
+}
 
-  quitAndInstall() {
-    squirrelUpdate.processStart();
-    return app.quit();
-  }
+require('util').inherits(AutoUpdater, EventEmitter);
 
-  setFeedURL(updateURL) {
-    return this.updateURL = updateURL;
-  }
+AutoUpdater.prototype.quitAndInstall = function() {
+  squirrelUpdate.processStart();
+  return app.quit();
+}
 
-  checkForUpdates() {
-    if (!this.updateURL) {
-      return this.emitError('Update URL is not set');
-    }
-    if (!squirrelUpdate.supported()) {
-      return this.emitError('Can not find Squirrel');
-    }
-    this.emit('checking-for-update');
-    return squirrelUpdate.download(this.updateURL, (function(_this) {
-      return function(error, update) {
+AutoUpdater.prototype.setFeedURL = function(updateURL) {
+  return this.updateURL = updateURL;
+}
+
+AutoUpdater.prototype.checkForUpdates = function() {
+  if (!this.updateURL) {
+    return this.emitError('Update URL is not set');
+  }
+  if (!squirrelUpdate.supported()) {
+    return this.emitError('Can not find Squirrel');
+  }
+  this.emit('checking-for-update');
+  return squirrelUpdate.download(this.updateURL, (function(_this) {
+    return function(error, update) {
+      if (error != null) {
+        return _this.emitError(error);
+      }
+      if (update == null) {
+        return _this.emit('update-not-available');
+      }
+      _this.emit('update-available');
+      return squirrelUpdate.update(_this.updateURL, function(error) {
+        var date, releaseNotes, version;
         if (error != null) {
           return _this.emitError(error);
         }
-        if (update == null) {
-          return _this.emit('update-not-available');
-        }
-        _this.emit('update-available');
-        return squirrelUpdate.update(_this.updateURL, function(error) {
-          var date, releaseNotes, version;
-          if (error != null) {
-            return _this.emitError(error);
-          }
-          releaseNotes = update.releaseNotes, version = update.version;
+        releaseNotes = update.releaseNotes, version = update.version;
 
-          // Following information is not available on Windows, so fake them.
-          date = new Date;
-          return _this.emit('update-downloaded', {}, releaseNotes, version, date, _this.updateURL, function() {
-            return _this.quitAndInstall();
-          });
+        // Following information is not available on Windows, so fake them.
+        date = new Date;
+        return _this.emit('update-downloaded', {}, releaseNotes, version, date, _this.updateURL, function() {
+          return _this.quitAndInstall();
         });
-      };
-    })(this));
-  }
+      });
+    };
+  })(this));
+}
 
-  // Private: Emit both error object and message, this is to keep compatibility
-  // with Old APIs.
-  emitError(message) {
-    return this.emit('error', new Error(message), message);
-  }
+// Private: Emit both error object and message, this is to keep compatibility
+// with Old APIs.
+AutoUpdater.prototype.emitError = (message) {
+  return this.emit('error', new Error(message), message);
 }
 
 module.exports = new AutoUpdater;

--- a/atom/browser/api/lib/auto-updater/auto-updater-win.js
+++ b/atom/browser/api/lib/auto-updater/auto-updater-win.js
@@ -3,12 +3,13 @@
 const app = require('electron').app;
 const EventEmitter = require('events').EventEmitter;
 const squirrelUpdate = require('./squirrel-update-win');
+const util = require('util');
 
 function AutoUpdater() {
   EventEmitter.call(this);
 }
 
-require('util').inherits(AutoUpdater, EventEmitter);
+util.inherits(AutoUpdater, EventEmitter);
 
 AutoUpdater.prototype.quitAndInstall = function() {
   squirrelUpdate.processStart();

--- a/atom/browser/api/lib/auto-updater/auto-updater-win.js
+++ b/atom/browser/api/lib/auto-updater/auto-updater-win.js
@@ -5,7 +5,7 @@ const EventEmitter = require('events').EventEmitter;
 const squirrelUpdate = require('./squirrel-update-win');
 
 function AutoUpdater() {
-  EventEmitter.call(this)
+  EventEmitter.call(this);
 }
 
 require('util').inherits(AutoUpdater, EventEmitter);
@@ -13,11 +13,11 @@ require('util').inherits(AutoUpdater, EventEmitter);
 AutoUpdater.prototype.quitAndInstall = function() {
   squirrelUpdate.processStart();
   return app.quit();
-}
+};
 
 AutoUpdater.prototype.setFeedURL = function(updateURL) {
   return this.updateURL = updateURL;
-}
+};
 
 AutoUpdater.prototype.checkForUpdates = function() {
   if (!this.updateURL) {
@@ -51,12 +51,12 @@ AutoUpdater.prototype.checkForUpdates = function() {
       });
     };
   })(this));
-}
+};
 
 // Private: Emit both error object and message, this is to keep compatibility
 // with Old APIs.
-AutoUpdater.prototype.emitError = (message) {
+AutoUpdater.prototype.emitError = function(message) {
   return this.emit('error', new Error(message), message);
-}
+};
 
 module.exports = new AutoUpdater;

--- a/spec/api-auto-updater-spec.js
+++ b/spec/api-auto-updater-spec.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+const autoUpdater = require('electron').remote.autoUpdater;
+const ipcRenderer = require('electron').ipcRenderer;
+
+describe('autoUpdater module', function() {
+  describe('checkForUpdates', function() {
+    it('emits an error on Windows when called the feed URL is not set', function (done) {
+      if (process.platform !== 'win32') {
+        return done();
+      }
+
+      ipcRenderer.once('auto-updater-error', function(event, message) {
+        assert.equal(message, 'Update URL is not set');
+        done();
+      });
+      autoUpdater.setFeedURL('');
+      autoUpdater.checkForUpdates();
+    });
+  });
+
+  describe('setFeedURL', function() {
+    it('emits an error on Mac OS X when the application is unsigned', function (done) {
+      if (process.platform !== 'darwin') {
+        return done();
+      }
+
+      ipcRenderer.once('auto-updater-error', function(event, message) {
+        assert.equal(message, 'Could not get code signature for running application');
+        done();
+      });
+      autoUpdater.setFeedURL('');
+    });
+  });
+});

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -72,6 +72,11 @@ app.on('ready', function() {
   // Test if using protocol module would crash.
   electron.protocol.registerStringProtocol('test-if-crashes', function() {});
 
+  // Send auto updater errors to window to be verified in specs
+  electron.autoUpdater.on('error', function (error) {
+    window.send('auto-updater-error', error.message)
+  });
+
   window = new BrowserWindow({
     title: 'Electron Tests',
     show: false,


### PR DESCRIPTION
Don't use an ES6 class for the `AutoUpdater` class on Windows due to #4066 

This was a regression introduced in #4121 

This pull request also adds some initial specs for the `autoUpdater` to prevent future regressions like this.

Here is a pic of it now working on Windows 10:

<img width="647" alt="screen shot 2016-02-03 at 10 46 07 am" src="https://cloud.githubusercontent.com/assets/671378/12793043/731c93f4-ca63-11e5-83c8-239319edd8b7.png">


Fixes #4346 

