### PR TITLE
Clarify overlay description

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -785,7 +785,7 @@ cleared
 * `description` String - a description that will be provided to Accessibility
 screen readers
 
-Sets a 16px overlay onto the current taskbar icon, usually used to convey some
+Sets a 16 x 16 pixel overlay onto the current taskbar icon, usually used to convey some
 sort of application status or to passively notify the user.
 
 ### `win.setHasShadow(hasShadow)` _OS X_


### PR DESCRIPTION
'16px' is ambiguous and not clear (4 x 4 px? or 16 x 16px)