### PR TITLE
Adding support to write RTF to clipboard.

### DIFF
--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -93,6 +93,13 @@ void WriteText(const base::string16& text, mate::Arguments* args) {
   writer.WriteText(text);
 }
 
+base::string16 ReadRtf(mate::Arguments* args) {
+  std::string data;
+  ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
+  clipboard->ReadRTF(GetClipboardType(args), &data);
+  return base::UTF8ToUTF16(data);
+}
+
 void WriteRtf(const std::string& text, mate::Arguments* args) {
   ui::ScopedClipboardWriter writer(GetClipboardType(args));
   writer.WriteRTF(text);
@@ -139,6 +146,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   dict.SetMethod("write", &Write);
   dict.SetMethod("readText", &ReadText);
   dict.SetMethod("writeText", &WriteText);
+  dict.SetMethod("readRtf", &ReadRtf);
   dict.SetMethod("writeRtf", &WriteRtf);
   dict.SetMethod("readHtml", &ReadHtml);
   dict.SetMethod("writeHtml", &WriteHtml);

--- a/atom/common/api/atom_api_clipboard.cc
+++ b/atom/common/api/atom_api_clipboard.cc
@@ -60,6 +60,11 @@ void Write(const mate::Dictionary& data,
   if (data.Get("text", &text))
     writer.WriteText(text);
 
+  if (data.Get("rtf", &text)) {
+    std::string rtf = base::UTF16ToUTF8(text);
+    writer.WriteRTF(rtf);
+  }
+
   if (data.Get("html", &html))
     writer.WriteHTML(html, std::string());
 
@@ -86,6 +91,11 @@ base::string16 ReadText(mate::Arguments* args) {
 void WriteText(const base::string16& text, mate::Arguments* args) {
   ui::ScopedClipboardWriter writer(GetClipboardType(args));
   writer.WriteText(text);
+}
+
+void WriteRtf(const std::string& text, mate::Arguments* args) {
+  ui::ScopedClipboardWriter writer(GetClipboardType(args));
+  writer.WriteRTF(text);
 }
 
 base::string16 ReadHtml(mate::Arguments* args) {
@@ -129,6 +139,7 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
   dict.SetMethod("write", &Write);
   dict.SetMethod("readText", &ReadText);
   dict.SetMethod("writeText", &WriteText);
+  dict.SetMethod("writeRtf", &WriteRtf);
   dict.SetMethod("readHtml", &ReadHtml);
   dict.SetMethod("writeHtml", &WriteHtml);
   dict.SetMethod("readImage", &ReadImage);

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -61,9 +61,17 @@ Returns the content in the clipboard as a [NativeImage](native-image.md).
 
 Writes `image` to the clipboard.
 
-### `clipboard.writeRtf(text)`
+### `clipboard.readRtf([type])`
+
+* `type` String (optional)
+
+Returns the content in the clipboard as RTF.
+
+
+### `clipboard.writeRtf(text[, type])`
 
 * `text` String
+* `type` String (optional)
 
 Writes the `text` into the clipboard in RTF.
 

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -61,6 +61,12 @@ Returns the content in the clipboard as a [NativeImage](native-image.md).
 
 Writes `image` to the clipboard.
 
+### `clipboard.writeRtf(text)`
+
+* `text` String
+
+Writes the `text` into the clipboard in RTF.
+
 ### `clipboard.clear([type])`
 
 * `type` String (optional)

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -35,20 +35,30 @@ describe('clipboard module', function() {
       return assert.equal(clipboard.readHtml(), markup);
     });
   });
+  describe('clipboard.readRtf', function() {
+    return it('returns rtf text correctly', function() {
+      var rtf = "{\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\pard\nThis is some {\\b bold} text.\\par\n}";
+      clipboard.writeRtf(rtf);
+      return assert.equal(clipboard.readRtf(), rtf);
+    });
+  });
   return describe('clipboard.write()', function() {
     return it('returns data correctly', function() {
-      var i, markup, p, text;
+      var i, markup, p, text, rtf;
       text = 'test';
+      rtf = '{\\rtf1\\utf8 text}';
       p = path.join(fixtures, 'assets', 'logo.png');
       i = nativeImage.createFromPath(p);
       markup = process.platform === 'darwin' ? '<meta charset=\'utf-8\'><b>Hi</b>' : process.platform === 'linux' ? '<meta http-equiv="content-type" ' + 'content="text/html; charset=utf-8"><b>Hi</b>' : '<b>Hi</b>';
       clipboard.write({
         text: "test",
         html: '<b>Hi</b>',
+        rtf: '{\\rtf1\\utf8 text}',
         image: p
       });
       assert.equal(clipboard.readText(), text);
       assert.equal(clipboard.readHtml(), markup);
+      assert.equal(clipboard.readRtf(), rtf);
       return assert.equal(clipboard.readImage().toDataURL(), i.toDataURL());
     });
   });


### PR DESCRIPTION
Created `writeRtf` method and added support to `write` for object with rtf property. Also added method to documentation (only in english).