### PR TITLE
Launch URL or HTML file directly

### DIFF
--- a/atom/browser/default_app/default_app.js
+++ b/atom/browser/default_app/default_app.js
@@ -9,13 +9,15 @@ app.on('window-all-closed', function() {
   app.quit();
 });
 
-app.on('ready', function() {
-  mainWindow = new BrowserWindow({
-    width: 800,
-    height: 600,
-    autoHideMenuBar: true,
-    useContentSize: true,
+exports.load = function(appUrl) {
+  app.on('ready', function() {
+    mainWindow = new BrowserWindow({
+      width: 800,
+      height: 600,
+      autoHideMenuBar: true,
+      useContentSize: true,
+    });
+    mainWindow.loadURL(appUrl);
+    mainWindow.focus();
   });
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
-  mainWindow.focus();
-});
+};

--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -278,11 +278,15 @@ function loadApplicationByUrl(appUrl) {
 // Start the specified app if there is one specified in command line, otherwise
 // start the default app.
 if (option.file && !option.webdriver) {
-  var protocol = url.parse(option.file).protocol;
+  var file = option.file;
+  var protocol = url.parse(file).protocol;
+  var extension = path.extname(file);
   if (protocol === 'http:' || protocol === 'https:') {
-    loadApplicationByUrl(option.file);
+    loadApplicationByUrl(file);
+  } else if (extension === '.html' || extension === '.htm') {
+    loadApplicationByUrl('file://' + path.resolve(file));
   } else {
-    loadPackagePath(option.file);
+    loadPackagePath(file);
   }
 } else if (option.version) {
   console.log('v' + process.versions.electron);

--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -235,7 +235,7 @@ if (option.modules.length > 0) {
   require('module')._preloadModules(option.modules);
 }
 
-function loadPackagePath(packagePath) {
+function loadApplicationPackage(packagePath) {
   try {
     // Override app name and version.
     packagePath = path.resolve(packagePath);
@@ -286,7 +286,7 @@ if (option.file && !option.webdriver) {
   } else if (extension === '.html' || extension === '.htm') {
     loadApplicationByUrl('file://' + path.resolve(file));
   } else {
-    loadPackagePath(file);
+    loadApplicationPackage(file);
   }
 } else if (option.version) {
   console.log('v' + process.versions.electron);

--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -294,9 +294,14 @@ if (option.file && !option.webdriver) {
 } else if (option.help) {
   var helpMessage = "Electron v" + process.versions.electron + " - Cross Platform Desktop Application Shell\n\n";
   helpMessage    += "Usage: electron [options] [path]\n\n";
-  helpMessage    += "A path to an Electron application may be specified. The path must be to \n";
-  helpMessage    += "an index.js file or to a folder containing a package.json or index.js file.\n\n";
-  helpMessage    += "Options:\n";
+  helpMessage    += "A path to an Electron application may be specified.\n";
+  helpMessage    += "The path must be one of the following:\n\n";
+  helpMessage    += "  - index.js file.\n";
+  helpMessage    += "  - Folder containing a package.json file.\n";
+  helpMessage    += "  - Folder containing an index.js file.\n";
+  helpMessage    += "  - .html/.htm file.\n";
+  helpMessage    += "  - http://, https://, or file:// URL.\n";
+  helpMessage    += "\nOptions:\n";
   helpMessage    += "  -r, --require         Module to preload (option can be repeated)\n";
   helpMessage    += "  -h, --help            Print this usage message.\n";
   helpMessage    += "  -v, --version         Print the version.";

--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -234,12 +234,10 @@ if (option.modules.length > 0) {
   require('module')._preloadModules(option.modules);
 }
 
-// Start the specified app if there is one specified in command line, otherwise
-// start the default app.
-if (option.file && !option.webdriver) {
+function loadPackagePath(packagePath) {
   try {
     // Override app name and version.
-    var packagePath = path.resolve(option.file);
+    packagePath = path.resolve(packagePath);
     var packageJsonPath = path.join(packagePath, 'package.json');
     if (fs.existsSync(packageJsonPath)) {
       var packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
@@ -270,6 +268,12 @@ if (option.file && !option.webdriver) {
       throw e;
     }
   }
+}
+
+// Start the specified app if there is one specified in command line, otherwise
+// start the default app.
+if (option.file && !option.webdriver) {
+  loadPackagePath(option.file);
 } else if (option.version) {
   console.log('v' + process.versions.electron);
   process.exit(0);

--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -4,8 +4,8 @@ const dialog   = electron.dialog;
 const shell    = electron.shell;
 const Menu     = electron.Menu;
 
-var fs = require('fs');
-var path = require('path');
+const fs = require('fs');
+const path = require('path');
 
 // Quit when all windows are closed and no other one is listening to this.
 app.on('window-all-closed', function() {

--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -281,7 +281,7 @@ if (option.file && !option.webdriver) {
   var file = option.file;
   var protocol = url.parse(file).protocol;
   var extension = path.extname(file);
-  if (protocol === 'http:' || protocol === 'https:') {
+  if (protocol === 'http:' || protocol === 'https:' || protocol === 'file:') {
     loadApplicationByUrl(file);
   } else if (extension === '.html' || extension === '.htm') {
     loadApplicationByUrl('file://' + path.resolve(file));

--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -6,6 +6,7 @@ const Menu     = electron.Menu;
 
 const fs = require('fs');
 const path = require('path');
+const url = require('url');
 
 // Quit when all windows are closed and no other one is listening to this.
 app.on('window-all-closed', function() {
@@ -270,10 +271,19 @@ function loadPackagePath(packagePath) {
   }
 }
 
+function loadApplicationByUrl(appUrl) {
+  require('./default_app').load(appUrl);
+}
+
 // Start the specified app if there is one specified in command line, otherwise
 // start the default app.
 if (option.file && !option.webdriver) {
-  loadPackagePath(option.file);
+  var protocol = url.parse(option.file).protocol;
+  if (protocol === 'http:' || protocol === 'https:') {
+    loadApplicationByUrl(option.file);
+  } else {
+    loadPackagePath(option.file);
+  }
 } else if (option.version) {
   console.log('v' + process.versions.electron);
   process.exit(0);
@@ -289,5 +299,5 @@ if (option.file && !option.webdriver) {
   console.log(helpMessage);
   process.exit(0);
 } else {
-  require('./default_app');
+  loadApplicationByUrl('file://' + __dirname + '/index.html');
 }


### PR DESCRIPTION
This pull request changes the default app to allow you to launch http/file URLs or HTML files directly in a window from the command line.

This will allow you to test pages and sites directly in Electron without having to create the standard app boilerplate around waiting for the app to be ready, creating the browser window, and loading the URL.

You'll now be able to do:

* `electron http://electron.atom.io`
* `electron ./site/index.html`
* `electron file:///Users/me/sites/page.html`