### PR TITLE
:memo: Fixing typo in ipc-renderer

### DIFF
--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -37,9 +37,9 @@ channel.
 
 This removes *all* handlers to this ipc channel.
 
-### `ipcMain.once(channel, callback)`
+### `ipcRenderer.once(channel, callback)`
 
-Use this in place of `ipcMain.on()` to fire handlers meant to occur only once,
+Use this in place of `ipcRenderer.on()` to fire handlers meant to occur only once,
 as in, they won't be activated after one call of `callback`
 
 ## Sending Messages


### PR DESCRIPTION
Looks like this was copypasta'd from ipc-main.md