### PR TITLE
Keyboard event fixes

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -382,6 +382,26 @@ void WebContents::HandleKeyboardEvent(
     // Escape exits tabbed fullscreen mode.
     ExitFullscreenModeForTab(source);
   } else if (type_ == BROWSER_WINDOW) {
+    // On OSX, if OS event is not existing (because it was forwarded with
+    // `sendInputEvent`) simulate basic operations: undo, redo, cut, copy,
+    // paste, select all.
+    #if defined(OS_MACOSX)
+      if (!event.os_event && (event.modifiers & blink::WebInputEvent::MetaKey)
+        && (event.type == blink::WebInputEvent::RawKeyDown)) {
+        switch (event.windowsKeyCode) {
+          case ui::VKEY_Z:
+            if (event.modifiers & blink::WebInputEvent::ShiftKey) Redo();
+            else
+              Undo();
+          break;
+          case ui::VKEY_X: Cut(); break;
+          case ui::VKEY_C: Copy(); break;
+          case ui::VKEY_V: Paste(); break;
+          case ui::VKEY_A: SelectAll(); break;
+        }
+      }
+    #endif
+
     owner_window()->HandleKeyboardEvent(source, event);
   } else if (type_ == WEB_VIEW && guest_delegate_) {
     // Send the unhandled keyboard events back to the embedder.

--- a/atom/common/keyboard_util.cc
+++ b/atom/common/keyboard_util.cc
@@ -80,6 +80,16 @@ ui::KeyboardCode KeyboardCodeFromKeyIdentifier(const std::string& chr) {
   if (chr == "tab")          return ui::VKEY_TAB;
   if (chr == "escape")       return ui::VKEY_ESCAPE;
   if (chr == "control")      return ui::VKEY_CONTROL;
+#if defined(OS_MACOSX)
+  if (chr == "command"
+   || chr == "cmd"
+   || chr == "meta")         return ui::VKEY_COMMAND;
+  if (chr == "option")       return ui::VKEY_MENU;
+#endif
+#if defined(OS_WIN)
+  if (chr == "meta")         return ui::VKEY_LWIN;
+  if (chr == "altgr")        return ui::VKEY_ALTGR;
+#endif
   if (chr == "alt")          return ui::VKEY_MENU;
   if (chr == "shift")        return ui::VKEY_SHIFT;
   if (chr == "end")          return ui::VKEY_END;

--- a/atom/common/keyboard_util.cc
+++ b/atom/common/keyboard_util.cc
@@ -82,8 +82,8 @@ ui::KeyboardCode KeyboardCodeFromKeyIdentifier(const std::string& chr) {
   if (chr == "control")      return ui::VKEY_CONTROL;
 #if defined(OS_MACOSX)
   if (chr == "command"
-   || chr == "cmd"
-   || chr == "meta")         return ui::VKEY_COMMAND;
+    || chr == "cmd"
+    || chr == "meta")        return ui::VKEY_COMMAND;
   if (chr == "option")       return ui::VKEY_MENU;
 #endif
 #if defined(OS_WIN)

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -776,8 +776,10 @@ For keyboard events, the `event` object also have following properties:
 * `keyCode` Char or String (**required**) - The character that will be sent
   as the keyboard event. Can be a single UTF-8 character, or the name of the
   key that generates the event. Accepted key names are `enter`, `backspace`,
-  `delete`, `tab`, `escape`, `control`, `alt`, `shift`, `end`, `home`, `insert`,
-  `left`, `up`, `right`, `down`, `pageUp`, `pageDown`, `printScreen`
+  `delete`, `tab`, `escape`, `control`, `alt`, `altgr` (Windows only), `shift`,
+  `end`, `home`, `insert`, `left`, `up`, `right`, `down`, `pageUp`, `pageDown`,
+  `printScreen`, `meta`, `cmd` (OSX only), `command` (OSX only), `option`
+  (OSX only)
 
 For mouse events, the `event` object also have following properties:
 


### PR DESCRIPTION
Adds some additional special key codes to be recognized for OSX and Windows.

On OSX, using `sendInputEvent`, the passed `NativeWebKeyboardEvent` object didn't have the `os_event` object, so the `Edit` menu's key combinations didn't work, e.g. `cmd+c`. Using the `webContents` object's methods this pull request executes these functions, when needed.