### PR TITLE
Update quick-start.md

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -72,7 +72,7 @@ like this:
 ```
 
 __Note__: If the `main` field is not present in `package.json`, Electron will
-attempt to load an `index.js`.
+fail with an error saying `SyntaxError: Unexpected token`.
 
 The `main.js` should create windows and handle system events, a typical
 example being:


### PR DESCRIPTION
The note about defaulting to index.js is incorrect. Electron 0.36.7 gives a syntax error and halts.