### PR TITLE
Add ability to specify v8 flags in package.json

### DIFF
--- a/atom/browser/lib/init.js
+++ b/atom/browser/lib/init.js
@@ -132,9 +132,9 @@ if (packageJson.desktopName != null) {
 // Chrome 42 disables NPAPI plugins by default, reenable them here
 app.commandLine.appendSwitch('enable-npapi');
 
-// Add othercommand line switches
+// Add other command line switches
 if (packageJson.commandLineSwitches) {
-  for (let i = 0; i < packageJson.commandLineSwitches.length; ++i) {
+  for (let i = 0; i < packageJson.commandLineSwitches.length; i++) {
     const option = packageJson.commandLineSwitches[i];
 
     if (typeof option === 'string') {

--- a/atom/browser/lib/init.js
+++ b/atom/browser/lib/init.js
@@ -132,6 +132,19 @@ if (packageJson.desktopName != null) {
 // Chrome 42 disables NPAPI plugins by default, reenable them here
 app.commandLine.appendSwitch('enable-npapi');
 
+// Add othercommand line switches
+if (packageJson.commandLineSwitches) {
+  for (let i = 0; i < packageJson.commandLineSwitches.length; ++i) {
+    const option = packageJson.commandLineSwitches[i];
+
+    if (typeof option === 'string') {
+      app.commandLine.appendSwitch(option);
+    } else {
+      app.commandLine.appendSwitch(option[0], option[1]);
+    }
+  }
+}
+
 // Set the user path according to application's name.
 app.setPath('userData', path.join(app.getPath('appData'), app.getName()));
 

--- a/atom/browser/lib/init.js
+++ b/atom/browser/lib/init.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const util = require('util');
 const Module = require('module');
+const v8 = require('v8');
 
 var slice = [].slice;
 
@@ -129,21 +130,13 @@ if (packageJson.desktopName != null) {
   app.setDesktopName((app.getName()) + ".desktop");
 }
 
+// Set v8 flags
+if (packageJson.v8Flags != null) {
+  v8.setFlagsFromString(packageJson.v8Flags);
+}
+
 // Chrome 42 disables NPAPI plugins by default, reenable them here
 app.commandLine.appendSwitch('enable-npapi');
-
-// Add other command line switches
-if (packageJson.commandLineSwitches) {
-  for (let i = 0; i < packageJson.commandLineSwitches.length; i++) {
-    const option = packageJson.commandLineSwitches[i];
-
-    if (typeof option === 'string') {
-      app.commandLine.appendSwitch(option);
-    } else {
-      app.commandLine.appendSwitch(option[0], option[1]);
-    }
-  }
-}
 
 // Set the user path according to application's name.
 app.setPath('userData', path.join(app.getPath('appData'), app.getName()));


### PR DESCRIPTION
Advantages:
- Automates `app.commandLine.appendSwitch(...)` calls using `package.json`.
- Allows Electron to be packaged so that it can be opened cross-platform with command line switches without resorting to PLIST/Manifest "hacks".

How to use:
```json
{
  "name": "your-app",
  "version": "0.1.0",
  "main": "main.js",
  "commandLineSwitches": [
    "ignore-certificate-errors", ["js-flags", "--expose_gc"]
  ]
}
```