### PR TITLE
browser: handle desktop capture devices in media permission request

### DIFF
--- a/atom/browser/web_contents_permission_helper.cc
+++ b/atom/browser/web_contents_permission_helper.cc
@@ -23,7 +23,7 @@ void MediaAccessAllowed(
     bool allowed) {
   brightray::MediaStreamDevicesController controller(request, callback);
   if (allowed)
-    controller.Accept();
+    controller.TakeAction();
   else
     controller.Deny(content::MEDIA_DEVICE_PERMISSION_DENIED);
 }


### PR DESCRIPTION
A regression introduced in https://github.com/atom/electron/pull/4223, when media access permission is allowed previously it didnt iterate over device for (DESKTOP|TAB)CAPTURE.  This fixes it.