### PR TITLE
Added node and npm to prerequisites for Ubuntu

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -19,7 +19,14 @@ On Ubuntu, install the following libraries:
 $ sudo apt-get install build-essential clang libdbus-1-dev libgtk2.0-dev \
                        libnotify-dev libgnome-keyring-dev libgconf2-dev \
                        libasound2-dev libcap-dev libcups2-dev libxtst-dev \
-                       libxss1 libnss3-dev gcc-multilib g++-multilib
+                       libxss1 libnss3-dev gcc-multilib g++-multilib npm
+```
+
+On Ubuntu the node command is called nodejs so make a symlink:
+
+```bash
+cd /usr/bin
+sudo ln -s nodejs node
 ```
 
 On Fedora, install the following libraries:


### PR DESCRIPTION
On a clean Ubuntu 14.04 the bootstrap script fails because npm and node are both missing.