### PR TITLE
makeSingleInstance clarification

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -398,7 +398,7 @@ quit.
 On OS X the system enforces single instance automatically when users try to open
 a second instance of your app in Finder, and the `open-file` and `open-url`
 events will be emitted for that. However when users start your app in command
-line the system's single instance machanism will be bypassed and you have to
+line the system's single instance mechanism will be bypassed and you have to
 use this method to ensure single instance.
 
 An example of activating the window of primary instance when a second instance
@@ -413,7 +413,6 @@ var shouldQuit = app.makeSingleInstance(function(commandLine, workingDirectory) 
     if (myWindow.isMinimized()) myWindow.restore();
     myWindow.focus();
   }
-  return true;
 });
 
 if (shouldQuit) {


### PR DESCRIPTION
Removed callback return value from the sample code for makeSingleInstance because it appears to not be used for anything.