### PR TITLE
fix dependencies badge  which shows out of date

### DIFF
--- a/atom/browser/lib/rpc-server.js
+++ b/atom/browser/lib/rpc-server.js
@@ -130,7 +130,7 @@ var unwrapArgs = function(sender, args) {
         return Promise.resolve({
           then: metaToValue(meta.then)
         });
-      case 'object':
+      case 'object': {
         let ret = v8Util.createObjectWithName(meta.name);
         ref = meta.members;
         for (i = 0, len = ref.length; i < len; i++) {
@@ -138,12 +138,13 @@ var unwrapArgs = function(sender, args) {
           ret[member.name] = metaToValue(member.value);
         }
         return ret;
+      }
       case 'function-with-return-value':
         returnValue = metaToValue(meta.value);
         return function() {
           return returnValue;
         };
-      case 'function':
+      case 'function': {
         // Cache the callbacks in renderer.
         if (!sender.callbacks) {
           sender.callbacks = new IDWeakMap;
@@ -172,6 +173,7 @@ var unwrapArgs = function(sender, args) {
         });
         sender.callbacks.set(meta.id, callIntoRenderer);
         return callIntoRenderer;
+      }
       default:
         throw new TypeError("Unknown type: " + meta.type);
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.36.7",
   "devDependencies": {
     "asar": "^0.9.0",
-    "eslint": "^1.10.3",
+    "eslint": "^2.1.0",
     "request": "*"
   },
   "optionalDependencies": {

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -517,7 +517,6 @@ describe('asar package', function() {
       });
     });
     describe('child_process.fork', function() {
-      child_process = require('child_process');
       it('opens a normal js file', function(done) {
         var child;
         child = child_process.fork(path.join(fixtures, 'asar', 'a.asar', 'ping.js'));

--- a/spec/fixtures/api/quit-app/main.js
+++ b/spec/fixtures/api/quit-app/main.js
@@ -1,12 +1,12 @@
-var app = require('electron').app
+var app = require('electron').app;
 
 app.on('ready', function () {
   // This setImmediate call gets the spec passing on Linux
   setImmediate(function () {
-    app.exit(123)
-  })
-})
+    app.exit(123);
+  });
+});
 
 process.on('exit', function (code) {
-  console.log('Exit event with code: ' + code)
-})
+  console.log('Exit event with code: ' + code);
+});

--- a/spec/fixtures/module/call.js
+++ b/spec/fixtures/module/call.js
@@ -1,7 +1,7 @@
 exports.call = function(func) {
   return func();
-}
+};
 
 exports.constructor = function() {
   this.test = 'test';
-}
+};

--- a/spec/fixtures/module/id.js
+++ b/spec/fixtures/module/id.js
@@ -1,1 +1,1 @@
-exports.id = 1127
+exports.id = 1127;

--- a/spec/fixtures/module/locale-compare.js
+++ b/spec/fixtures/module/locale-compare.js
@@ -1,4 +1,4 @@
-process.on('message', function (msg) {
+process.on('message', function () {
   process.send([
     'a'.localeCompare('a'),
     'ä'.localeCompare('z', 'de'),

--- a/spec/fixtures/module/original-fs.js
+++ b/spec/fixtures/module/original-fs.js
@@ -1,3 +1,3 @@
-process.on('message', function (msg) {
+process.on('message', function () {
   process.send(typeof require('original-fs'));
 });

--- a/spec/fixtures/module/print_name.js
+++ b/spec/fixtures/module/print_name.js
@@ -1,7 +1,7 @@
 exports.print = function(obj) {
   return obj.constructor.name;
-}
+};
 
 exports.echo = function(obj) {
   return obj;
-}
+};

--- a/spec/fixtures/module/promise.js
+++ b/spec/fixtures/module/promise.js
@@ -2,4 +2,4 @@ exports.twicePromise = function (promise) {
   return promise.then(function (value) {
     return value * 2;
   });
-}
+};

--- a/spec/fixtures/module/property.js
+++ b/spec/fixtures/module/property.js
@@ -1,1 +1,1 @@
-exports.property = 1127
+exports.property = 1127;

--- a/spec/fixtures/module/send-later.js
+++ b/spec/fixtures/module/send-later.js
@@ -1,4 +1,4 @@
 var ipcRenderer = require('electron').ipcRenderer;
 window.onload = function() {
   ipcRenderer.send('answer', typeof window.process);
-}
+};

--- a/spec/fixtures/module/set-immediate.js
+++ b/spec/fixtures/module/set-immediate.js
@@ -3,7 +3,7 @@ process.on('uncaughtException', function(error) {
   process.exit(1);
 });
 
-process.on('message', function(msg) {
+process.on('message', function() {
   setImmediate(function() {
     process.send('ok');
     process.exit(0);

--- a/spec/fixtures/workers/shared_worker.js
+++ b/spec/fixtures/workers/shared_worker.js
@@ -1,7 +1,7 @@
-onconnect = function(event) {
+this.onconnect = function(event) {
   var port = event.ports[0];
   port.start();
   port.onmessage = function(event) {
     port.postMessage(event.data);
-  }
-}
+  };
+};

--- a/spec/fixtures/workers/worker.js
+++ b/spec/fixtures/workers/worker.js
@@ -1,3 +1,3 @@
 this.onmessage = function(msg) {
   this.postMessage(msg.data);
-}
+};

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -74,7 +74,7 @@ app.on('ready', function() {
 
   // Send auto updater errors to window to be verified in specs
   electron.autoUpdater.on('error', function (error) {
-    window.send('auto-updater-error', error.message)
+    window.send('auto-updater-error', error.message);
   });
 
   window = new BrowserWindow({
@@ -108,7 +108,7 @@ app.on('ready', function() {
   // reply the result to renderer for verifying
   var downloadFilePath = path.join(__dirname, '..', 'fixtures', 'mock.pdf');
   ipcMain.on('set-download-option', function(event, need_cancel, prevent_default) {
-    window.webContents.session.once('will-download', function(e, item, webContents) {
+    window.webContents.session.once('will-download', function(e, item) {
       if (prevent_default) {
         e.preventDefault();
         const url = item.getURL();


### PR DESCRIPTION
The dependancies badge looks out of date on the main page, only `eslint` was out of date so I took a look to see if I could update it.

<img width="1004" alt="screen shot 2016-02-15 at 10 32 45 pm" src="https://cloud.githubusercontent.com/assets/196199/13066458/1439e23a-d434-11e5-85cd-8d6941c3120b.png">


<img width="965" alt="screen shot 2016-02-15 at 9 11 47 pm" src="https://cloud.githubusercontent.com/assets/196199/13066415/9c905e58-d433-11e5-944e-930749671471.png">


- [x] Verified migration doc (nothing to be done) http://eslint.org/docs/user-guide/migrating-to-2.0.0
- [x] fixed the eslint errors