### PR TITLE
Add API for custom handling of deprecations

### DIFF
--- a/atom/common/api/lib/deprecate.js
+++ b/atom/common/api/lib/deprecate.js
@@ -88,9 +88,13 @@ deprecate.warn = function(oldName, newName) {
   return deprecate.log(oldName + " is deprecated. Use " + newName + " instead.");
 };
 
+var deprecationHandler = null;
+
 // Print deprecation message.
 deprecate.log = function(message) {
-  if (process.throwDeprecation) {
+  if (typeof deprecationHandler === 'function') {
+    deprecationHandler(message);
+  } else if (process.throwDeprecation) {
     throw new Error(message);
   } else if (process.traceDeprecation) {
     return console.trace(message);
@@ -98,5 +102,13 @@ deprecate.log = function(message) {
     return console.warn("(electron) " + message);
   }
 };
+
+deprecate.setHandler = function(handler) {
+  deprecationHandler = handler;
+};
+
+deprecate.getHandler = function() {
+  return deprecationHandler;
+}
 
 module.exports = deprecate;

--- a/atom/common/api/lib/deprecate.js
+++ b/atom/common/api/lib/deprecate.js
@@ -109,6 +109,6 @@ deprecate.setHandler = function(handler) {
 
 deprecate.getHandler = function() {
   return deprecationHandler;
-}
+};
 
 module.exports = deprecate;

--- a/atom/common/api/lib/deprecations.js
+++ b/atom/common/api/lib/deprecations.js
@@ -8,4 +8,4 @@ exports.setHandler = function (deprecationHandler) {
 
 exports.getHandler = function () {
   return deprecate.getHandler();
-}
+};

--- a/atom/common/api/lib/deprecations.js
+++ b/atom/common/api/lib/deprecations.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const deprecate = require('electron').deprecate;
+
+exports.setHandler = function (deprecationHandler) {
+  deprecate.setHandler(deprecationHandler);
+};
+
+exports.getHandler = function () {
+  return deprecate.getHandler();
+}

--- a/atom/common/api/lib/exports/electron.js
+++ b/atom/common/api/lib/exports/electron.js
@@ -31,6 +31,12 @@ exports.defineProperties = function(exports) {
         return require('../crash-reporter');
       }
     },
+    deprecations: {
+      enumerable: true,
+      get: function() {
+        return require('../deprecations');
+      }
+    },
     nativeImage: {
       enumerable: true,
       get: function() {

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -41,6 +41,7 @@
       'atom/common/api/lib/clipboard.js',
       'atom/common/api/lib/crash-reporter.js',
       'atom/common/api/lib/deprecate.js',
+      'atom/common/api/lib/deprecations.js',
       'atom/common/api/lib/exports/electron.js',
       'atom/common/api/lib/native-image.js',
       'atom/common/api/lib/shell.js',

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const deprecations = require('electron').deprecations;
+
+describe('deprecations', function() {
+  beforeEach(function() {
+    deprecations.setHandler(null);
+    process.throwDeprecation = true;
+  });
+
+  it('allows a deprecation handler function to be specified', function() {
+    var messages = [];
+
+    deprecations.setHandler(function (message) {
+      messages.push(message)
+    });
+
+    require('electron').webFrame.registerUrlSchemeAsSecure('some-scheme')
+
+    assert.deepEqual(messages, ['registerUrlSchemeAsSecure is deprecated. Use registerURLSchemeAsSecure instead.']);
+  });
+
+  it('throws an exception if no deprecation handler is specified', function() {
+    assert.throws(function() {
+      require('electron').webFrame.registerUrlSchemeAsPrivileged('some-scheme')
+    }, "registerUrlSchemeAsPrivileged is deprecated. Use registerURLSchemeAsPrivileged instead.");
+  });
+})

--- a/spec/api-deprecations-spec.js
+++ b/spec/api-deprecations-spec.js
@@ -11,17 +11,17 @@ describe('deprecations', function() {
     var messages = [];
 
     deprecations.setHandler(function (message) {
-      messages.push(message)
+      messages.push(message);
     });
 
-    require('electron').webFrame.registerUrlSchemeAsSecure('some-scheme')
+    require('electron').webFrame.registerUrlSchemeAsSecure('some-scheme');
 
     assert.deepEqual(messages, ['registerUrlSchemeAsSecure is deprecated. Use registerURLSchemeAsSecure instead.']);
   });
 
   it('throws an exception if no deprecation handler is specified', function() {
     assert.throws(function() {
-      require('electron').webFrame.registerUrlSchemeAsPrivileged('some-scheme')
+      require('electron').webFrame.registerUrlSchemeAsPrivileged('some-scheme');
     }, "registerUrlSchemeAsPrivileged is deprecated. Use registerURLSchemeAsPrivileged instead.");
   });
-})
+});


### PR DESCRIPTION
Refs https://github.com/atom/atom/pull/9627

In Atom, we'd like to show electron deprecations in the [Deprecation Cop](https://github.com/atom/deprecation-cop) view. This PR adds the following APIs:

```js
const deprecations = require('electron').deprecations;
deprecations.setHandler(myHandler);
assert(deprecations.getHandler() === myHandler);
```

I noticed that there was already a non-enumerable `deprecate` module, used internally by the other modules. I added `deprecations` as a separate module in order to keep the private and internal APIs separate.

/cc @zcbenz @jlord @kevinsawicki