### PR TITLE
Clean up specs post CoffeeScript conversion

### DIFF
--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -66,11 +66,10 @@ describe('app module', function() {
     });
 
     it('emits a process exit event with the code', function(done) {
-      var appPath, electronPath, output;
-      appPath = path.join(__dirname, 'fixtures', 'api', 'quit-app');
-      electronPath = remote.getGlobal('process').execPath;
+      var appPath = path.join(__dirname, 'fixtures', 'api', 'quit-app');
+      var electronPath = remote.getGlobal('process').execPath;
+      var output = '';
       appProcess = ChildProcess.spawn(electronPath, [appPath]);
-      output = '';
       appProcess.stdout.on('data', function(data) {
         output += data;
       });

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -23,38 +23,38 @@ describe('electron module', function() {
 
 describe('app module', function() {
   describe('app.getVersion()', function() {
-    return it('returns the version field of package.json', function() {
-      return assert.equal(app.getVersion(), '0.1.0');
+    it('returns the version field of package.json', function() {
+      assert.equal(app.getVersion(), '0.1.0');
     });
   });
 
   describe('app.setVersion(version)', function() {
-    return it('overrides the version', function() {
+    it('overrides the version', function() {
       assert.equal(app.getVersion(), '0.1.0');
       app.setVersion('test-version');
       assert.equal(app.getVersion(), 'test-version');
-      return app.setVersion('0.1.0');
+      app.setVersion('0.1.0');
     });
   });
 
   describe('app.getName()', function() {
-    return it('returns the name field of package.json', function() {
-      return assert.equal(app.getName(), 'Electron Test');
+    it('returns the name field of package.json', function() {
+      assert.equal(app.getName(), 'Electron Test');
     });
   });
 
   describe('app.setName(name)', function() {
-    return it('overrides the name', function() {
+    it('overrides the name', function() {
       assert.equal(app.getName(), 'Electron Test');
       app.setName('test-name');
       assert.equal(app.getName(), 'test-name');
-      return app.setName('Electron Test');
+      app.setName('Electron Test');
     });
   });
 
   describe('app.getLocale()', function() {
-    return it('should not be empty', function() {
-      return assert.notEqual(app.getLocale(), '');
+    it('should not be empty', function() {
+      assert.notEqual(app.getLocale(), '');
     });
   });
 
@@ -62,71 +62,71 @@ describe('app module', function() {
     var appProcess = null;
 
     afterEach(function() {
-      return appProcess != null ? appProcess.kill() : void 0;
+      appProcess != null ? appProcess.kill() : void 0;
     });
 
-    return it('emits a process exit event with the code', function(done) {
+    it('emits a process exit event with the code', function(done) {
       var appPath, electronPath, output;
       appPath = path.join(__dirname, 'fixtures', 'api', 'quit-app');
       electronPath = remote.getGlobal('process').execPath;
       appProcess = ChildProcess.spawn(electronPath, [appPath]);
       output = '';
       appProcess.stdout.on('data', function(data) {
-        return output += data;
+        output += data;
       });
-      return appProcess.on('close', function(code) {
+      appProcess.on('close', function(code) {
         if (process.platform !== 'win32') {
           assert.notEqual(output.indexOf('Exit event with code: 123'), -1);
         }
         assert.equal(code, 123);
-        return done();
+        done();
       });
     });
   });
 
-  return describe('BrowserWindow events', function() {
+  describe('BrowserWindow events', function() {
     var w = null;
 
     afterEach(function() {
       if (w != null) {
         w.destroy();
       }
-      return w = null;
+      w = null;
     });
 
     it('should emit browser-window-focus event when window is focused', function(done) {
       app.once('browser-window-focus', function(e, window) {
         assert.equal(w.id, window.id);
-        return done();
+        done();
       });
       w = new BrowserWindow({
         show: false
       });
-      return w.emit('focus');
+      w.emit('focus');
     });
 
     it('should emit browser-window-blur event when window is blured', function(done) {
       app.once('browser-window-blur', function(e, window) {
         assert.equal(w.id, window.id);
-        return done();
+        done();
       });
       w = new BrowserWindow({
         show: false
       });
-      return w.emit('blur');
+      w.emit('blur');
     });
 
-    return it('should emit browser-window-created event when window is created', function(done) {
+    it('should emit browser-window-created event when window is created', function(done) {
       app.once('browser-window-created', function(e, window) {
-        return setImmediate(function() {
+        setImmediate(function() {
           assert.equal(w.id, window.id);
-          return done();
+          done();
         });
       });
       w = new BrowserWindow({
         show: false
       });
-      return w.emit('blur');
+      w.emit('blur');
     });
   });
 });

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -27,6 +27,7 @@ describe('app module', function() {
       return assert.equal(app.getVersion(), '0.1.0');
     });
   });
+
   describe('app.setVersion(version)', function() {
     return it('overrides the version', function() {
       assert.equal(app.getVersion(), '0.1.0');
@@ -35,11 +36,13 @@ describe('app module', function() {
       return app.setVersion('0.1.0');
     });
   });
+
   describe('app.getName()', function() {
     return it('returns the name field of package.json', function() {
       return assert.equal(app.getName(), 'Electron Test');
     });
   });
+
   describe('app.setName(name)', function() {
     return it('overrides the name', function() {
       assert.equal(app.getName(), 'Electron Test');
@@ -48,17 +51,20 @@ describe('app module', function() {
       return app.setName('Electron Test');
     });
   });
+
   describe('app.getLocale()', function() {
     return it('should not be empty', function() {
       return assert.notEqual(app.getLocale(), '');
     });
   });
+
   describe('app.exit(exitCode)', function() {
-    var appProcess;
-    appProcess = null;
+    var appProcess = null;
+
     afterEach(function() {
       return appProcess != null ? appProcess.kill() : void 0;
     });
+
     return it('emits a process exit event with the code', function(done) {
       var appPath, electronPath, output;
       appPath = path.join(__dirname, 'fixtures', 'api', 'quit-app');
@@ -77,15 +83,17 @@ describe('app module', function() {
       });
     });
   });
+
   return describe('BrowserWindow events', function() {
-    var w;
-    w = null;
+    var w = null;
+
     afterEach(function() {
       if (w != null) {
         w.destroy();
       }
       return w = null;
     });
+
     it('should emit browser-window-focus event when window is focused', function(done) {
       app.once('browser-window-focus', function(e, window) {
         assert.equal(w.id, window.id);
@@ -96,6 +104,7 @@ describe('app module', function() {
       });
       return w.emit('focus');
     });
+
     it('should emit browser-window-blur event when window is blured', function(done) {
       app.once('browser-window-blur', function(e, window) {
         assert.equal(w.id, window.id);
@@ -106,6 +115,7 @@ describe('app module', function() {
       });
       return w.emit('blur');
     });
+
     return it('should emit browser-window-created event when window is created', function(done) {
       app.once('browser-window-created', function(e, window) {
         return setImmediate(function() {

--- a/spec/api-app-spec.js
+++ b/spec/api-app-spec.js
@@ -1,14 +1,10 @@
-var BrowserWindow, ChildProcess, app, assert, path, ref, remote;
+const assert = require('assert');
+const ChildProcess = require('child_process');
+const path = require('path');
+const remote = require('electron').remote;
 
-assert = require('assert');
-
-ChildProcess = require('child_process');
-
-path = require('path');
-
-remote = require('electron').remote;
-
-ref = remote.require('electron'), app = ref.app, BrowserWindow = ref.BrowserWindow;
+const app = remote.require('electron').app;
+const BrowserWindow = remote.require('electron').BrowserWindow;
 
 describe('electron module', function() {
   it ('can prevent exposing internal modules to require', function(done) {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -42,9 +42,8 @@ describe('browser-window module', function() {
         w.close();
       });
       w.on('closed', function() {
-        var content, test;
-        test = path.join(fixtures, 'api', 'unload');
-        content = fs.readFileSync(test);
+        var test = path.join(fixtures, 'api', 'unload');
+        var content = fs.readFileSync(test);
         fs.unlinkSync(test);
         assert.equal(String(content), 'unload');
         done();
@@ -66,9 +65,8 @@ describe('browser-window module', function() {
   describe('window.close()', function() {
     it('should emit unload handler', function(done) {
       w.on('closed', function() {
-        var content, test;
-        test = path.join(fixtures, 'api', 'close');
-        content = fs.readFileSync(test);
+        var test = path.join(fixtures, 'api', 'close');
+        var content = fs.readFileSync(test);
         fs.unlinkSync(test);
         assert.equal(String(content), 'close');
         done();
@@ -86,8 +84,7 @@ describe('browser-window module', function() {
 
   describe('BrowserWindow.destroy()', function() {
     it('prevents users to access methods of webContents', function() {
-      var webContents;
-      webContents = w.webContents;
+      var webContents = w.webContents;
       w.destroy();
       assert.throws((function() {
         webContents.getId();
@@ -178,8 +175,7 @@ describe('browser-window module', function() {
     it('sets the window position', function(done) {
       var pos = [10, 10];
       w.once('move', function() {
-        var newPos;
-        newPos = w.getPosition();
+        var newPos = w.getPosition();
         assert.equal(newPos[0], pos[0]);
         assert.equal(newPos[1], pos[1]);
         done();
@@ -190,16 +186,14 @@ describe('browser-window module', function() {
 
   describe('BrowserWindow.setContentSize(width, height)', function() {
     it('sets the content size', function() {
-      var after, size;
-      size = [400, 400];
+      var size = [400, 400];
       w.setContentSize(size[0], size[1]);
-      after = w.getContentSize();
+      var after = w.getContentSize();
       assert.equal(after[0], size[0]);
       assert.equal(after[1], size[1]);
     });
 
     it('works for framless window', function() {
-      var after, size;
       w.destroy();
       w = new BrowserWindow({
         show: false,
@@ -207,9 +201,9 @@ describe('browser-window module', function() {
         width: 400,
         height: 400
       });
-      size = [400, 400];
+      var size = [400, 400];
       w.setContentSize(size[0], size[1]);
-      after = w.getContentSize();
+      var after = w.getContentSize();
       assert.equal(after[0], size[0]);
       assert.equal(after[1], size[1]);
     });
@@ -223,7 +217,6 @@ describe('browser-window module', function() {
 
   describe('"useContentSize" option', function() {
     it('make window created with content size when used', function() {
-      var contentSize;
       w.destroy();
       w = new BrowserWindow({
         show: false,
@@ -231,7 +224,7 @@ describe('browser-window module', function() {
         height: 400,
         useContentSize: true
       });
-      contentSize = w.getContentSize();
+      var contentSize = w.getContentSize();
       assert.equal(contentSize[0], 400);
       assert.equal(contentSize[1], 400);
     });
@@ -243,7 +236,6 @@ describe('browser-window module', function() {
     });
 
     it('works for framless window', function() {
-      var contentSize, size;
       w.destroy();
       w = new BrowserWindow({
         show: false,
@@ -252,10 +244,10 @@ describe('browser-window module', function() {
         height: 400,
         useContentSize: true
       });
-      contentSize = w.getContentSize();
+      var contentSize = w.getContentSize();
       assert.equal(contentSize[0], 400);
       assert.equal(contentSize[1], 400);
-      size = w.getSize();
+      var size = w.getSize();
       assert.equal(size[0], 400);
       assert.equal(size[1], 400);
     });
@@ -270,7 +262,6 @@ describe('browser-window module', function() {
     }
 
     it('creates browser window with hidden title bar', function() {
-      var contentSize;
       w.destroy();
       w = new BrowserWindow({
         show: false,
@@ -278,12 +269,11 @@ describe('browser-window module', function() {
         height: 400,
         titleBarStyle: 'hidden'
       });
-      contentSize = w.getContentSize();
+      var contentSize = w.getContentSize();
       assert.equal(contentSize[1], 400);
     });
 
     it('creates browser window with hidden inset title bar', function() {
-      var contentSize;
       w.destroy();
       w = new BrowserWindow({
         show: false,
@@ -291,7 +281,7 @@ describe('browser-window module', function() {
         height: 400,
         titleBarStyle: 'hidden-inset'
       });
-      contentSize = w.getContentSize();
+      var contentSize = w.getContentSize();
       assert.equal(contentSize[1], 400);
     });
   });
@@ -312,20 +302,18 @@ describe('browser-window module', function() {
     });
 
     it('can move the window out of screen', function() {
-      var after;
       w.setPosition(-10, -10);
-      after = w.getPosition();
+      var after = w.getPosition();
       assert.equal(after[0], -10);
       assert.equal(after[1], -10);
     });
 
     it('can set the window larger than screen', function() {
-      var after, size;
-      size = screen.getPrimaryDisplay().size;
+      var size = screen.getPrimaryDisplay().size;
       size.width += 100;
       size.height += 100;
       w.setSize(size.width, size.height);
-      after = w.getSize();
+      var after = w.getSize();
       assert.equal(after[0], size.width);
       assert.equal(after[1], size.height);
     });
@@ -338,8 +326,7 @@ describe('browser-window module', function() {
 
     describe('"preload" option', function() {
       it('loads the script before other scripts in window', function(done) {
-        var preload;
-        preload = path.join(fixtures, 'module', 'set-global.js');
+        var preload = path.join(fixtures, 'module', 'set-global.js');
         ipcMain.once('answer', function(event, test) {
           assert.equal(test, 'preload');
           done();
@@ -357,8 +344,7 @@ describe('browser-window module', function() {
 
     describe('"node-integration" option', function() {
       it('disables node integration when specified to false', function(done) {
-        var preload;
-        preload = path.join(fixtures, 'module', 'send-later.js');
+        var preload = path.join(fixtures, 'module', 'send-later.js');
         ipcMain.once('answer', function(event, test) {
           assert.equal(test, 'undefined');
           done();
@@ -532,10 +518,9 @@ describe('browser-window module', function() {
 
   describe('BrowserWindow options argument is optional', function() {
     it('should create a window with default size (800x600)', function() {
-      var size;
       w.destroy();
       w = new BrowserWindow();
-      size = w.getSize();
+      var size = w.getSize();
       assert.equal(size[0], 800);
       assert.equal(size[1], 600);
     });

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -8,50 +8,46 @@ describe('clipboard module', function() {
   var fixtures = path.resolve(__dirname, 'fixtures');
 
   describe('clipboard.readImage()', function() {
-    return it('returns NativeImage intance', function() {
-      var i, p;
-      p = path.join(fixtures, 'assets', 'logo.png');
-      i = nativeImage.createFromPath(p);
+    it('returns NativeImage intance', function() {
+      var p = path.join(fixtures, 'assets', 'logo.png');
+      var i = nativeImage.createFromPath(p);
       clipboard.writeImage(p);
-      return assert.equal(clipboard.readImage().toDataURL(), i.toDataURL());
+      assert.equal(clipboard.readImage().toDataURL(), i.toDataURL());
     });
   });
 
   describe('clipboard.readText()', function() {
-    return it('returns unicode string correctly', function() {
-      var text;
-      text = '千江有水千江月，万里无云万里天';
+    it('returns unicode string correctly', function() {
+      var text = '千江有水千江月，万里无云万里天';
       clipboard.writeText(text);
-      return assert.equal(clipboard.readText(), text);
+      assert.equal(clipboard.readText(), text);
     });
   });
 
   describe('clipboard.readHtml()', function() {
-    return it('returns markup correctly', function() {
-      var markup, text;
-      text = '<string>Hi</string>';
-      markup = process.platform === 'darwin' ? '<meta charset=\'utf-8\'><string>Hi</string>' : process.platform === 'linux' ? '<meta http-equiv="content-type" ' + 'content="text/html; charset=utf-8"><string>Hi</string>' : '<string>Hi</string>';
+    it('returns markup correctly', function() {
+      var text = '<string>Hi</string>';
+      var markup = process.platform === 'darwin' ? '<meta charset=\'utf-8\'><string>Hi</string>' : process.platform === 'linux' ? '<meta http-equiv="content-type" ' + 'content="text/html; charset=utf-8"><string>Hi</string>' : '<string>Hi</string>';
       clipboard.writeHtml(text);
-      return assert.equal(clipboard.readHtml(), markup);
+      assert.equal(clipboard.readHtml(), markup);
     });
   });
 
   describe('clipboard.readRtf', function() {
-    return it('returns rtf text correctly', function() {
+    it('returns rtf text correctly', function() {
       var rtf = "{\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\pard\nThis is some {\\b bold} text.\\par\n}";
       clipboard.writeRtf(rtf);
-      return assert.equal(clipboard.readRtf(), rtf);
+      assert.equal(clipboard.readRtf(), rtf);
     });
   });
 
-  return describe('clipboard.write()', function() {
-    return it('returns data correctly', function() {
-      var i, markup, p, text, rtf;
-      text = 'test';
-      rtf = '{\\rtf1\\utf8 text}';
-      p = path.join(fixtures, 'assets', 'logo.png');
-      i = nativeImage.createFromPath(p);
-      markup = process.platform === 'darwin' ? '<meta charset=\'utf-8\'><b>Hi</b>' : process.platform === 'linux' ? '<meta http-equiv="content-type" ' + 'content="text/html; charset=utf-8"><b>Hi</b>' : '<b>Hi</b>';
+  describe('clipboard.write()', function() {
+    it('returns data correctly', function() {
+      var text = 'test';
+      var rtf = '{\\rtf1\\utf8 text}';
+      var p = path.join(fixtures, 'assets', 'logo.png');
+      var i = nativeImage.createFromPath(p);
+      var markup = process.platform === 'darwin' ? '<meta charset=\'utf-8\'><b>Hi</b>' : process.platform === 'linux' ? '<meta http-equiv="content-type" ' + 'content="text/html; charset=utf-8"><b>Hi</b>' : '<b>Hi</b>';
       clipboard.write({
         text: "test",
         html: '<b>Hi</b>',
@@ -61,7 +57,7 @@ describe('clipboard module', function() {
       assert.equal(clipboard.readText(), text);
       assert.equal(clipboard.readHtml(), markup);
       assert.equal(clipboard.readRtf(), rtf);
-      return assert.equal(clipboard.readImage().toDataURL(), i.toDataURL());
+      assert.equal(clipboard.readImage().toDataURL(), i.toDataURL());
     });
   });
 });

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -5,8 +5,8 @@ const clipboard = require('electron').clipboard;
 const nativeImage = require('electron').nativeImage;
 
 describe('clipboard module', function() {
-  var fixtures;
-  fixtures = path.resolve(__dirname, 'fixtures');
+  var fixtures = path.resolve(__dirname, 'fixtures');
+
   describe('clipboard.readImage()', function() {
     return it('returns NativeImage intance', function() {
       var i, p;
@@ -16,6 +16,7 @@ describe('clipboard module', function() {
       return assert.equal(clipboard.readImage().toDataURL(), i.toDataURL());
     });
   });
+
   describe('clipboard.readText()', function() {
     return it('returns unicode string correctly', function() {
       var text;
@@ -24,6 +25,7 @@ describe('clipboard module', function() {
       return assert.equal(clipboard.readText(), text);
     });
   });
+
   describe('clipboard.readHtml()', function() {
     return it('returns markup correctly', function() {
       var markup, text;
@@ -33,6 +35,7 @@ describe('clipboard module', function() {
       return assert.equal(clipboard.readHtml(), markup);
     });
   });
+
   describe('clipboard.readRtf', function() {
     return it('returns rtf text correctly', function() {
       var rtf = "{\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\pard\nThis is some {\\b bold} text.\\par\n}";
@@ -40,6 +43,7 @@ describe('clipboard module', function() {
       return assert.equal(clipboard.readRtf(), rtf);
     });
   });
+
   return describe('clipboard.write()', function() {
     return it('returns data correctly', function() {
       var i, markup, p, text, rtf;

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -1,10 +1,8 @@
-var assert, clipboard, nativeImage, path, ref;
+const assert = require('assert');
+const path = require('path');
 
-assert = require('assert');
-
-path = require('path');
-
-ref = require('electron'), clipboard = ref.clipboard, nativeImage = ref.nativeImage;
+const clipboard = require('electron').clipboard;
+const nativeImage = require('electron').nativeImage;
 
 describe('clipboard module', function() {
   var fixtures;

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -1,18 +1,13 @@
-var BrowserWindow, app, assert, crashReporter, http, multiparty, path, ref, remote, url;
+const assert = require('assert');
+const http = require('http');
+const multiparty = require('multiparty');
+const path = require('path');
+const url = require('url');
 
-assert = require('assert');
-
-path = require('path');
-
-http = require('http');
-
-url = require('url');
-
-multiparty = require('multiparty');
-
-remote = require('electron').remote;
-
-ref = remote.require('electron'), app = ref.app, crashReporter = ref.crashReporter, BrowserWindow = ref.BrowserWindow;
+const remote = require('electron').remote;
+const app = remote.require('electron').app;
+const crashReporter = remote.require('electron').crashReporter;
+const BrowserWindow = remote.require('electron').BrowserWindow;
 
 describe('crash-reporter module', function() {
   var fixtures, isCI, w;
@@ -63,7 +58,7 @@ describe('crash-reporter module', function() {
     return server.listen(port, '127.0.0.1', function() {
       port = server.address().port;
       remote.process.port = port;
-      url = url.format({
+      const crashUrl = url.format({
         protocol: 'file',
         pathname: path.join(fixtures, 'api', 'crash.html'),
         search: "?port=" + port
@@ -74,7 +69,7 @@ describe('crash-reporter module', function() {
           submitURL: "http://127.0.0.1:" + port
         });
       }
-      return w.loadURL(url);
+      return w.loadURL(crashUrl);
     });
   });
   return describe(".start(options)", function() {

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -10,29 +10,33 @@ const crashReporter = remote.require('electron').crashReporter;
 const BrowserWindow = remote.require('electron').BrowserWindow;
 
 describe('crash-reporter module', function() {
-  var fixtures, isCI, w;
-  fixtures = path.resolve(__dirname, 'fixtures');
-  w = null;
+  var fixtures = path.resolve(__dirname, 'fixtures');
+  var w = null;
+
   beforeEach(function() {
     return w = new BrowserWindow({
       show: false
     });
   });
+
   afterEach(function() {
     return w.destroy();
   });
+
   if (process.mas) {
     return;
   }
-  isCI = remote.getGlobal('isCi');
+
+  var isCI = remote.getGlobal('isCi');
   if (isCI) {
     return;
   }
+
   it('should send minidump when renderer crashes', function(done) {
-    var called, port, server;
     this.timeout(120000);
-    called = false;
-    server = http.createServer(function(req, res) {
+
+    var called = false;
+    var server = http.createServer(function(req, res) {
       var form;
       server.close();
       form = new multiparty.Form();
@@ -54,7 +58,7 @@ describe('crash-reporter module', function() {
         return done();
       });
     });
-    port = remote.process.port;
+    var port = remote.process.port;
     return server.listen(port, '127.0.0.1', function() {
       port = server.address().port;
       remote.process.port = port;
@@ -72,6 +76,7 @@ describe('crash-reporter module', function() {
       return w.loadURL(crashUrl);
     });
   });
+
   return describe(".start(options)", function() {
     return it('requires that the companyName and submitURL options be specified', function() {
       assert.throws(function() {

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -14,13 +14,13 @@ describe('crash-reporter module', function() {
   var w = null;
 
   beforeEach(function() {
-    return w = new BrowserWindow({
+    w = new BrowserWindow({
       show: false
     });
   });
 
   afterEach(function() {
-    return w.destroy();
+    w.destroy();
   });
 
   if (process.mas) {
@@ -40,7 +40,7 @@ describe('crash-reporter module', function() {
       var form;
       server.close();
       form = new multiparty.Form();
-      return form.parse(req, function(error, fields) {
+      form.parse(req, function(error, fields) {
         if (called) {
           return;
         }
@@ -55,11 +55,11 @@ describe('crash-reporter module', function() {
         assert.equal(fields['_companyName'], 'Umbrella Corporation');
         assert.equal(fields['_version'], app.getVersion());
         res.end('abc-123-def');
-        return done();
+        done();
       });
     });
     var port = remote.process.port;
-    return server.listen(port, '127.0.0.1', function() {
+    server.listen(port, '127.0.0.1', function() {
       port = server.address().port;
       remote.process.port = port;
       const crashUrl = url.format({
@@ -73,19 +73,19 @@ describe('crash-reporter module', function() {
           submitURL: "http://127.0.0.1:" + port
         });
       }
-      return w.loadURL(crashUrl);
+      w.loadURL(crashUrl);
     });
   });
 
-  return describe(".start(options)", function() {
-    return it('requires that the companyName and submitURL options be specified', function() {
+  describe(".start(options)", function() {
+    it('requires that the companyName and submitURL options be specified', function() {
       assert.throws(function() {
-        return crashReporter.start({
+        crashReporter.start({
           companyName: 'Missing submitURL'
         });
       });
-      return assert.throws(function() {
-        return crashReporter.start({
+      assert.throws(function() {
+        crashReporter.start({
           submitURL: 'Missing companyName'
         });
       });

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -37,9 +37,8 @@ describe('crash-reporter module', function() {
 
     var called = false;
     var server = http.createServer(function(req, res) {
-      var form;
       server.close();
-      form = new multiparty.Form();
+      var form = new multiparty.Form();
       form.parse(req, function(error, fields) {
         if (called) {
           return;

--- a/spec/api-debugger-spec.js
+++ b/spec/api-debugger-spec.js
@@ -1,12 +1,6 @@
-var assert, path, remote, BrowserWindow;
-
-assert = require('assert');
-
-path = require('path');
-
-remote = require('electron').remote;
-
-BrowserWindow = remote.BrowserWindow;
+const assert = require('assert');
+const path = require('path');
+const BrowserWindow = require('electron').remote.BrowserWindow;
 
 describe('debugger module', function() {
   var fixtures, w;

--- a/spec/api-debugger-spec.js
+++ b/spec/api-debugger-spec.js
@@ -3,9 +3,9 @@ const path = require('path');
 const BrowserWindow = require('electron').remote.BrowserWindow;
 
 describe('debugger module', function() {
-  var fixtures, w;
-  fixtures = path.resolve(__dirname, 'fixtures');
-  w = null;
+  var fixtures = path.resolve(__dirname, 'fixtures');
+  var w = null;
+
   beforeEach(function() {
     if (w != null) {
       w.destroy();
@@ -16,6 +16,7 @@ describe('debugger module', function() {
       height: 400
     });
   });
+
   afterEach(function() {
     if (w != null) {
       w.destroy();

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -12,7 +12,7 @@ const comparePaths = function(path1, path2) {
     path1 = path1.toLowerCase();
     path2 = path2.toLowerCase();
   }
-  return assert.equal(path1, path2);
+  assert.equal(path1, path2);
 };
 
 describe('ipc module', function() {
@@ -23,27 +23,26 @@ describe('ipc module', function() {
       var dialog1, dialog2;
       dialog1 = remote.require('electron');
       dialog2 = remote.require('electron');
-      return assert.equal(dialog1, dialog2);
+      assert.equal(dialog1, dialog2);
     });
 
     it('should work when object contains id property', function() {
-      var a;
-      a = remote.require(path.join(fixtures, 'module', 'id.js'));
-      return assert.equal(a.id, 1127);
+      var a = remote.require(path.join(fixtures, 'module', 'id.js'));
+      assert.equal(a.id, 1127);
     });
 
-    return it('should search module from the user app', function() {
+    it('should search module from the user app', function() {
       comparePaths(path.normalize(remote.process.mainModule.filename), path.resolve(__dirname, 'static', 'main.js'));
-      return comparePaths(path.normalize(remote.process.mainModule.paths[0]), path.resolve(__dirname, 'static', 'node_modules'));
+      comparePaths(path.normalize(remote.process.mainModule.paths[0]), path.resolve(__dirname, 'static', 'node_modules'));
     });
   });
 
   describe('remote.createFunctionWithReturnValue', function() {
-    return it('should be called in browser synchronously', function() {
+    it('should be called in browser synchronously', function() {
       var buf = new Buffer('test');
       var call = remote.require(path.join(fixtures, 'module', 'call.js'));
       var result = call.call(remote.createFunctionWithReturnValue(buf));
-      return assert.equal(result.constructor.name, 'Buffer');
+      assert.equal(result.constructor.name, 'Buffer');
     });
   });
 
@@ -55,14 +54,14 @@ describe('ipc module', function() {
       assert.equal(property.property, 1007);
       var property2 = remote.require(path.join(fixtures, 'module', 'property.js'));
       assert.equal(property2.property, 1007);
-      return property.property = 1127;
+      property.property = 1127;
     });
 
-    return it('can construct an object from its member', function() {
+    it('can construct an object from its member', function() {
       var call, obj;
       call = remote.require(path.join(fixtures, 'module', 'call.js'));
       obj = new call.constructor;
-      return assert.equal(obj.test, 'test');
+      assert.equal(obj.test, 'test');
     });
   });
 
@@ -72,48 +71,48 @@ describe('ipc module', function() {
     it('keeps its constructor name for objects', function() {
       var buf = new Buffer('test');
       var print_name = remote.require(print);
-      return assert.equal(print_name.print(buf), 'Buffer');
+      assert.equal(print_name.print(buf), 'Buffer');
     });
 
-    return it('supports instanceof Date', function() {
+    it('supports instanceof Date', function() {
       var now = new Date();
       var print_name = remote.require(print);
       assert.equal(print_name.print(now), 'Date');
-      return assert.deepEqual(print_name.echo(now), now);
+      assert.deepEqual(print_name.echo(now), now);
     });
   });
 
   describe('remote promise', function() {
-    return it('can be used as promise in each side', function(done) {
+    it('can be used as promise in each side', function(done) {
       var promise = remote.require(path.join(fixtures, 'module', 'promise.js'));
-      return promise.twicePromise(Promise.resolve(1234)).then(function(value) {
+      promise.twicePromise(Promise.resolve(1234)).then(function(value) {
         assert.equal(value, 2468);
-        return done();
+        done();
       });
     });
   });
 
   describe('ipc.sender.send', function() {
-    return it('should work when sending an object containing id property', function(done) {
+    it('should work when sending an object containing id property', function(done) {
       var obj = {
         id: 1,
         name: 'ly'
       };
       ipcRenderer.once('message', function(event, message) {
         assert.deepEqual(message, obj);
-        return done();
+        done();
       });
-      return ipcRenderer.send('message', obj);
+      ipcRenderer.send('message', obj);
     });
   });
 
   describe('ipc.sendSync', function() {
     it('can be replied by setting event.returnValue', function() {
       var msg = ipcRenderer.sendSync('echo', 'test');
-      return assert.equal(msg, 'test');
+      assert.equal(msg, 'test');
     });
 
-    return it('does not crash when reply is not sent and browser is destroyed', function(done) {
+    it('does not crash when reply is not sent and browser is destroyed', function(done) {
       this.timeout(10000);
 
       var w = new BrowserWindow({
@@ -122,20 +121,20 @@ describe('ipc module', function() {
       ipcMain.once('send-sync-message', function(event) {
         event.returnValue = null;
         w.destroy();
-        return done();
+        done();
       });
-      return w.loadURL('file://' + path.join(fixtures, 'api', 'send-sync-message.html'));
+      w.loadURL('file://' + path.join(fixtures, 'api', 'send-sync-message.html'));
     });
   });
 
-  return describe('remote listeners', function() {
+  describe('remote listeners', function() {
     var w = null;
 
     afterEach(function() {
-      return w.destroy();
+      w.destroy();
     });
 
-    return it('can be added and removed correctly', function() {
+    it('can be added and removed correctly', function() {
       w = new BrowserWindow({
         show: false
       });
@@ -143,7 +142,7 @@ describe('ipc module', function() {
       w.on('test', listener);
       assert.equal(w.listenerCount('test'), 1);
       w.removeListener('test', listener);
-      return assert.equal(w.listenerCount('test'), 0);
+      assert.equal(w.listenerCount('test'), 0);
     });
   });
 });

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -20,9 +20,8 @@ describe('ipc module', function() {
 
   describe('remote.require', function() {
     it('should returns same object for the same module', function() {
-      var dialog1, dialog2;
-      dialog1 = remote.require('electron');
-      dialog2 = remote.require('electron');
+      var dialog1 = remote.require('electron');
+      var dialog2 = remote.require('electron');
       assert.equal(dialog1, dialog2);
     });
 
@@ -58,9 +57,8 @@ describe('ipc module', function() {
     });
 
     it('can construct an object from its member', function() {
-      var call, obj;
-      call = remote.require(path.join(fixtures, 'module', 'call.js'));
-      obj = new call.constructor;
+      var call = remote.require(path.join(fixtures, 'module', 'call.js'));
+      var obj = new call.constructor;
       assert.equal(obj.test, 'test');
     });
   });

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -16,8 +16,8 @@ const comparePaths = function(path1, path2) {
 };
 
 describe('ipc module', function() {
-  var fixtures;
-  fixtures = path.join(__dirname, 'fixtures');
+  var fixtures = path.join(__dirname, 'fixtures');
+
   describe('remote.require', function() {
     it('should returns same object for the same module', function() {
       var dialog1, dialog2;
@@ -25,36 +25,39 @@ describe('ipc module', function() {
       dialog2 = remote.require('electron');
       return assert.equal(dialog1, dialog2);
     });
+
     it('should work when object contains id property', function() {
       var a;
       a = remote.require(path.join(fixtures, 'module', 'id.js'));
       return assert.equal(a.id, 1127);
     });
+
     return it('should search module from the user app', function() {
       comparePaths(path.normalize(remote.process.mainModule.filename), path.resolve(__dirname, 'static', 'main.js'));
       return comparePaths(path.normalize(remote.process.mainModule.paths[0]), path.resolve(__dirname, 'static', 'node_modules'));
     });
   });
+
   describe('remote.createFunctionWithReturnValue', function() {
     return it('should be called in browser synchronously', function() {
-      var buf, call, result;
-      buf = new Buffer('test');
-      call = remote.require(path.join(fixtures, 'module', 'call.js'));
-      result = call.call(remote.createFunctionWithReturnValue(buf));
+      var buf = new Buffer('test');
+      var call = remote.require(path.join(fixtures, 'module', 'call.js'));
+      var result = call.call(remote.createFunctionWithReturnValue(buf));
       return assert.equal(result.constructor.name, 'Buffer');
     });
   });
+
   describe('remote object in renderer', function() {
     it('can change its properties', function() {
-      var property, property2;
-      property = remote.require(path.join(fixtures, 'module', 'property.js'));
+      var property = remote.require(path.join(fixtures, 'module', 'property.js'));
       assert.equal(property.property, 1127);
       property.property = 1007;
       assert.equal(property.property, 1007);
-      property2 = remote.require(path.join(fixtures, 'module', 'property.js'));
+      var property2 = remote.require(path.join(fixtures, 'module', 'property.js'));
       assert.equal(property2.property, 1007);
       return property.property = 1127;
     });
+
     return it('can construct an object from its member', function() {
       var call, obj;
       call = remote.require(path.join(fixtures, 'module', 'call.js'));
@@ -62,37 +65,37 @@ describe('ipc module', function() {
       return assert.equal(obj.test, 'test');
     });
   });
+
   describe('remote value in browser', function() {
-    var print;
-    print = path.join(fixtures, 'module', 'print_name.js');
+    var print = path.join(fixtures, 'module', 'print_name.js');
+
     it('keeps its constructor name for objects', function() {
-      var buf, print_name;
-      buf = new Buffer('test');
-      print_name = remote.require(print);
+      var buf = new Buffer('test');
+      var print_name = remote.require(print);
       return assert.equal(print_name.print(buf), 'Buffer');
     });
+
     return it('supports instanceof Date', function() {
-      var now, print_name;
-      now = new Date();
-      print_name = remote.require(print);
+      var now = new Date();
+      var print_name = remote.require(print);
       assert.equal(print_name.print(now), 'Date');
       return assert.deepEqual(print_name.echo(now), now);
     });
   });
+
   describe('remote promise', function() {
     return it('can be used as promise in each side', function(done) {
-      var promise;
-      promise = remote.require(path.join(fixtures, 'module', 'promise.js'));
+      var promise = remote.require(path.join(fixtures, 'module', 'promise.js'));
       return promise.twicePromise(Promise.resolve(1234)).then(function(value) {
         assert.equal(value, 2468);
         return done();
       });
     });
   });
+
   describe('ipc.sender.send', function() {
     return it('should work when sending an object containing id property', function(done) {
-      var obj;
-      obj = {
+      var obj = {
         id: 1,
         name: 'ly'
       };
@@ -103,16 +106,17 @@ describe('ipc module', function() {
       return ipcRenderer.send('message', obj);
     });
   });
+
   describe('ipc.sendSync', function() {
     it('can be replied by setting event.returnValue', function() {
-      var msg;
-      msg = ipcRenderer.sendSync('echo', 'test');
+      var msg = ipcRenderer.sendSync('echo', 'test');
       return assert.equal(msg, 'test');
     });
+
     return it('does not crash when reply is not sent and browser is destroyed', function(done) {
-      var w;
       this.timeout(10000);
-      w = new BrowserWindow({
+
+      var w = new BrowserWindow({
         show: false
       });
       ipcMain.once('send-sync-message', function(event) {
@@ -123,18 +127,19 @@ describe('ipc module', function() {
       return w.loadURL('file://' + path.join(fixtures, 'api', 'send-sync-message.html'));
     });
   });
+
   return describe('remote listeners', function() {
-    var w;
-    w = null;
+    var w = null;
+
     afterEach(function() {
       return w.destroy();
     });
+
     return it('can be added and removed correctly', function() {
-      var listener;
       w = new BrowserWindow({
         show: false
       });
-      listener = function() {};
+      var listener = function() {};
       w.on('test', listener);
       assert.equal(w.listenerCount('test'), 1);
       w.removeListener('test', listener);

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -1,14 +1,13 @@
-var BrowserWindow, assert, comparePaths, ipcMain, ipcRenderer, path, ref, ref1, remote;
+const assert = require('assert');
+const path = require('path');
 
-assert = require('assert');
+const ipcRenderer = require('electron').ipcRenderer;
+const remote = require('electron').remote;
 
-path = require('path');
+const ipcMain = remote.require('electron').ipcMain;
+const BrowserWindow = remote.require('electron').BrowserWindow;
 
-ref = require('electron'), ipcRenderer = ref.ipcRenderer, remote = ref.remote;
-
-ref1 = remote.require('electron'), ipcMain = ref1.ipcMain, BrowserWindow = ref1.BrowserWindow;
-
-comparePaths = function(path1, path2) {
+const comparePaths = function(path1, path2) {
   if (process.platform === 'win32') {
     path1 = path1.toLowerCase();
     path2 = path2.toLowerCase();

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -1,10 +1,10 @@
-var Menu, MenuItem, assert, ipcRenderer, ref, ref1, remote;
+const assert = require('assert');
 
-assert = require('assert');
+const remote = require('electron').remote;
+const ipcRenderer = require('electron').ipcRenderer;
 
-ref = require('electron'), remote = ref.remote, ipcRenderer = ref.ipcRenderer;
-
-ref1 = remote.require('electron'), Menu = ref1.Menu, MenuItem = ref1.MenuItem;
+const Menu = remote.require('electron').Menu;
+const MenuItem = remote.require('electron').MenuItem;
 
 describe('menu module', function() {
   describe('Menu.buildFromTemplate', function() {

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -15,12 +15,12 @@ describe('menu module', function() {
           extra: 'field'
         }
       ]);
-      return assert.equal(menu.items[0].extra, 'field');
+      assert.equal(menu.items[0].extra, 'field');
     });
 
     it('does not modify the specified template', function() {
       var template = ipcRenderer.sendSync('eval', "var template = [{label: 'text', submenu: [{label: 'sub'}]}];\nrequire('electron').Menu.buildFromTemplate(template);\ntemplate;");
-      return assert.deepStrictEqual(template, [
+      assert.deepStrictEqual(template, [
         {
           label: 'text',
           submenu: [
@@ -32,7 +32,7 @@ describe('menu module', function() {
       ]);
     });
 
-    return describe('Menu.buildFromTemplate should reorder based on item position specifiers', function() {
+    describe('Menu.buildFromTemplate should reorder based on item position specifiers', function() {
       it('should position before existing item', function() {
         var menu = Menu.buildFromTemplate([
           {
@@ -49,7 +49,7 @@ describe('menu module', function() {
         ]);
         assert.equal(menu.items[0].label, '1');
         assert.equal(menu.items[1].label, '2');
-        return assert.equal(menu.items[2].label, '3');
+        assert.equal(menu.items[2].label, '3');
       });
 
       it('should position after existing item', function() {
@@ -68,7 +68,7 @@ describe('menu module', function() {
         ]);
         assert.equal(menu.items[0].label, '1');
         assert.equal(menu.items[1].label, '2');
-        return assert.equal(menu.items[2].label, '3');
+        assert.equal(menu.items[2].label, '3');
       });
 
       it('should position at endof existing separator groups', function() {
@@ -112,7 +112,7 @@ describe('menu module', function() {
         assert.equal(menu.items[4].id, 'letters');
         assert.equal(menu.items[5].label, 'a');
         assert.equal(menu.items[6].label, 'b');
-        return assert.equal(menu.items[7].label, 'c');
+        assert.equal(menu.items[7].label, 'c');
       });
 
       it('should create separator group if endof does not reference existing separator group', function() {
@@ -150,10 +150,10 @@ describe('menu module', function() {
         assert.equal(menu.items[4].id, 'numbers');
         assert.equal(menu.items[5].label, '1');
         assert.equal(menu.items[6].label, '2');
-        return assert.equal(menu.items[7].label, '3');
+        assert.equal(menu.items[7].label, '3');
       });
 
-      return it('should continue inserting items at next index when no specifier is present', function() {
+      it('should continue inserting items at next index when no specifier is present', function() {
         var menu = Menu.buildFromTemplate([
           {
             label: '4',
@@ -177,13 +177,13 @@ describe('menu module', function() {
         assert.equal(menu.items[1].label, '2');
         assert.equal(menu.items[2].label, '3');
         assert.equal(menu.items[3].label, '4');
-        return assert.equal(menu.items[4].label, '5');
+        assert.equal(menu.items[4].label, '5');
       });
     });
   });
 
   describe('Menu.insert', function() {
-    return it('should store item in @items by its index', function() {
+    it('should store item in @items by its index', function() {
       var menu = Menu.buildFromTemplate([
         {
           label: '1'
@@ -200,27 +200,27 @@ describe('menu module', function() {
       assert.equal(menu.items[0].label, '1');
       assert.equal(menu.items[1].label, 'inserted');
       assert.equal(menu.items[2].label, '2');
-      return assert.equal(menu.items[3].label, '3');
+      assert.equal(menu.items[3].label, '3');
     });
   });
 
   describe('MenuItem.click', function() {
-    return it('should be called with the item object passed', function(done) {
+    it('should be called with the item object passed', function(done) {
       var menu = Menu.buildFromTemplate([
         {
           label: 'text',
           click: function(item) {
             assert.equal(item.constructor.name, 'MenuItem');
             assert.equal(item.label, 'text');
-            return done();
+            done();
           }
         }
       ]);
-      return menu.delegate.executeCommand(menu.items[0].commandId);
+      menu.delegate.executeCommand(menu.items[0].commandId);
     });
   });
 
-  return describe('MenuItem with checked property', function() {
+  describe('MenuItem with checked property', function() {
     it('clicking an checkbox item should flip the checked property', function() {
       var menu = Menu.buildFromTemplate([
         {
@@ -230,7 +230,7 @@ describe('menu module', function() {
       ]);
       assert.equal(menu.items[0].checked, false);
       menu.delegate.executeCommand(menu.items[0].commandId);
-      return assert.equal(menu.items[0].checked, true);
+      assert.equal(menu.items[0].checked, true);
     });
 
     it('clicking an radio item should always make checked property true', function() {
@@ -243,7 +243,7 @@ describe('menu module', function() {
       menu.delegate.executeCommand(menu.items[0].commandId);
       assert.equal(menu.items[0].checked, true);
       menu.delegate.executeCommand(menu.items[0].commandId);
-      return assert.equal(menu.items[0].checked, true);
+      assert.equal(menu.items[0].checked, true);
     });
 
     it('at least have one item checked in each group', function() {
@@ -267,7 +267,7 @@ describe('menu module', function() {
       menu = Menu.buildFromTemplate(template);
       menu.delegate.menuWillShow();
       assert.equal(menu.items[0].checked, true);
-      return assert.equal(menu.items[12].checked, true);
+      assert.equal(menu.items[12].checked, true);
     });
 
     it('should assign groupId automatically', function() {
@@ -293,14 +293,12 @@ describe('menu module', function() {
       for (i = l = 0; l <= 10; i = ++l) {
         assert.equal(menu.items[i].groupId, groupId);
       }
-      results = [];
       for (i = m = 12; m <= 20; i = ++m) {
-        results.push(assert.equal(menu.items[i].groupId, groupId + 1));
+        assert.equal(menu.items[i].groupId, groupId + 1);
       }
-      return results;
     });
 
-    return it("setting 'checked' should flip other items' 'checked' property", function() {
+    it("setting 'checked' should flip other items' 'checked' property", function() {
       var i, j, k, l, m, menu, n, o, p, q, results, template;
       template = [];
       for (i = j = 0; j <= 10; i = ++j) {
@@ -341,11 +339,9 @@ describe('menu module', function() {
         assert.equal(menu.items[i].checked, false);
       }
       assert.equal(menu.items[12].checked, true);
-      results = [];
       for (i = q = 13; q <= 20; i = ++q) {
-        results.push(assert.equal(menu.items[i].checked, false));
+        assert.equal(menu.items[i].checked, false);
       }
-      return results;
     });
   });
 });

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -9,8 +9,7 @@ const MenuItem = remote.require('electron').MenuItem;
 describe('menu module', function() {
   describe('Menu.buildFromTemplate', function() {
     it('should be able to attach extra fields', function() {
-      var menu;
-      menu = Menu.buildFromTemplate([
+      var menu = Menu.buildFromTemplate([
         {
           label: 'text',
           extra: 'field'
@@ -18,9 +17,9 @@ describe('menu module', function() {
       ]);
       return assert.equal(menu.items[0].extra, 'field');
     });
+
     it('does not modify the specified template', function() {
-      var template;
-      template = ipcRenderer.sendSync('eval', "var template = [{label: 'text', submenu: [{label: 'sub'}]}];\nrequire('electron').Menu.buildFromTemplate(template);\ntemplate;");
+      var template = ipcRenderer.sendSync('eval', "var template = [{label: 'text', submenu: [{label: 'sub'}]}];\nrequire('electron').Menu.buildFromTemplate(template);\ntemplate;");
       return assert.deepStrictEqual(template, [
         {
           label: 'text',
@@ -32,10 +31,10 @@ describe('menu module', function() {
         }
       ]);
     });
+
     return describe('Menu.buildFromTemplate should reorder based on item position specifiers', function() {
       it('should position before existing item', function() {
-        var menu;
-        menu = Menu.buildFromTemplate([
+        var menu = Menu.buildFromTemplate([
           {
             label: '2',
             id: '2'
@@ -52,9 +51,9 @@ describe('menu module', function() {
         assert.equal(menu.items[1].label, '2');
         return assert.equal(menu.items[2].label, '3');
       });
+
       it('should position after existing item', function() {
-        var menu;
-        menu = Menu.buildFromTemplate([
+        var menu = Menu.buildFromTemplate([
           {
             label: '1',
             id: '1'
@@ -71,9 +70,9 @@ describe('menu module', function() {
         assert.equal(menu.items[1].label, '2');
         return assert.equal(menu.items[2].label, '3');
       });
+
       it('should position at endof existing separator groups', function() {
-        var menu;
-        menu = Menu.buildFromTemplate([
+        var menu = Menu.buildFromTemplate([
           {
             type: 'separator',
             id: 'numbers'
@@ -115,9 +114,9 @@ describe('menu module', function() {
         assert.equal(menu.items[6].label, 'b');
         return assert.equal(menu.items[7].label, 'c');
       });
+
       it('should create separator group if endof does not reference existing separator group', function() {
-        var menu;
-        menu = Menu.buildFromTemplate([
+        var menu = Menu.buildFromTemplate([
           {
             label: 'a',
             id: 'a',
@@ -153,9 +152,9 @@ describe('menu module', function() {
         assert.equal(menu.items[6].label, '2');
         return assert.equal(menu.items[7].label, '3');
       });
+
       return it('should continue inserting items at next index when no specifier is present', function() {
-        var menu;
-        menu = Menu.buildFromTemplate([
+        var menu = Menu.buildFromTemplate([
           {
             label: '4',
             id: '4'
@@ -182,10 +181,10 @@ describe('menu module', function() {
       });
     });
   });
+
   describe('Menu.insert', function() {
     return it('should store item in @items by its index', function() {
-      var item, menu;
-      menu = Menu.buildFromTemplate([
+      var menu = Menu.buildFromTemplate([
         {
           label: '1'
         }, {
@@ -194,7 +193,7 @@ describe('menu module', function() {
           label: '3'
         }
       ]);
-      item = new MenuItem({
+      var item = new MenuItem({
         label: 'inserted'
       });
       menu.insert(1, item);
@@ -204,10 +203,10 @@ describe('menu module', function() {
       return assert.equal(menu.items[3].label, '3');
     });
   });
+
   describe('MenuItem.click', function() {
     return it('should be called with the item object passed', function(done) {
-      var menu;
-      menu = Menu.buildFromTemplate([
+      var menu = Menu.buildFromTemplate([
         {
           label: 'text',
           click: function(item) {
@@ -220,10 +219,10 @@ describe('menu module', function() {
       return menu.delegate.executeCommand(menu.items[0].commandId);
     });
   });
+
   return describe('MenuItem with checked property', function() {
     it('clicking an checkbox item should flip the checked property', function() {
-      var menu;
-      menu = Menu.buildFromTemplate([
+      var menu = Menu.buildFromTemplate([
         {
           label: 'text',
           type: 'checkbox'
@@ -233,9 +232,9 @@ describe('menu module', function() {
       menu.delegate.executeCommand(menu.items[0].commandId);
       return assert.equal(menu.items[0].checked, true);
     });
+
     it('clicking an radio item should always make checked property true', function() {
-      var menu;
-      menu = Menu.buildFromTemplate([
+      var menu = Menu.buildFromTemplate([
         {
           label: 'text',
           type: 'radio'
@@ -246,6 +245,7 @@ describe('menu module', function() {
       menu.delegate.executeCommand(menu.items[0].commandId);
       return assert.equal(menu.items[0].checked, true);
     });
+
     it('at least have one item checked in each group', function() {
       var i, j, k, menu, template;
       template = [];
@@ -269,6 +269,7 @@ describe('menu module', function() {
       assert.equal(menu.items[0].checked, true);
       return assert.equal(menu.items[12].checked, true);
     });
+
     it('should assign groupId automatically', function() {
       var groupId, i, j, k, l, m, menu, results, template;
       template = [];
@@ -298,6 +299,7 @@ describe('menu module', function() {
       }
       return results;
     });
+
     return it("setting 'checked' should flip other items' 'checked' property", function() {
       var i, j, k, l, m, menu, n, o, p, q, results, template;
       template = [];

--- a/spec/api-menu-spec.js
+++ b/spec/api-menu-spec.js
@@ -271,7 +271,7 @@ describe('menu module', function() {
     });
 
     it('should assign groupId automatically', function() {
-      var groupId, i, j, k, l, m, menu, results, template;
+      var groupId, i, j, k, l, m, menu, template;
       template = [];
       for (i = j = 0; j <= 10; i = ++j) {
         template.push({
@@ -299,7 +299,7 @@ describe('menu module', function() {
     });
 
     it("setting 'checked' should flip other items' 'checked' property", function() {
-      var i, j, k, l, m, menu, n, o, p, q, results, template;
+      var i, j, k, l, m, menu, n, o, p, q, template;
       template = [];
       for (i = j = 0; j <= 10; i = ++j) {
         template.push({

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -122,7 +122,7 @@ describe('protocol module', function() {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function(data) {
             assert.equal(data, text);
@@ -310,7 +310,7 @@ describe('protocol module', function() {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function(data) {
             assert.equal(data, String(fileContent));
@@ -325,7 +325,7 @@ describe('protocol module', function() {
 
     it('sets Access-Control-Allow-Origin', function(done) {
       var handler = function(request, callback) {
-        return callback(filePath);
+        callback(filePath);
       };
       protocol.registerFileProtocol(protocolName, handler, function(error) {
         if (error) {
@@ -346,7 +346,7 @@ describe('protocol module', function() {
     });
     it('sends object as response', function(done) {
       var handler = function(request, callback) {
-        return callback({
+        callback({
           path: filePath
         });
       };
@@ -440,7 +440,7 @@ describe('protocol module', function() {
         res.end(text);
         server.close();
       });
-      return server.listen(0, '127.0.0.1', function() {
+      server.listen(0, '127.0.0.1', function() {
         var port = server.address().port;
         var url = "http://127.0.0.1:" + port;
         var handler = function(request, callback) {
@@ -586,7 +586,7 @@ describe('protocol module', function() {
       var doubleHandler = function(request, callback) {
         try {
           callback(text);
-          return callback();
+          callback();
         } catch (error) {
           // Ignore error
         }

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -14,24 +14,24 @@ describe('protocol module', function() {
   };
 
   afterEach(function(done) {
-    return protocol.unregisterProtocol(protocolName, function() {
-      return protocol.uninterceptProtocol('http', function() {
-        return done();
+    protocol.unregisterProtocol(protocolName, function() {
+      protocol.uninterceptProtocol('http', function() {
+        done();
       });
     });
   });
 
   describe('protocol.register(Any)Protocol', function() {
     var emptyHandler = function(request, callback) {
-      return callback();
+      callback();
     };
 
     it('throws error when scheme is already registered', function(done) {
-      return protocol.registerStringProtocol(protocolName, emptyHandler, function(error) {
+      protocol.registerStringProtocol(protocolName, emptyHandler, function(error) {
         assert.equal(error, null);
-        return protocol.registerBufferProtocol(protocolName, emptyHandler, function(error) {
+        protocol.registerBufferProtocol(protocolName, emptyHandler, function(error) {
           assert.notEqual(error, null);
-          return done();
+          done();
         });
       });
     });
@@ -40,34 +40,34 @@ describe('protocol module', function() {
       var doubleHandler = function(request, callback) {
         try {
           callback(text);
-          return callback();
+          callback();
         } catch (error) {
           // Ignore error
         }
       };
-      return protocol.registerStringProtocol(protocolName, doubleHandler, function(error) {
+      protocol.registerStringProtocol(protocolName, doubleHandler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function(data) {
             assert.equal(data, text);
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
     });
 
     it('sends error when callback is called with nothing', function(done) {
-      return protocol.registerBufferProtocol(protocolName, emptyHandler, function(error) {
+      protocol.registerBufferProtocol(protocolName, emptyHandler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function() {
             return done('request succeeded but it should not');
@@ -80,24 +80,24 @@ describe('protocol module', function() {
       });
     });
 
-    return it('does not crash when callback is called in next tick', function(done) {
+    it('does not crash when callback is called in next tick', function(done) {
       var handler = function(request, callback) {
-        return setImmediate(function() {
-          return callback(text);
+        setImmediate(function() {
+          callback(text);
         });
       };
-      return protocol.registerStringProtocol(protocolName, handler, function(error) {
+      protocol.registerStringProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function(data) {
             assert.equal(data, text);
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
@@ -105,10 +105,10 @@ describe('protocol module', function() {
   });
 
   describe('protocol.unregisterProtocol', function() {
-    return it('returns error when scheme does not exist', function(done) {
-      return protocol.unregisterProtocol('not-exist', function(error) {
+    it('returns error when scheme does not exist', function(done) {
+      protocol.unregisterProtocol('not-exist', function(error) {
         assert.notEqual(error, null);
-        return done();
+        done();
       });
     });
   });
@@ -116,9 +116,9 @@ describe('protocol module', function() {
   describe('protocol.registerStringProtocol', function() {
     it('sends string as response', function(done) {
       var handler = function(request, callback) {
-        return callback(text);
+        callback(text);
       };
-      return protocol.registerStringProtocol(protocolName, handler, function(error) {
+      protocol.registerStringProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
@@ -126,10 +126,10 @@ describe('protocol module', function() {
           url: protocolName + "://fake-host",
           success: function(data) {
             assert.equal(data, text);
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
@@ -137,21 +137,21 @@ describe('protocol module', function() {
 
     it('sets Access-Control-Allow-Origin', function(done) {
       var handler = function(request, callback) {
-        return callback(text);
+        callback(text);
       };
-      return protocol.registerStringProtocol(protocolName, handler, function(error) {
+      protocol.registerStringProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function(data, status, request) {
             assert.equal(data, text);
             assert.equal(request.getResponseHeader('Access-Control-Allow-Origin'), '*');
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
@@ -159,44 +159,44 @@ describe('protocol module', function() {
 
     it('sends object as response', function(done) {
       var handler = function(request, callback) {
-        return callback({
+        callback({
           data: text,
           mimeType: 'text/html'
         });
       };
-      return protocol.registerStringProtocol(protocolName, handler, function(error) {
+      protocol.registerStringProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function(data) {
             assert.equal(data, text);
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
     });
 
-    return it('fails when sending object other than string', function(done) {
+    it('fails when sending object other than string', function(done) {
       var handler = function(request, callback) {
-        return callback(new Date);
+        callback(new Date);
       };
-      return protocol.registerBufferProtocol(protocolName, handler, function(error) {
+      protocol.registerBufferProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function() {
-            return done('request succeeded but it should not');
+            done('request succeeded but it should not');
           },
           error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
-            return done();
+            done();
           }
         });
       });
@@ -208,20 +208,20 @@ describe('protocol module', function() {
 
     it('sends Buffer as response', function(done) {
       var handler = function(request, callback) {
-        return callback(buffer);
+        callback(buffer);
       };
-      return protocol.registerBufferProtocol(protocolName, handler, function(error) {
+      protocol.registerBufferProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function(data) {
             assert.equal(data, text);
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
@@ -229,22 +229,22 @@ describe('protocol module', function() {
 
     it('sets Access-Control-Allow-Origin', function(done) {
       var handler = function(request, callback) {
-        return callback(buffer);
+        callback(buffer);
       };
 
-      return protocol.registerBufferProtocol(protocolName, handler, function(error) {
+      protocol.registerBufferProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function(data, status, request) {
             assert.equal(data, text);
             assert.equal(request.getResponseHeader('Access-Control-Allow-Origin'), '*');
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
@@ -252,44 +252,44 @@ describe('protocol module', function() {
 
     it('sends object as response', function(done) {
       var handler = function(request, callback) {
-        return callback({
+        callback({
           data: buffer,
           mimeType: 'text/html'
         });
       };
-      return protocol.registerBufferProtocol(protocolName, handler, function(error) {
+      protocol.registerBufferProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function(data) {
             assert.equal(data, text);
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
     });
 
-    return it('fails when sending string', function(done) {
+    it('fails when sending string', function(done) {
       var handler = function(request, callback) {
-        return callback(text);
+        callback(text);
       };
-      return protocol.registerBufferProtocol(protocolName, handler, function(error) {
+      protocol.registerBufferProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function() {
-            return done('request succeeded but it should not');
+            done('request succeeded but it should not');
           },
           error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
-            return done();
+            done();
           }
         });
       });
@@ -304,9 +304,9 @@ describe('protocol module', function() {
 
     it('sends file path as response', function(done) {
       var handler = function(request, callback) {
-        return callback(filePath);
+        callback(filePath);
       };
-      return protocol.registerFileProtocol(protocolName, handler, function(error) {
+      protocol.registerFileProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
@@ -327,42 +327,41 @@ describe('protocol module', function() {
       var handler = function(request, callback) {
         return callback(filePath);
       };
-      return protocol.registerFileProtocol(protocolName, handler, function(error) {
+      protocol.registerFileProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function(data, status, request) {
             assert.equal(data, String(fileContent));
             assert.equal(request.getResponseHeader('Access-Control-Allow-Origin'), '*');
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
     });
     it('sends object as response', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback({
           path: filePath
         });
       };
-      return protocol.registerFileProtocol(protocolName, handler, function(error) {
+      protocol.registerFileProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function(data) {
             assert.equal(data, String(fileContent));
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
@@ -370,21 +369,21 @@ describe('protocol module', function() {
 
     it('can send normal file', function(done) {
       var handler = function(request, callback) {
-        return callback(normalPath);
+        callback(normalPath);
       };
 
-      return protocol.registerFileProtocol(protocolName, handler, function(error) {
+      protocol.registerFileProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function(data) {
             assert.equal(data, String(normalContent));
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
@@ -393,41 +392,41 @@ describe('protocol module', function() {
     it('fails when sending unexist-file', function(done) {
       var fakeFilePath = path.join(__dirname, 'fixtures', 'asar', 'a.asar', 'not-exist');
       var handler = function(request, callback) {
-        return callback(fakeFilePath);
+        callback(fakeFilePath);
       };
-      return protocol.registerBufferProtocol(protocolName, handler, function(error) {
+      protocol.registerBufferProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function() {
-            return done('request succeeded but it should not');
+            done('request succeeded but it should not');
           },
           error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
-            return done();
+            done();
           }
         });
       });
     });
 
-    return it('fails when sending unsupported content', function(done) {
+    it('fails when sending unsupported content', function(done) {
       var handler = function(request, callback) {
-        return callback(new Date);
+        callback(new Date);
       };
-      return protocol.registerBufferProtocol(protocolName, handler, function(error) {
+      protocol.registerBufferProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function() {
-            return done('request succeeded but it should not');
+            done('request succeeded but it should not');
           },
           error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
-            return done();
+            done();
           }
         });
       });
@@ -439,29 +438,28 @@ describe('protocol module', function() {
       var server = http.createServer(function(req, res) {
         assert.notEqual(req.headers.accept, '');
         res.end(text);
-        return server.close();
+        server.close();
       });
       return server.listen(0, '127.0.0.1', function() {
-        var handler, port, url;
-        port = server.address().port;
-        url = "http://127.0.0.1:" + port;
-        handler = function(request, callback) {
-          return callback({
+        var port = server.address().port;
+        var url = "http://127.0.0.1:" + port;
+        var handler = function(request, callback) {
+          callback({
             url: url
           });
         };
-        return protocol.registerHttpProtocol(protocolName, handler, function(error) {
+        protocol.registerHttpProtocol(protocolName, handler, function(error) {
           if (error) {
             return done(error);
           }
-          return $.ajax({
+          $.ajax({
             url: protocolName + "://fake-host",
             success: function(data) {
               assert.equal(data, text);
-              return done();
+              done();
             },
             error: function(xhr, errorType, error) {
-              return done(error);
+              done(error);
             }
           });
         });
@@ -470,43 +468,43 @@ describe('protocol module', function() {
 
     it('fails when sending invalid url', function(done) {
       var handler = function(request, callback) {
-        return callback({
+        callback({
           url: 'url'
         });
       };
-      return protocol.registerHttpProtocol(protocolName, handler, function(error) {
+      protocol.registerHttpProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function() {
-            return done('request succeeded but it should not');
+            done('request succeeded but it should not');
           },
           error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
-            return done();
+            done();
           }
         });
       });
     });
 
-    return it('fails when sending unsupported content', function(done) {
+    it('fails when sending unsupported content', function(done) {
       var handler = function(request, callback) {
-        return callback(new Date);
+        callback(new Date);
       };
-      return protocol.registerHttpProtocol(protocolName, handler, function(error) {
+      protocol.registerHttpProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: protocolName + "://fake-host",
           success: function() {
-            return done('request succeeded but it should not');
+            done('request succeeded but it should not');
           },
           error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
-            return done();
+            done();
           }
         });
       });
@@ -515,55 +513,55 @@ describe('protocol module', function() {
 
   describe('protocol.isProtocolHandled', function() {
     it('returns true for file:', function(done) {
-      return protocol.isProtocolHandled('file', function(result) {
+      protocol.isProtocolHandled('file', function(result) {
         assert.equal(result, true);
-        return done();
+        done();
       });
     });
 
     it('returns true for http:', function(done) {
-      return protocol.isProtocolHandled('http', function(result) {
+      protocol.isProtocolHandled('http', function(result) {
         assert.equal(result, true);
-        return done();
+        done();
       });
     });
 
     it('returns true for https:', function(done) {
-      return protocol.isProtocolHandled('https', function(result) {
+      protocol.isProtocolHandled('https', function(result) {
         assert.equal(result, true);
-        return done();
+        done();
       });
     });
 
     it('returns false when scheme is not registred', function(done) {
-      return protocol.isProtocolHandled('no-exist', function(result) {
+      protocol.isProtocolHandled('no-exist', function(result) {
         assert.equal(result, false);
-        return done();
+        done();
       });
     });
 
     it('returns true for custom protocol', function(done) {
       var emptyHandler = function(request, callback) {
-        return callback();
+        callback();
       };
-      return protocol.registerStringProtocol(protocolName, emptyHandler, function(error) {
+      protocol.registerStringProtocol(protocolName, emptyHandler, function(error) {
         assert.equal(error, null);
-        return protocol.isProtocolHandled(protocolName, function(result) {
+        protocol.isProtocolHandled(protocolName, function(result) {
           assert.equal(result, true);
-          return done();
+          done();
         });
       });
     });
 
-    return it('returns true for intercepted protocol', function(done) {
+    it('returns true for intercepted protocol', function(done) {
       var emptyHandler = function(request, callback) {
-        return callback();
+        callback();
       };
-      return protocol.interceptStringProtocol('http', emptyHandler, function(error) {
+      protocol.interceptStringProtocol('http', emptyHandler, function(error) {
         assert.equal(error, null);
-        return protocol.isProtocolHandled('http', function(result) {
+        protocol.isProtocolHandled('http', function(result) {
           assert.equal(result, true);
-          return done();
+          done();
         });
       });
     });
@@ -571,15 +569,15 @@ describe('protocol module', function() {
 
   describe('protocol.intercept(Any)Protocol', function() {
     var emptyHandler = function(request, callback) {
-      return callback();
+      callback();
     };
 
     it('throws error when scheme is already intercepted', function(done) {
-      return protocol.interceptStringProtocol('http', emptyHandler, function(error) {
+      protocol.interceptStringProtocol('http', emptyHandler, function(error) {
         assert.equal(error, null);
-        return protocol.interceptBufferProtocol('http', emptyHandler, function(error) {
+        protocol.interceptBufferProtocol('http', emptyHandler, function(error) {
           assert.notEqual(error, null);
-          return done();
+          done();
         });
       });
     });
@@ -593,39 +591,39 @@ describe('protocol module', function() {
           // Ignore error
         }
       };
-      return protocol.interceptStringProtocol('http', doubleHandler, function(error) {
+      protocol.interceptStringProtocol('http', doubleHandler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: 'http://fake-host',
           success: function(data) {
             assert.equal(data, text);
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
     });
 
-    return it('sends error when callback is called with nothing', function(done) {
+    it('sends error when callback is called with nothing', function(done) {
       if (process.env.TRAVIS === 'true') {
         return done();
       }
-      return protocol.interceptBufferProtocol('http', emptyHandler, function(error) {
+      protocol.interceptBufferProtocol('http', emptyHandler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: 'http://fake-host',
           success: function() {
-            return done('request succeeded but it should not');
+            done('request succeeded but it should not');
           },
           error: function(xhr, errorType) {
             assert.equal(errorType, 'error');
-            return done();
+            done();
           }
         });
       });
@@ -635,20 +633,20 @@ describe('protocol module', function() {
   describe('protocol.interceptStringProtocol', function() {
     it('can intercept http protocol', function(done) {
       var handler = function(request, callback) {
-        return callback(text);
+        callback(text);
       };
-      return protocol.interceptStringProtocol('http', handler, function(error) {
+      protocol.interceptStringProtocol('http', handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: 'http://fake-host',
           success: function(data) {
             assert.equal(data, text);
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
@@ -656,51 +654,50 @@ describe('protocol module', function() {
 
     it('can set content-type', function(done) {
       var handler = function(request, callback) {
-        return callback({
+        callback({
           mimeType: 'application/json',
           data: '{"value": 1}'
         });
       };
-      return protocol.interceptStringProtocol('http', handler, function(error) {
+      protocol.interceptStringProtocol('http', handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: 'http://fake-host',
           success: function(data) {
             assert.equal(typeof data, 'object');
             assert.equal(data.value, 1);
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
     });
 
-    return it('can receive post data', function(done) {
+    it('can receive post data', function(done) {
       var handler = function(request, callback) {
-        var uploadData;
-        uploadData = request.uploadData[0].bytes.toString();
-        return callback({
+        var uploadData = request.uploadData[0].bytes.toString();
+        callback({
           data: uploadData
         });
       };
-      return protocol.interceptStringProtocol('http', handler, function(error) {
+      protocol.interceptStringProtocol('http', handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: "http://fake-host",
           type: "POST",
           data: postData,
           success: function(data) {
             assert.deepEqual(qs.parse(data), postData);
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
@@ -710,45 +707,44 @@ describe('protocol module', function() {
   describe('protocol.interceptBufferProtocol', function() {
     it('can intercept http protocol', function(done) {
       var handler = function(request, callback) {
-        return callback(new Buffer(text));
+        callback(new Buffer(text));
       };
-      return protocol.interceptBufferProtocol('http', handler, function(error) {
+      protocol.interceptBufferProtocol('http', handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: 'http://fake-host',
           success: function(data) {
             assert.equal(data, text);
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
     });
 
-    return it('can receive post data', function(done) {
+    it('can receive post data', function(done) {
       var handler = function(request, callback) {
-        var uploadData;
-        uploadData = request.uploadData[0].bytes;
-        return callback(uploadData);
+        var uploadData = request.uploadData[0].bytes;
+        callback(uploadData);
       };
-      return protocol.interceptBufferProtocol('http', handler, function(error) {
+      protocol.interceptBufferProtocol('http', handler, function(error) {
         if (error) {
           return done(error);
         }
-        return $.ajax({
+        $.ajax({
           url: "http://fake-host",
           type: "POST",
           data: postData,
           success: function(data) {
             assert.equal(data, $.param(postData));
-            return done();
+            done();
           },
           error: function(xhr, errorType, error) {
-            return done(error);
+            done(error);
           }
         });
       });
@@ -756,24 +752,22 @@ describe('protocol module', function() {
   });
 
   describe('protocol.interceptHttpProtocol', function() {
-    return it('can send POST request', function(done) {
+    it('can send POST request', function(done) {
       var server = http.createServer(function(req, res) {
-        var body;
-        body = '';
+        var body = '';
         req.on('data', function(chunk) {
-          return body += chunk;
+          body += chunk;
         });
         req.on('end', function() {
-          return res.end(body);
+          res.end(body);
         });
-        return server.close();
+        server.close();
       });
-      return server.listen(0, '127.0.0.1', function() {
+      server.listen(0, '127.0.0.1', function() {
         var port = server.address().port;
         var url = "http://127.0.0.1:" + port;
         var handler = function(request, callback) {
-          var data;
-          data = {
+          var data = {
             url: url,
             method: 'POST',
             uploadData: {
@@ -782,22 +776,22 @@ describe('protocol module', function() {
             },
             session: null
           };
-          return callback(data);
+          callback(data);
         };
-        return protocol.interceptHttpProtocol('http', handler, function(error) {
+        protocol.interceptHttpProtocol('http', handler, function(error) {
           if (error) {
             return done(error);
           }
-          return $.ajax({
+          $.ajax({
             url: "http://fake-host",
             type: "POST",
             data: postData,
             success: function(data) {
               assert.deepEqual(qs.parse(data), postData);
-              return done();
+              done();
             },
             error: function(xhr, errorType, error) {
-              return done(error);
+              done(error);
             }
           });
         });
@@ -805,18 +799,18 @@ describe('protocol module', function() {
     });
   });
 
-  return describe('protocol.uninterceptProtocol', function() {
+  describe('protocol.uninterceptProtocol', function() {
     it('returns error when scheme does not exist', function(done) {
-      return protocol.uninterceptProtocol('not-exist', function(error) {
+      protocol.uninterceptProtocol('not-exist', function(error) {
         assert.notEqual(error, null);
-        return done();
+        done();
       });
     });
 
-    return it('returns error when scheme is not intercepted', function(done) {
-      return protocol.uninterceptProtocol('http', function(error) {
+    it('returns error when scheme is not intercepted', function(done) {
+      protocol.uninterceptProtocol('http', function(error) {
         assert.notEqual(error, null);
-        return done();
+        done();
       });
     });
   });

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -6,13 +6,13 @@ const remote = require('electron').remote;
 const protocol = remote.require('electron').protocol;
 
 describe('protocol module', function() {
-  var postData, protocolName, text;
-  protocolName = 'sp';
-  text = 'valar morghulis';
-  postData = {
+  var protocolName = 'sp';
+  var text = 'valar morghulis';
+  var postData = {
     name: 'post test',
     type: 'string'
   };
+
   afterEach(function(done) {
     return protocol.unregisterProtocol(protocolName, function() {
       return protocol.uninterceptProtocol('http', function() {
@@ -20,11 +20,12 @@ describe('protocol module', function() {
       });
     });
   });
+
   describe('protocol.register(Any)Protocol', function() {
-    var emptyHandler;
-    emptyHandler = function(request, callback) {
+    var emptyHandler = function(request, callback) {
       return callback();
     };
+
     it('throws error when scheme is already registered', function(done) {
       return protocol.registerStringProtocol(protocolName, emptyHandler, function(error) {
         assert.equal(error, null);
@@ -34,9 +35,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     it('does not crash when handler is called twice', function(done) {
-      var doubleHandler;
-      doubleHandler = function(request, callback) {
+      var doubleHandler = function(request, callback) {
         try {
           callback(text);
           return callback();
@@ -60,6 +61,7 @@ describe('protocol module', function() {
         });
       });
     });
+
     it('sends error when callback is called with nothing', function(done) {
       return protocol.registerBufferProtocol(protocolName, emptyHandler, function(error) {
         if (error) {
@@ -77,9 +79,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     return it('does not crash when callback is called in next tick', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return setImmediate(function() {
           return callback(text);
         });
@@ -101,6 +103,7 @@ describe('protocol module', function() {
       });
     });
   });
+
   describe('protocol.unregisterProtocol', function() {
     return it('returns error when scheme does not exist', function(done) {
       return protocol.unregisterProtocol('not-exist', function(error) {
@@ -109,10 +112,10 @@ describe('protocol module', function() {
       });
     });
   });
+
   describe('protocol.registerStringProtocol', function() {
     it('sends string as response', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback(text);
       };
       return protocol.registerStringProtocol(protocolName, handler, function(error) {
@@ -131,9 +134,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     it('sets Access-Control-Allow-Origin', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback(text);
       };
       return protocol.registerStringProtocol(protocolName, handler, function(error) {
@@ -153,9 +156,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     it('sends object as response', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback({
           data: text,
           mimeType: 'text/html'
@@ -177,9 +180,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     return it('fails when sending object other than string', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback(new Date);
       };
       return protocol.registerBufferProtocol(protocolName, handler, function(error) {
@@ -199,12 +202,12 @@ describe('protocol module', function() {
       });
     });
   });
+
   describe('protocol.registerBufferProtocol', function() {
-    var buffer;
-    buffer = new Buffer(text);
+    var buffer = new Buffer(text);
+
     it('sends Buffer as response', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback(buffer);
       };
       return protocol.registerBufferProtocol(protocolName, handler, function(error) {
@@ -223,11 +226,12 @@ describe('protocol module', function() {
         });
       });
     });
+
     it('sets Access-Control-Allow-Origin', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback(buffer);
       };
+
       return protocol.registerBufferProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
@@ -245,9 +249,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     it('sends object as response', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback({
           data: buffer,
           mimeType: 'text/html'
@@ -269,9 +273,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     return it('fails when sending string', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback(text);
       };
       return protocol.registerBufferProtocol(protocolName, handler, function(error) {
@@ -291,15 +295,15 @@ describe('protocol module', function() {
       });
     });
   });
+
   describe('protocol.registerFileProtocol', function() {
-    var fileContent, filePath, normalContent, normalPath;
-    filePath = path.join(__dirname, 'fixtures', 'asar', 'a.asar', 'file1');
-    fileContent = require('fs').readFileSync(filePath);
-    normalPath = path.join(__dirname, 'fixtures', 'pages', 'a.html');
-    normalContent = require('fs').readFileSync(normalPath);
+    var filePath = path.join(__dirname, 'fixtures', 'asar', 'a.asar', 'file1');
+    var fileContent = require('fs').readFileSync(filePath);
+    var normalPath = path.join(__dirname, 'fixtures', 'pages', 'a.html');
+    var normalContent = require('fs').readFileSync(normalPath);
+
     it('sends file path as response', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback(filePath);
       };
       return protocol.registerFileProtocol(protocolName, handler, function(error) {
@@ -318,9 +322,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     it('sets Access-Control-Allow-Origin', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback(filePath);
       };
       return protocol.registerFileProtocol(protocolName, handler, function(error) {
@@ -363,11 +367,12 @@ describe('protocol module', function() {
         });
       });
     });
+
     it('can send normal file', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback(normalPath);
       };
+
       return protocol.registerFileProtocol(protocolName, handler, function(error) {
         if (error) {
           return done(error);
@@ -384,10 +389,10 @@ describe('protocol module', function() {
         });
       });
     });
+
     it('fails when sending unexist-file', function(done) {
-      var fakeFilePath, handler;
-      fakeFilePath = path.join(__dirname, 'fixtures', 'asar', 'a.asar', 'not-exist');
-      handler = function(request, callback) {
+      var fakeFilePath = path.join(__dirname, 'fixtures', 'asar', 'a.asar', 'not-exist');
+      var handler = function(request, callback) {
         return callback(fakeFilePath);
       };
       return protocol.registerBufferProtocol(protocolName, handler, function(error) {
@@ -406,9 +411,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     return it('fails when sending unsupported content', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback(new Date);
       };
       return protocol.registerBufferProtocol(protocolName, handler, function(error) {
@@ -428,10 +433,10 @@ describe('protocol module', function() {
       });
     });
   });
+
   describe('protocol.registerHttpProtocol', function() {
     it('sends url as response', function(done) {
-      var server;
-      server = http.createServer(function(req, res) {
+      var server = http.createServer(function(req, res) {
         assert.notEqual(req.headers.accept, '');
         res.end(text);
         return server.close();
@@ -462,9 +467,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     it('fails when sending invalid url', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback({
           url: 'url'
         });
@@ -485,9 +490,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     return it('fails when sending unsupported content', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback(new Date);
       };
       return protocol.registerHttpProtocol(protocolName, handler, function(error) {
@@ -507,6 +512,7 @@ describe('protocol module', function() {
       });
     });
   });
+
   describe('protocol.isProtocolHandled', function() {
     it('returns true for file:', function(done) {
       return protocol.isProtocolHandled('file', function(result) {
@@ -514,27 +520,30 @@ describe('protocol module', function() {
         return done();
       });
     });
+
     it('returns true for http:', function(done) {
       return protocol.isProtocolHandled('http', function(result) {
         assert.equal(result, true);
         return done();
       });
     });
+
     it('returns true for https:', function(done) {
       return protocol.isProtocolHandled('https', function(result) {
         assert.equal(result, true);
         return done();
       });
     });
+
     it('returns false when scheme is not registred', function(done) {
       return protocol.isProtocolHandled('no-exist', function(result) {
         assert.equal(result, false);
         return done();
       });
     });
+
     it('returns true for custom protocol', function(done) {
-      var emptyHandler;
-      emptyHandler = function(request, callback) {
+      var emptyHandler = function(request, callback) {
         return callback();
       };
       return protocol.registerStringProtocol(protocolName, emptyHandler, function(error) {
@@ -545,9 +554,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     return it('returns true for intercepted protocol', function(done) {
-      var emptyHandler;
-      emptyHandler = function(request, callback) {
+      var emptyHandler = function(request, callback) {
         return callback();
       };
       return protocol.interceptStringProtocol('http', emptyHandler, function(error) {
@@ -559,11 +568,12 @@ describe('protocol module', function() {
       });
     });
   });
+
   describe('protocol.intercept(Any)Protocol', function() {
-    var emptyHandler;
-    emptyHandler = function(request, callback) {
+    var emptyHandler = function(request, callback) {
       return callback();
     };
+
     it('throws error when scheme is already intercepted', function(done) {
       return protocol.interceptStringProtocol('http', emptyHandler, function(error) {
         assert.equal(error, null);
@@ -573,9 +583,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     it('does not crash when handler is called twice', function(done) {
-      var doubleHandler;
-      doubleHandler = function(request, callback) {
+      var doubleHandler = function(request, callback) {
         try {
           callback(text);
           return callback();
@@ -599,6 +609,7 @@ describe('protocol module', function() {
         });
       });
     });
+
     return it('sends error when callback is called with nothing', function(done) {
       if (process.env.TRAVIS === 'true') {
         return done();
@@ -620,10 +631,10 @@ describe('protocol module', function() {
       });
     });
   });
+
   describe('protocol.interceptStringProtocol', function() {
     it('can intercept http protocol', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback(text);
       };
       return protocol.interceptStringProtocol('http', handler, function(error) {
@@ -642,9 +653,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     it('can set content-type', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback({
           mimeType: 'application/json',
           data: '{"value": 1}'
@@ -667,9 +678,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     return it('can receive post data', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         var uploadData;
         uploadData = request.uploadData[0].bytes.toString();
         return callback({
@@ -695,10 +706,10 @@ describe('protocol module', function() {
       });
     });
   });
+
   describe('protocol.interceptBufferProtocol', function() {
     it('can intercept http protocol', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         return callback(new Buffer(text));
       };
       return protocol.interceptBufferProtocol('http', handler, function(error) {
@@ -717,9 +728,9 @@ describe('protocol module', function() {
         });
       });
     });
+
     return it('can receive post data', function(done) {
-      var handler;
-      handler = function(request, callback) {
+      var handler = function(request, callback) {
         var uploadData;
         uploadData = request.uploadData[0].bytes;
         return callback(uploadData);
@@ -743,10 +754,10 @@ describe('protocol module', function() {
       });
     });
   });
+
   describe('protocol.interceptHttpProtocol', function() {
     return it('can send POST request', function(done) {
-      var server;
-      server = http.createServer(function(req, res) {
+      var server = http.createServer(function(req, res) {
         var body;
         body = '';
         req.on('data', function(chunk) {
@@ -758,10 +769,9 @@ describe('protocol module', function() {
         return server.close();
       });
       return server.listen(0, '127.0.0.1', function() {
-        var handler, port, url;
-        port = server.address().port;
-        url = "http://127.0.0.1:" + port;
-        handler = function(request, callback) {
+        var port = server.address().port;
+        var url = "http://127.0.0.1:" + port;
+        var handler = function(request, callback) {
           var data;
           data = {
             url: url,
@@ -794,6 +804,7 @@ describe('protocol module', function() {
       });
     });
   });
+
   return describe('protocol.uninterceptProtocol', function() {
     it('returns error when scheme does not exist', function(done) {
       return protocol.uninterceptProtocol('not-exist', function(error) {
@@ -801,6 +812,7 @@ describe('protocol module', function() {
         return done();
       });
     });
+
     return it('returns error when scheme is not intercepted', function(done) {
       return protocol.uninterceptProtocol('http', function(error) {
         assert.notEqual(error, null);

--- a/spec/api-screen-spec.js
+++ b/spec/api-screen-spec.js
@@ -1,8 +1,5 @@
-var assert, screen;
-
-assert = require('assert');
-
-screen = require('electron').screen;
+const assert = require('assert');
+const screen = require('electron').screen;
 
 describe('screen module', function() {
   describe('screen.getCursorScreenPoint()', function() {

--- a/spec/api-screen-spec.js
+++ b/spec/api-screen-spec.js
@@ -4,16 +4,15 @@ const screen = require('electron').screen;
 describe('screen module', function() {
   describe('screen.getCursorScreenPoint()', function() {
     return it('returns a point object', function() {
-      var point;
-      point = screen.getCursorScreenPoint();
+      var point = screen.getCursorScreenPoint();
       assert.equal(typeof point.x, 'number');
       return assert.equal(typeof point.y, 'number');
     });
   });
+
   return describe('screen.getPrimaryDisplay()', function() {
     return it('returns a display object', function() {
-      var display;
-      display = screen.getPrimaryDisplay();
+      var display = screen.getPrimaryDisplay();
       assert.equal(typeof display.scaleFactor, 'number');
       assert(display.size.width > 0);
       return assert(display.size.height > 0);

--- a/spec/api-screen-spec.js
+++ b/spec/api-screen-spec.js
@@ -3,19 +3,19 @@ const screen = require('electron').screen;
 
 describe('screen module', function() {
   describe('screen.getCursorScreenPoint()', function() {
-    return it('returns a point object', function() {
+    it('returns a point object', function() {
       var point = screen.getCursorScreenPoint();
       assert.equal(typeof point.x, 'number');
-      return assert.equal(typeof point.y, 'number');
+      assert.equal(typeof point.y, 'number');
     });
   });
 
-  return describe('screen.getPrimaryDisplay()', function() {
-    return it('returns a display object', function() {
+  describe('screen.getPrimaryDisplay()', function() {
+    it('returns a display object', function() {
       var display = screen.getPrimaryDisplay();
       assert.equal(typeof display.scaleFactor, 'number');
       assert(display.size.width > 0);
-      return assert(display.size.height > 0);
+      assert(display.size.height > 0);
     });
   });
 });

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -31,15 +31,13 @@ describe('session module', function() {
 
   describe('session.cookies', function() {
     it('should get cookies', function(done) {
-      var server;
-      server = http.createServer(function(req, res) {
+      var server = http.createServer(function(req, res) {
         res.setHeader('Set-Cookie', ['0=0']);
         res.end('finished');
         server.close();
       });
       server.listen(0, '127.0.0.1', function() {
-        var port;
-        port = server.address().port;
+        var port = server.address().port;
         w.loadURL(url + ":" + port);
         w.webContents.on('did-finish-load', function() {
           w.webContents.session.cookies.get({
@@ -136,8 +134,7 @@ describe('session module', function() {
       });
       w.loadURL('file://' + path.join(fixtures, 'api', 'localstorage.html'));
       w.webContents.on('did-finish-load', function() {
-        var options;
-        options = {
+        var options = {
           origin: "file://",
           storages: ['localstorage'],
           quotas: ['persistent']

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -11,11 +11,12 @@ const session = remote.session;
 const BrowserWindow = remote.BrowserWindow;
 
 describe('session module', function() {
-  var fixtures, url, w;
   this.timeout(10000);
-  fixtures = path.resolve(__dirname, 'fixtures');
-  w = null;
-  url = "http://127.0.0.1";
+
+  var fixtures = path.resolve(__dirname, 'fixtures');
+  var w = null;
+  var url = "http://127.0.0.1";
+
   beforeEach(function() {
     return w = new BrowserWindow({
       show: false,
@@ -23,6 +24,7 @@ describe('session module', function() {
       height: 400
     });
   });
+
   afterEach(function() {
     return w.destroy();
   });
@@ -62,6 +64,7 @@ describe('session module', function() {
         });
       });
     });
+
     it('should over-write the existent cookie', function(done) {
       return session.defaultSession.cookies.set({
         url: url,
@@ -92,6 +95,7 @@ describe('session module', function() {
         });
       });
     });
+
     it('should remove cookies', function(done) {
       return session.defaultSession.cookies.set({
         url: url,
@@ -155,6 +159,7 @@ describe('session module', function() {
         height: 400
       });
     });
+
     afterEach(function() {
       return w.destroy();
     });
@@ -213,6 +218,7 @@ describe('session module', function() {
       assert(fs.existsSync(downloadFilePath));
       return fs.unlinkSync(downloadFilePath);
     };
+
     it('can download using BrowserWindow.loadURL', function(done) {
       return downloadServer.listen(0, '127.0.0.1', function() {
         var port;
@@ -225,6 +231,7 @@ describe('session module', function() {
         });
       });
     });
+
     it('can download using WebView.downloadURL', function(done) {
       return downloadServer.listen(0, '127.0.0.1', function() {
         var port, webview;
@@ -243,6 +250,7 @@ describe('session module', function() {
         return document.body.appendChild(webview);
       });
     });
+
     it('can cancel download', function(done) {
       return downloadServer.listen(0, '127.0.0.1', function() {
         var port;

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -18,7 +18,7 @@ describe('session module', function() {
   var url = "http://127.0.0.1";
 
   beforeEach(function() {
-    return w = new BrowserWindow({
+    w = new BrowserWindow({
       show: false,
       width: 400,
       height: 400
@@ -26,7 +26,7 @@ describe('session module', function() {
   });
 
   afterEach(function() {
-    return w.destroy();
+    w.destroy();
   });
 
   describe('session.cookies', function() {
@@ -35,14 +35,14 @@ describe('session module', function() {
       server = http.createServer(function(req, res) {
         res.setHeader('Set-Cookie', ['0=0']);
         res.end('finished');
-        return server.close();
+        server.close();
       });
-      return server.listen(0, '127.0.0.1', function() {
+      server.listen(0, '127.0.0.1', function() {
         var port;
         port = server.address().port;
         w.loadURL(url + ":" + port);
-        return w.webContents.on('did-finish-load', function() {
-          return w.webContents.session.cookies.get({
+        w.webContents.on('did-finish-load', function() {
+          w.webContents.session.cookies.get({
             url: url
           }, function(error, list) {
             var cookie, i, len;
@@ -59,14 +59,14 @@ describe('session module', function() {
                 }
               }
             }
-            return done('Can not find cookie');
+            done('Can not find cookie');
           });
         });
       });
     });
 
     it('should over-write the existent cookie', function(done) {
-      return session.defaultSession.cookies.set({
+      session.defaultSession.cookies.set({
         url: url,
         name: '1',
         value: '1'
@@ -74,7 +74,7 @@ describe('session module', function() {
         if (error) {
           return done(error);
         }
-        return session.defaultSession.cookies.get({
+        session.defaultSession.cookies.get({
           url: url
         }, function(error, list) {
           var cookie, i, len;
@@ -91,13 +91,13 @@ describe('session module', function() {
               }
             }
           }
-          return done('Can not find cookie');
+          done('Can not find cookie');
         });
       });
     });
 
     it('should remove cookies', function(done) {
-      return session.defaultSession.cookies.set({
+      session.defaultSession.cookies.set({
         url: url,
         name: '2',
         value: '2'
@@ -105,8 +105,8 @@ describe('session module', function() {
         if (error) {
           return done(error);
         }
-        return session.defaultSession.cookies.remove(url, '2', function() {
-          return session.defaultSession.cookies.get({
+        session.defaultSession.cookies.remove(url, '2', function() {
+          session.defaultSession.cookies.get({
             url: url
           }, function(error, list) {
             var cookie, i, len;
@@ -119,7 +119,7 @@ describe('session module', function() {
                 return done('Cookie not deleted');
               }
             }
-            return done();
+            done();
           });
         });
       });
@@ -128,22 +128,22 @@ describe('session module', function() {
 
   describe('session.clearStorageData(options)', function() {
     fixtures = path.resolve(__dirname, 'fixtures');
-    return it('clears localstorage data', function(done) {
+    it('clears localstorage data', function(done) {
       ipcMain.on('count', function(event, count) {
         ipcMain.removeAllListeners('count');
         assert(!count);
-        return done();
+        done();
       });
       w.loadURL('file://' + path.join(fixtures, 'api', 'localstorage.html'));
-      return w.webContents.on('did-finish-load', function() {
+      w.webContents.on('did-finish-load', function() {
         var options;
         options = {
           origin: "file://",
           storages: ['localstorage'],
           quotas: ['persistent']
         };
-        return w.webContents.session.clearStorageData(options, function() {
-          return w.webContents.send('getcount');
+        w.webContents.session.clearStorageData(options, function() {
+          w.webContents.send('getcount');
         });
       });
     });
@@ -161,7 +161,7 @@ describe('session module', function() {
     });
 
     afterEach(function() {
-      return w.destroy();
+      w.destroy();
     });
 
     it('can cancel default download behavior', function(done) {
@@ -193,21 +193,20 @@ describe('session module', function() {
     });
   });
 
-  return describe('DownloadItem', function() {
-    var assertDownload, contentDisposition, downloadFilePath, downloadServer, mockPDF;
-    mockPDF = new Buffer(1024 * 1024 * 5);
-    contentDisposition = 'inline; filename="mock.pdf"';
-    downloadFilePath = path.join(fixtures, 'mock.pdf');
-    downloadServer = http.createServer(function(req, res) {
+  describe('DownloadItem', function() {
+    var mockPDF = new Buffer(1024 * 1024 * 5);
+    var contentDisposition = 'inline; filename="mock.pdf"';
+    var downloadFilePath = path.join(fixtures, 'mock.pdf');
+    var downloadServer = http.createServer(function(req, res) {
       res.writeHead(200, {
         'Content-Length': mockPDF.length,
         'Content-Type': 'application/pdf',
         'Content-Disposition': contentDisposition
       });
       res.end(mockPDF);
-      return downloadServer.close();
+      downloadServer.close();
     });
-    assertDownload = function(event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, port) {
+    var assertDownload = function(event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, port) {
       assert.equal(state, 'completed');
       assert.equal(filename, 'mock.pdf');
       assert.equal(url, "http://127.0.0.1:" + port + "/");
@@ -216,55 +215,52 @@ describe('session module', function() {
       assert.equal(totalBytes, mockPDF.length);
       assert.equal(disposition, contentDisposition);
       assert(fs.existsSync(downloadFilePath));
-      return fs.unlinkSync(downloadFilePath);
+      fs.unlinkSync(downloadFilePath);
     };
 
     it('can download using BrowserWindow.loadURL', function(done) {
-      return downloadServer.listen(0, '127.0.0.1', function() {
-        var port;
-        port = downloadServer.address().port;
+      downloadServer.listen(0, '127.0.0.1', function() {
+        var port = downloadServer.address().port;
         ipcRenderer.sendSync('set-download-option', false, false);
         w.loadURL(url + ":" + port);
-        return ipcRenderer.once('download-done', function(event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename) {
+        ipcRenderer.once('download-done', function(event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename) {
           assertDownload(event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, port);
-          return done();
+          done();
         });
       });
     });
 
     it('can download using WebView.downloadURL', function(done) {
-      return downloadServer.listen(0, '127.0.0.1', function() {
-        var port, webview;
-        port = downloadServer.address().port;
+      downloadServer.listen(0, '127.0.0.1', function() {
+        var port = downloadServer.address().port;
         ipcRenderer.sendSync('set-download-option', false, false);
-        webview = new WebView;
+        var webview = new WebView;
         webview.src = "file://" + fixtures + "/api/blank.html";
         webview.addEventListener('did-finish-load', function() {
-          return webview.downloadURL(url + ":" + port + "/");
+          webview.downloadURL(url + ":" + port + "/");
         });
         ipcRenderer.once('download-done', function(event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename) {
           assertDownload(event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename, port);
           document.body.removeChild(webview);
-          return done();
+          done();
         });
-        return document.body.appendChild(webview);
+        document.body.appendChild(webview);
       });
     });
 
     it('can cancel download', function(done) {
-      return downloadServer.listen(0, '127.0.0.1', function() {
-        var port;
-        port = downloadServer.address().port;
+      downloadServer.listen(0, '127.0.0.1', function() {
+        var port = downloadServer.address().port;
         ipcRenderer.sendSync('set-download-option', true, false);
         w.loadURL(url + ":" + port + "/");
-        return ipcRenderer.once('download-done', function(event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename) {
+        ipcRenderer.once('download-done', function(event, state, url, mimeType, receivedBytes, totalBytes, disposition, filename) {
           assert.equal(state, 'cancelled');
           assert.equal(filename, 'mock.pdf');
           assert.equal(mimeType, 'application/pdf');
           assert.equal(receivedBytes, 0);
           assert.equal(totalBytes, mockPDF.length);
           assert.equal(disposition, contentDisposition);
-          return done();
+          done();
         });
       });
     });

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -1,10 +1,6 @@
-var assert, path, webFrame;
-
-assert = require('assert');
-
-path = require('path');
-
-webFrame = require('electron').webFrame;
+const assert = require('assert');
+const path = require('path');
+const webFrame = require('electron').webFrame;
 
 describe('webFrame module', function() {
   var fixtures;

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -4,15 +4,15 @@ const webFrame = require('electron').webFrame;
 
 describe('webFrame module', function() {
   var fixtures = path.resolve(__dirname, 'fixtures');
-  return describe('webFrame.registerURLSchemeAsPrivileged', function() {
-    return it('supports fetch api', function(done) {
+  describe('webFrame.registerURLSchemeAsPrivileged', function() {
+    it('supports fetch api', function(done) {
       webFrame.registerURLSchemeAsPrivileged('file');
       var url = "file://" + fixtures + "/assets/logo.png";
-      return fetch(url).then(function(response) {
+      fetch(url).then(function(response) {
         assert(response.ok);
-        return done();
-      })["catch"](function(err) {
-        return done('unexpected error : ' + err);
+        done();
+      }).catch(function(err) {
+        done('unexpected error : ' + err);
       });
     });
   });

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -3,13 +3,11 @@ const path = require('path');
 const webFrame = require('electron').webFrame;
 
 describe('webFrame module', function() {
-  var fixtures;
-  fixtures = path.resolve(__dirname, 'fixtures');
+  var fixtures = path.resolve(__dirname, 'fixtures');
   return describe('webFrame.registerURLSchemeAsPrivileged', function() {
     return it('supports fetch api', function(done) {
-      var url;
       webFrame.registerURLSchemeAsPrivileged('file');
-      url = "file://" + fixtures + "/assets/logo.png";
+      var url = "file://" + fixtures + "/assets/logo.png";
       return fetch(url).then(function(response) {
         assert(response.ok);
         return done();

--- a/spec/api-web-request-spec.js
+++ b/spec/api-web-request-spec.js
@@ -7,9 +7,8 @@ const session = remote.session;
 describe('webRequest module', function() {
   var ses = session.defaultSession;
   var server = http.createServer(function(req, res) {
-    var content;
     res.setHeader('Custom', ['Header']);
-    content = req.url;
+    var content = req.url;
     if (req.headers.accept === '*/*;test/header') {
       content += 'header/received';
     }
@@ -19,8 +18,7 @@ describe('webRequest module', function() {
 
   before(function(done) {
     server.listen(0, '127.0.0.1', function() {
-      var port;
-      port = server.address().port;
+      var port = server.address().port;
       defaultURL = "http://127.0.0.1:" + port + "/";
       done();
     });
@@ -109,11 +107,10 @@ describe('webRequest module', function() {
         type: 'string'
       };
       ses.webRequest.onBeforeRequest(function(details, callback) {
-        var data;
         assert.equal(details.url, defaultURL);
         assert.equal(details.method, 'POST');
         assert.equal(details.uploadData.length, 1);
-        data = qs.parse(details.uploadData[0].bytes.toString());
+        var data = qs.parse(details.uploadData[0].bytes.toString());
         assert.deepEqual(data, postData);
         callback({
           cancel: true
@@ -178,8 +175,7 @@ describe('webRequest module', function() {
 
     it('can change the request headers', function(done) {
       ses.webRequest.onBeforeSendHeaders(function(details, callback) {
-        var requestHeaders;
-        requestHeaders = details.requestHeaders;
+        var requestHeaders = details.requestHeaders;
         requestHeaders.Accept = '*/*;test/header';
         callback({
           requestHeaders: requestHeaders

--- a/spec/api-web-request-spec.js
+++ b/spec/api-web-request-spec.js
@@ -13,41 +13,41 @@ describe('webRequest module', function() {
     if (req.headers.accept === '*/*;test/header') {
       content += 'header/received';
     }
-    return res.end(content);
+    res.end(content);
   });
   var defaultURL = null;
 
   before(function(done) {
-    return server.listen(0, '127.0.0.1', function() {
+    server.listen(0, '127.0.0.1', function() {
       var port;
       port = server.address().port;
       defaultURL = "http://127.0.0.1:" + port + "/";
-      return done();
+      done();
     });
   });
 
   after(function() {
-    return server.close();
+    server.close();
   });
 
   describe('webRequest.onBeforeRequest', function() {
     afterEach(function() {
-      return ses.webRequest.onBeforeRequest(null);
+      ses.webRequest.onBeforeRequest(null);
     });
 
     it('can cancel the request', function(done) {
       ses.webRequest.onBeforeRequest(function(details, callback) {
-        return callback({
+        callback({
           cancel: true
         });
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         success: function() {
-          return done('unexpected success');
+          done('unexpected success');
         },
         error: function() {
-          return done();
+          done();
         }
       });
     });
@@ -57,26 +57,26 @@ describe('webRequest module', function() {
         urls: [defaultURL + "filter/*"]
       };
       ses.webRequest.onBeforeRequest(filter, function(details, callback) {
-        return callback({
+        callback({
           cancel: true
         });
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL + "nofilter/test",
         success: function(data) {
           assert.equal(data, '/nofilter/test');
-          return $.ajax({
+          $.ajax({
             url: defaultURL + "filter/test",
             success: function() {
-              return done('unexpected success');
+              done('unexpected success');
             },
             error: function() {
-              return done();
+              done();
             }
           });
         },
         error: function(xhr, errorType) {
-          return done(errorType);
+          done(errorType);
         }
       });
     });
@@ -89,16 +89,16 @@ describe('webRequest module', function() {
         assert.equal(details.method, 'GET');
         assert.equal(details.resourceType, 'xhr');
         assert(!details.uploadData);
-        return callback({});
+        callback({});
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         success: function(data) {
           assert.equal(data, '/');
-          return done();
+          done();
         },
         error: function(xhr, errorType) {
-          return done(errorType);
+          done(errorType);
         }
       });
     });
@@ -115,11 +115,11 @@ describe('webRequest module', function() {
         assert.equal(details.uploadData.length, 1);
         data = qs.parse(details.uploadData[0].bytes.toString());
         assert.deepEqual(data, postData);
-        return callback({
+        callback({
           cancel: true
         });
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         type: 'POST',
         data: postData,
@@ -131,24 +131,24 @@ describe('webRequest module', function() {
       });
     });
 
-    return it('can redirect the request', function(done) {
+    it('can redirect the request', function(done) {
       ses.webRequest.onBeforeRequest(function(details, callback) {
         if (details.url === defaultURL) {
-          return callback({
+          callback({
             redirectURL: defaultURL + "redirect"
           });
         } else {
-          return callback({});
+          callback({});
         }
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         success: function(data) {
           assert.equal(data, '/redirect');
-          return done();
+          done();
         },
         error: function(xhr, errorType) {
-          return done(errorType);
+          done(errorType);
         }
       });
     });
@@ -156,22 +156,22 @@ describe('webRequest module', function() {
 
   describe('webRequest.onBeforeSendHeaders', function() {
     afterEach(function() {
-      return ses.webRequest.onBeforeSendHeaders(null);
+      ses.webRequest.onBeforeSendHeaders(null);
     });
 
     it('receives details object', function(done) {
       ses.webRequest.onBeforeSendHeaders(function(details, callback) {
         assert.equal(typeof details.requestHeaders, 'object');
-        return callback({});
+        callback({});
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         success: function(data) {
           assert.equal(data, '/');
-          return done();
+          done();
         },
         error: function(xhr, errorType) {
-          return done(errorType);
+          done(errorType);
         }
       });
     });
@@ -181,40 +181,39 @@ describe('webRequest module', function() {
         var requestHeaders;
         requestHeaders = details.requestHeaders;
         requestHeaders.Accept = '*/*;test/header';
-        return callback({
+        callback({
           requestHeaders: requestHeaders
         });
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         success: function(data) {
           assert.equal(data, '/header/received');
-          return done();
+          done();
         },
         error: function(xhr, errorType) {
-          return done(errorType);
+          done(errorType);
         }
       });
     });
 
-    return it('resets the whole headers', function(done) {
-      var requestHeaders;
-      requestHeaders = {
+    it('resets the whole headers', function(done) {
+      var requestHeaders = {
         Test: 'header'
       };
       ses.webRequest.onBeforeSendHeaders(function(details, callback) {
-        return callback({
+        callback({
           requestHeaders: requestHeaders
         });
       });
       ses.webRequest.onSendHeaders(function(details) {
         assert.deepEqual(details.requestHeaders, requestHeaders);
-        return done();
+        done();
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         error: function(xhr, errorType) {
-          return done(errorType);
+          done(errorType);
         }
       });
     });
@@ -222,21 +221,21 @@ describe('webRequest module', function() {
 
   describe('webRequest.onSendHeaders', function() {
     afterEach(function() {
-      return ses.webRequest.onSendHeaders(null);
+      ses.webRequest.onSendHeaders(null);
     });
 
-    return it('receives details object', function(done) {
+    it('receives details object', function(done) {
       ses.webRequest.onSendHeaders(function(details) {
-        return assert.equal(typeof details.requestHeaders, 'object');
+        assert.equal(typeof details.requestHeaders, 'object');
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         success: function(data) {
           assert.equal(data, '/');
-          return done();
+          done();
         },
         error: function(xhr, errorType) {
-          return done(errorType);
+          done(errorType);
         }
       });
     });
@@ -244,7 +243,7 @@ describe('webRequest module', function() {
 
   describe('webRequest.onHeadersReceived', function() {
     afterEach(function() {
-      return ses.webRequest.onHeadersReceived(null);
+      ses.webRequest.onHeadersReceived(null);
     });
 
     it('receives details object', function(done) {
@@ -252,55 +251,54 @@ describe('webRequest module', function() {
         assert.equal(details.statusLine, 'HTTP/1.1 200 OK');
         assert.equal(details.statusCode, 200);
         assert.equal(details.responseHeaders['Custom'], 'Header');
-        return callback({});
+        callback({});
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         success: function(data) {
           assert.equal(data, '/');
-          return done();
+          done();
         },
         error: function(xhr, errorType) {
-          return done(errorType);
+          done(errorType);
         }
       });
     });
 
     it('can change the response header', function(done) {
       ses.webRequest.onHeadersReceived(function(details, callback) {
-        var responseHeaders;
-        responseHeaders = details.responseHeaders;
+        var responseHeaders = details.responseHeaders;
         responseHeaders['Custom'] = ['Changed'];
-        return callback({
+        callback({
           responseHeaders: responseHeaders
         });
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         success: function(data, status, xhr) {
           assert.equal(xhr.getResponseHeader('Custom'), 'Changed');
           assert.equal(data, '/');
-          return done();
+          done();
         },
         error: function(xhr, errorType) {
-          return done(errorType);
+          done(errorType);
         }
       });
     });
 
-    return it('does not change header by default', function(done) {
+    it('does not change header by default', function(done) {
       ses.webRequest.onHeadersReceived(function(details, callback) {
-        return callback({});
+        callback({});
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         success: function(data, status, xhr) {
           assert.equal(xhr.getResponseHeader('Custom'), 'Header');
           assert.equal(data, '/');
-          return done();
+          done();
         },
         error: function(xhr, errorType) {
-          return done(errorType);
+          done(errorType);
         }
       });
     });
@@ -308,25 +306,25 @@ describe('webRequest module', function() {
 
   describe('webRequest.onResponseStarted', function() {
     afterEach(function() {
-      return ses.webRequest.onResponseStarted(null);
+      ses.webRequest.onResponseStarted(null);
     });
 
-    return it('receives details object', function(done) {
+    it('receives details object', function(done) {
       ses.webRequest.onResponseStarted(function(details) {
         assert.equal(typeof details.fromCache, 'boolean');
         assert.equal(details.statusLine, 'HTTP/1.1 200 OK');
         assert.equal(details.statusCode, 200);
-        return assert.equal(details.responseHeaders['Custom'], 'Header');
+        assert.equal(details.responseHeaders['Custom'], 'Header');
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         success: function(data, status, xhr) {
           assert.equal(xhr.getResponseHeader('Custom'), 'Header');
           assert.equal(data, '/');
-          return done();
+          done();
         },
         error: function(xhr, errorType) {
-          return done(errorType);
+          done(errorType);
         }
       });
     });
@@ -335,35 +333,34 @@ describe('webRequest module', function() {
   describe('webRequest.onBeforeRedirect', function() {
     afterEach(function() {
       ses.webRequest.onBeforeRedirect(null);
-      return ses.webRequest.onBeforeRequest(null);
+      ses.webRequest.onBeforeRequest(null);
     });
 
-    return it('receives details object', function(done) {
-      var redirectURL;
-      redirectURL = defaultURL + "redirect";
+    it('receives details object', function(done) {
+      var redirectURL = defaultURL + "redirect";
       ses.webRequest.onBeforeRequest(function(details, callback) {
         if (details.url === defaultURL) {
-          return callback({
+          callback({
             redirectURL: redirectURL
           });
         } else {
-          return callback({});
+          callback({});
         }
       });
       ses.webRequest.onBeforeRedirect(function(details) {
         assert.equal(typeof details.fromCache, 'boolean');
         assert.equal(details.statusLine, 'HTTP/1.1 307 Internal Redirect');
         assert.equal(details.statusCode, 307);
-        return assert.equal(details.redirectURL, redirectURL);
+        assert.equal(details.redirectURL, redirectURL);
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         success: function(data) {
           assert.equal(data, '/redirect');
-          return done();
+          done();
         },
         error: function(xhr, errorType) {
-          return done(errorType);
+          done(errorType);
         }
       });
     });
@@ -371,48 +368,48 @@ describe('webRequest module', function() {
 
   describe('webRequest.onCompleted', function() {
     afterEach(function() {
-      return ses.webRequest.onCompleted(null);
+      ses.webRequest.onCompleted(null);
     });
 
-    return it('receives details object', function(done) {
+    it('receives details object', function(done) {
       ses.webRequest.onCompleted(function(details) {
         assert.equal(typeof details.fromCache, 'boolean');
         assert.equal(details.statusLine, 'HTTP/1.1 200 OK');
-        return assert.equal(details.statusCode, 200);
+        assert.equal(details.statusCode, 200);
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         success: function(data) {
           assert.equal(data, '/');
-          return done();
+          done();
         },
         error: function(xhr, errorType) {
-          return done(errorType);
+          done(errorType);
         }
       });
     });
   });
 
-  return describe('webRequest.onErrorOccurred', function() {
+  describe('webRequest.onErrorOccurred', function() {
     afterEach(function() {
       ses.webRequest.onErrorOccurred(null);
-      return ses.webRequest.onBeforeRequest(null);
+      ses.webRequest.onBeforeRequest(null);
     });
 
-    return it('receives details object', function(done) {
+    it('receives details object', function(done) {
       ses.webRequest.onBeforeRequest(function(details, callback) {
-        return callback({
+        callback({
           cancel: true
         });
       });
       ses.webRequest.onErrorOccurred(function(details) {
         assert.equal(details.error, 'net::ERR_BLOCKED_BY_CLIENT');
-        return done();
+        done();
       });
-      return $.ajax({
+      $.ajax({
         url: defaultURL,
         success: function() {
-          return done('unexpected success');
+          done('unexpected success');
         }
       });
     });

--- a/spec/api-web-request-spec.js
+++ b/spec/api-web-request-spec.js
@@ -5,9 +5,8 @@ const remote = require('electron').remote;
 const session = remote.session;
 
 describe('webRequest module', function() {
-  var defaultURL, server, ses;
-  ses = session.defaultSession;
-  server = http.createServer(function(req, res) {
+  var ses = session.defaultSession;
+  var server = http.createServer(function(req, res) {
     var content;
     res.setHeader('Custom', ['Header']);
     content = req.url;
@@ -16,7 +15,8 @@ describe('webRequest module', function() {
     }
     return res.end(content);
   });
-  defaultURL = null;
+  var defaultURL = null;
+
   before(function(done) {
     return server.listen(0, '127.0.0.1', function() {
       var port;
@@ -25,13 +25,16 @@ describe('webRequest module', function() {
       return done();
     });
   });
+
   after(function() {
     return server.close();
   });
+
   describe('webRequest.onBeforeRequest', function() {
     afterEach(function() {
       return ses.webRequest.onBeforeRequest(null);
     });
+
     it('can cancel the request', function(done) {
       ses.webRequest.onBeforeRequest(function(details, callback) {
         return callback({
@@ -48,9 +51,9 @@ describe('webRequest module', function() {
         }
       });
     });
+
     it('can filter URLs', function(done) {
-      var filter;
-      filter = {
+      var filter = {
         urls: [defaultURL + "filter/*"]
       };
       ses.webRequest.onBeforeRequest(filter, function(details, callback) {
@@ -77,6 +80,7 @@ describe('webRequest module', function() {
         }
       });
     });
+
     it('receives details object', function(done) {
       ses.webRequest.onBeforeRequest(function(details, callback) {
         assert.equal(typeof details.id, 'number');
@@ -98,6 +102,7 @@ describe('webRequest module', function() {
         }
       });
     });
+
     it('receives post data in details object', function(done) {
       var postData = {
         name: 'post test',
@@ -125,6 +130,7 @@ describe('webRequest module', function() {
         }
       });
     });
+
     return it('can redirect the request', function(done) {
       ses.webRequest.onBeforeRequest(function(details, callback) {
         if (details.url === defaultURL) {
@@ -147,10 +153,12 @@ describe('webRequest module', function() {
       });
     });
   });
+
   describe('webRequest.onBeforeSendHeaders', function() {
     afterEach(function() {
       return ses.webRequest.onBeforeSendHeaders(null);
     });
+
     it('receives details object', function(done) {
       ses.webRequest.onBeforeSendHeaders(function(details, callback) {
         assert.equal(typeof details.requestHeaders, 'object');
@@ -167,6 +175,7 @@ describe('webRequest module', function() {
         }
       });
     });
+
     it('can change the request headers', function(done) {
       ses.webRequest.onBeforeSendHeaders(function(details, callback) {
         var requestHeaders;
@@ -187,6 +196,7 @@ describe('webRequest module', function() {
         }
       });
     });
+
     return it('resets the whole headers', function(done) {
       var requestHeaders;
       requestHeaders = {
@@ -209,10 +219,12 @@ describe('webRequest module', function() {
       });
     });
   });
+
   describe('webRequest.onSendHeaders', function() {
     afterEach(function() {
       return ses.webRequest.onSendHeaders(null);
     });
+
     return it('receives details object', function(done) {
       ses.webRequest.onSendHeaders(function(details) {
         return assert.equal(typeof details.requestHeaders, 'object');
@@ -229,10 +241,12 @@ describe('webRequest module', function() {
       });
     });
   });
+
   describe('webRequest.onHeadersReceived', function() {
     afterEach(function() {
       return ses.webRequest.onHeadersReceived(null);
     });
+
     it('receives details object', function(done) {
       ses.webRequest.onHeadersReceived(function(details, callback) {
         assert.equal(details.statusLine, 'HTTP/1.1 200 OK');
@@ -251,6 +265,7 @@ describe('webRequest module', function() {
         }
       });
     });
+
     it('can change the response header', function(done) {
       ses.webRequest.onHeadersReceived(function(details, callback) {
         var responseHeaders;
@@ -272,6 +287,7 @@ describe('webRequest module', function() {
         }
       });
     });
+
     return it('does not change header by default', function(done) {
       ses.webRequest.onHeadersReceived(function(details, callback) {
         return callback({});
@@ -289,10 +305,12 @@ describe('webRequest module', function() {
       });
     });
   });
+
   describe('webRequest.onResponseStarted', function() {
     afterEach(function() {
       return ses.webRequest.onResponseStarted(null);
     });
+
     return it('receives details object', function(done) {
       ses.webRequest.onResponseStarted(function(details) {
         assert.equal(typeof details.fromCache, 'boolean');
@@ -313,11 +331,13 @@ describe('webRequest module', function() {
       });
     });
   });
+
   describe('webRequest.onBeforeRedirect', function() {
     afterEach(function() {
       ses.webRequest.onBeforeRedirect(null);
       return ses.webRequest.onBeforeRequest(null);
     });
+
     return it('receives details object', function(done) {
       var redirectURL;
       redirectURL = defaultURL + "redirect";
@@ -348,10 +368,12 @@ describe('webRequest module', function() {
       });
     });
   });
+
   describe('webRequest.onCompleted', function() {
     afterEach(function() {
       return ses.webRequest.onCompleted(null);
     });
+
     return it('receives details object', function(done) {
       ses.webRequest.onCompleted(function(details) {
         assert.equal(typeof details.fromCache, 'boolean');
@@ -370,11 +392,13 @@ describe('webRequest module', function() {
       });
     });
   });
+
   return describe('webRequest.onErrorOccurred', function() {
     afterEach(function() {
       ses.webRequest.onErrorOccurred(null);
       return ses.webRequest.onBeforeRequest(null);
     });
+
     return it('receives details object', function(done) {
       ses.webRequest.onBeforeRequest(function(details, callback) {
         return callback({

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -128,9 +128,8 @@ describe('asar package', function() {
       });
 
       it('returns information of root', function() {
-        var p, stats;
-        p = path.join(fixtures, 'asar', 'a.asar');
-        stats = fs.lstatSync(p);
+        var p = path.join(fixtures, 'asar', 'a.asar');
+        var stats = fs.lstatSync(p);
         assert.equal(stats.isFile(), false);
         assert.equal(stats.isDirectory(), true);
         assert.equal(stats.isSymbolicLink(), false);
@@ -607,9 +606,8 @@ describe('asar package', function() {
       });
 
       it('disables asar support in async API', function(done) {
-        var dir, file;
-        file = path.join(fixtures, 'asar', 'a.asar', 'file1');
-        dir = path.join(fixtures, 'asar', 'a.asar', 'dir1');
+        var file = path.join(fixtures, 'asar', 'a.asar', 'file1');
+        var dir = path.join(fixtures, 'asar', 'a.asar', 'dir1');
         fs.readFile(file, function(error) {
           assert.equal(error.code, errorName);
           fs.lstat(file, function(error) {
@@ -737,15 +735,13 @@ describe('asar package', function() {
     var originalFs = require('original-fs');
 
     it('treats .asar as file', function() {
-      var file, stats;
-      file = path.join(fixtures, 'asar', 'a.asar');
-      stats = originalFs.statSync(file);
+      var file = path.join(fixtures, 'asar', 'a.asar');
+      var stats = originalFs.statSync(file);
       assert(stats.isFile());
     });
 
     it('is available in forked scripts', function(done) {
-      var child;
-      child = child_process.fork(path.join(fixtures, 'module', 'original-fs.js'));
+      var child = child_process.fork(path.join(fixtures, 'module', 'original-fs.js'));
       child.on('message', function(msg) {
         assert.equal(msg, 'object');
         done();

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -138,9 +138,8 @@ describe('asar package', function() {
       });
 
       it('returns information of a normal file', function() {
-        var file, j, len, p, ref2, results, stats;
+        var file, j, len, p, ref2, stats;
         ref2 = ['file1', 'file2', 'file3', path.join('dir1', 'file1'), path.join('link2', 'file1')];
-        results = [];
         for (j = 0, len = ref2.length; j < len; j++) {
           file = ref2[j];
           p = path.join(fixtures, 'asar', 'a.asar', file);
@@ -148,15 +147,13 @@ describe('asar package', function() {
           assert.equal(stats.isFile(), true);
           assert.equal(stats.isDirectory(), false);
           assert.equal(stats.isSymbolicLink(), false);
-          results.push(assert.equal(stats.size, 6));
+          assert.equal(stats.size, 6);
         }
-        results;
       });
 
       it('returns information of a normal directory', function() {
-        var file, j, len, p, ref2, results, stats;
+        var file, j, len, p, ref2, stats;
         ref2 = ['dir1', 'dir2', 'dir3'];
-        results = [];
         for (j = 0, len = ref2.length; j < len; j++) {
           file = ref2[j];
           p = path.join(fixtures, 'asar', 'a.asar', file);
@@ -164,15 +161,13 @@ describe('asar package', function() {
           assert.equal(stats.isFile(), false);
           assert.equal(stats.isDirectory(), true);
           assert.equal(stats.isSymbolicLink(), false);
-          results.push(assert.equal(stats.size, 0));
+          assert.equal(stats.size, 0);
         }
-        results;
       });
 
       it('returns information of a linked file', function() {
-        var file, j, len, p, ref2, results, stats;
+        var file, j, len, p, ref2, stats;
         ref2 = ['link1', path.join('dir1', 'link1'), path.join('link2', 'link2')];
-        results = [];
         for (j = 0, len = ref2.length; j < len; j++) {
           file = ref2[j];
           p = path.join(fixtures, 'asar', 'a.asar', file);
@@ -180,15 +175,13 @@ describe('asar package', function() {
           assert.equal(stats.isFile(), false);
           assert.equal(stats.isDirectory(), false);
           assert.equal(stats.isSymbolicLink(), true);
-          results.push(assert.equal(stats.size, 0));
+          assert.equal(stats.size, 0);
         }
-        results;
       });
 
       it('returns information of a linked directory', function() {
-        var file, j, len, p, ref2, results, stats;
+        var file, j, len, p, ref2, stats;
         ref2 = ['link2', path.join('dir1', 'link2'), path.join('link2', 'link2')];
-        results = [];
         for (j = 0, len = ref2.length; j < len; j++) {
           file = ref2[j];
           p = path.join(fixtures, 'asar', 'a.asar', file);
@@ -196,9 +189,8 @@ describe('asar package', function() {
           assert.equal(stats.isFile(), false);
           assert.equal(stats.isDirectory(), false);
           assert.equal(stats.isSymbolicLink(), true);
-          results.push(assert.equal(stats.size, 0));
+          assert.equal(stats.size, 0);
         }
-        results;
       });
 
       it('throws ENOENT error when can not find file', function() {
@@ -461,7 +453,7 @@ describe('asar package', function() {
 
     describe('fs.openSync', function() {
       it('opens a normal/linked/under-linked-directory file', function() {
-        var buffer, fd, file, j, len, p, ref2, results;
+        var buffer, fd, file, j, len, p, ref2;
         ref2 = ['file1', 'link1', path.join('link2', 'file1')];
         for (j = 0, len = ref2.length; j < len; j++) {
           file = ref2[j];

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -23,121 +23,108 @@ describe('asar package', function() {
       });
 
       it('reads a normal file', function() {
-        var file1, file2, file3;
-        file1 = path.join(fixtures, 'asar', 'a.asar', 'file1');
+        var file1 = path.join(fixtures, 'asar', 'a.asar', 'file1');
         assert.equal(fs.readFileSync(file1).toString().trim(), 'file1');
-        file2 = path.join(fixtures, 'asar', 'a.asar', 'file2');
+        var file2 = path.join(fixtures, 'asar', 'a.asar', 'file2');
         assert.equal(fs.readFileSync(file2).toString().trim(), 'file2');
-        file3 = path.join(fixtures, 'asar', 'a.asar', 'file3');
-        return assert.equal(fs.readFileSync(file3).toString().trim(), 'file3');
+        var file3 = path.join(fixtures, 'asar', 'a.asar', 'file3');
+        assert.equal(fs.readFileSync(file3).toString().trim(), 'file3');
       });
 
       it('reads from a empty file', function() {
-        var buffer, file;
-        file = path.join(fixtures, 'asar', 'empty.asar', 'file1');
-        buffer = fs.readFileSync(file);
+        var file = path.join(fixtures, 'asar', 'empty.asar', 'file1');
+        var buffer = fs.readFileSync(file);
         assert.equal(buffer.length, 0);
-        return assert.equal(buffer.toString(), '');
+        assert.equal(buffer.toString(), '');
       });
 
       it('reads a linked file', function() {
-        var p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'link1');
-        return assert.equal(fs.readFileSync(p).toString().trim(), 'file1');
+        var p = path.join(fixtures, 'asar', 'a.asar', 'link1');
+        assert.equal(fs.readFileSync(p).toString().trim(), 'file1');
       });
 
       it('reads a file from linked directory', function() {
-        var p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'file1');
+        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'file1');
         assert.equal(fs.readFileSync(p).toString().trim(), 'file1');
         p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1');
-        return assert.equal(fs.readFileSync(p).toString().trim(), 'file1');
+        assert.equal(fs.readFileSync(p).toString().trim(), 'file1');
       });
 
       it('throws ENOENT error when can not find file', function() {
-        var p, throws;
-        p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
-        throws = function() {
-          return fs.readFileSync(p);
+        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
+        var throws = function() {
+          fs.readFileSync(p);
         };
-        return assert.throws(throws, /ENOENT/);
+        assert.throws(throws, /ENOENT/);
       });
 
       it('passes ENOENT error to callback when can not find file', function() {
-        var async, p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
-        async = false;
+        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
+        var async = false;
         fs.readFile(p, function(e) {
           assert(async);
-          return assert(/ENOENT/.test(e));
+          assert(/ENOENT/.test(e));
         });
-        return async = true;
+        async = true;
       });
 
-      return it('reads a normal file with unpacked files', function() {
-        var p;
-        p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt');
-        return assert.equal(fs.readFileSync(p).toString().trim(), 'a');
+      it('reads a normal file with unpacked files', function() {
+        var p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt');
+        assert.equal(fs.readFileSync(p).toString().trim(), 'a');
       });
     });
 
     describe('fs.readFile', function() {
       it('reads a normal file', function(done) {
-        var p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'file1');
-        return fs.readFile(p, function(err, content) {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'file1');
+        fs.readFile(p, function(err, content) {
           assert.equal(err, null);
           assert.equal(String(content).trim(), 'file1');
-          return done();
+          done();
         });
       });
 
       it('reads from a empty file', function(done) {
-        var p;
-        p = path.join(fixtures, 'asar', 'empty.asar', 'file1');
-        return fs.readFile(p, function(err, content) {
+        var p = path.join(fixtures, 'asar', 'empty.asar', 'file1');
+        fs.readFile(p, function(err, content) {
           assert.equal(err, null);
           assert.equal(String(content), '');
-          return done();
+          done();
         });
       });
 
       it('reads a linked file', function(done) {
-        var p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'link1');
-        return fs.readFile(p, function(err, content) {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'link1');
+        fs.readFile(p, function(err, content) {
           assert.equal(err, null);
           assert.equal(String(content).trim(), 'file1');
-          return done();
+          done();
         });
       });
 
       it('reads a file from linked directory', function(done) {
-        var p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1');
-        return fs.readFile(p, function(err, content) {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1');
+        fs.readFile(p, function(err, content) {
           assert.equal(err, null);
           assert.equal(String(content).trim(), 'file1');
-          return done();
+          done();
         });
       });
 
-      return it('throws ENOENT error when can not find file', function(done) {
-        var p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
-        return fs.readFile(p, function(err) {
+      it('throws ENOENT error when can not find file', function(done) {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
+        fs.readFile(p, function(err) {
           assert.equal(err.code, 'ENOENT');
-          return done();
+          done();
         });
       });
     });
 
     describe('fs.lstatSync', function() {
       it('handles path with trailing slash correctly', function() {
-        var p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1');
+        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1');
         fs.lstatSync(p);
-        return fs.lstatSync(p + '/');
+        fs.lstatSync(p + '/');
       });
 
       it('returns information of root', function() {
@@ -147,7 +134,7 @@ describe('asar package', function() {
         assert.equal(stats.isFile(), false);
         assert.equal(stats.isDirectory(), true);
         assert.equal(stats.isSymbolicLink(), false);
-        return assert.equal(stats.size, 0);
+        assert.equal(stats.size, 0);
       });
 
       it('returns information of a normal file', function() {
@@ -163,7 +150,7 @@ describe('asar package', function() {
           assert.equal(stats.isSymbolicLink(), false);
           results.push(assert.equal(stats.size, 6));
         }
-        return results;
+        results;
       });
 
       it('returns information of a normal directory', function() {
@@ -179,7 +166,7 @@ describe('asar package', function() {
           assert.equal(stats.isSymbolicLink(), false);
           results.push(assert.equal(stats.size, 0));
         }
-        return results;
+        results;
       });
 
       it('returns information of a linked file', function() {
@@ -195,7 +182,7 @@ describe('asar package', function() {
           assert.equal(stats.isSymbolicLink(), true);
           results.push(assert.equal(stats.size, 0));
         }
-        return results;
+        results;
       });
 
       it('returns information of a linked directory', function() {
@@ -211,29 +198,27 @@ describe('asar package', function() {
           assert.equal(stats.isSymbolicLink(), true);
           results.push(assert.equal(stats.size, 0));
         }
-        return results;
+        results;
       });
 
-      return it('throws ENOENT error when can not find file', function() {
-        var file, j, len, p, ref2, results, throws;
+      it('throws ENOENT error when can not find file', function() {
+        var file, j, len, p, ref2, throws;
         ref2 = ['file4', 'file5', path.join('dir1', 'file4')];
-        results = [];
         for (j = 0, len = ref2.length; j < len; j++) {
           file = ref2[j];
           p = path.join(fixtures, 'asar', 'a.asar', file);
           throws = function() {
-            return fs.lstatSync(p);
+            fs.lstatSync(p);
           };
-          results.push(assert.throws(throws, /ENOENT/));
+          assert.throws(throws, /ENOENT/);
         }
-        return results;
       });
     });
 
     describe('fs.lstat', function() {
       it('handles path with trailing slash correctly', function(done) {
         var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1');
-        return fs.lstat(p + '/', done);
+        fs.lstat(p + '/', done);
       });
 
       it('returns information of root', function(done) {
@@ -244,7 +229,7 @@ describe('asar package', function() {
           assert.equal(stats.isDirectory(), true);
           assert.equal(stats.isSymbolicLink(), false);
           assert.equal(stats.size, 0);
-          return done();
+          done();
         });
       });
 
@@ -256,7 +241,7 @@ describe('asar package', function() {
           assert.equal(stats.isDirectory(), false);
           assert.equal(stats.isSymbolicLink(), false);
           assert.equal(stats.size, 6);
-          return done();
+          done();
         });
       });
 
@@ -268,7 +253,7 @@ describe('asar package', function() {
           assert.equal(stats.isDirectory(), true);
           assert.equal(stats.isSymbolicLink(), false);
           assert.equal(stats.size, 0);
-          return done();
+          done();
         });
       });
 
@@ -280,7 +265,7 @@ describe('asar package', function() {
           assert.equal(stats.isDirectory(), false);
           assert.equal(stats.isSymbolicLink(), true);
           assert.equal(stats.size, 0);
-          return done();
+          done();
         });
       });
 
@@ -292,15 +277,15 @@ describe('asar package', function() {
           assert.equal(stats.isDirectory(), false);
           assert.equal(stats.isSymbolicLink(), true);
           assert.equal(stats.size, 0);
-          return done();
+          done();
         });
       });
 
-      return it('throws ENOENT error when can not find file', function(done) {
+      it('throws ENOENT error when can not find file', function(done) {
         var p = path.join(fixtures, 'asar', 'a.asar', 'file4');
         fs.lstat(p, function(err) {
           assert.equal(err.code, 'ENOENT');
-          return done();
+          done();
         });
       });
     });
@@ -310,44 +295,44 @@ describe('asar package', function() {
         var parent = fs.realpathSync(path.join(fixtures, 'asar'));
         var p = 'a.asar';
         var r = fs.realpathSync(path.join(parent, p));
-        return assert.equal(r, path.join(parent, p));
+        assert.equal(r, path.join(parent, p));
       });
 
       it('returns real path of a normal file', function() {
         var parent = fs.realpathSync(path.join(fixtures, 'asar'));
         var p = path.join('a.asar', 'file1');
         var r = fs.realpathSync(path.join(parent, p));
-        return assert.equal(r, path.join(parent, p));
+        assert.equal(r, path.join(parent, p));
       });
 
       it('returns real path of a normal directory', function() {
         var parent = fs.realpathSync(path.join(fixtures, 'asar'));
         var p = path.join('a.asar', 'dir1');
         var r = fs.realpathSync(path.join(parent, p));
-        return assert.equal(r, path.join(parent, p));
+        assert.equal(r, path.join(parent, p));
       });
 
       it('returns real path of a linked file', function() {
         var parent = fs.realpathSync(path.join(fixtures, 'asar'));
         var p = path.join('a.asar', 'link2', 'link1');
         var r = fs.realpathSync(path.join(parent, p));
-        return assert.equal(r, path.join(parent, 'a.asar', 'file1'));
+        assert.equal(r, path.join(parent, 'a.asar', 'file1'));
       });
 
       it('returns real path of a linked directory', function() {
         var parent = fs.realpathSync(path.join(fixtures, 'asar'));
         var p = path.join('a.asar', 'link2', 'link2');
         var r = fs.realpathSync(path.join(parent, p));
-        return assert.equal(r, path.join(parent, 'a.asar', 'dir1'));
+        assert.equal(r, path.join(parent, 'a.asar', 'dir1'));
       });
 
-      return it('throws ENOENT error when can not find file', function() {
+      it('throws ENOENT error when can not find file', function() {
         var parent = fs.realpathSync(path.join(fixtures, 'asar'));
         var p = path.join('a.asar', 'not-exist');
         var throws = function() {
-          return fs.realpathSync(path.join(parent, p));
+          fs.realpathSync(path.join(parent, p));
         };
-        return assert.throws(throws, /ENOENT/);
+        assert.throws(throws, /ENOENT/);
       });
     });
 
@@ -355,58 +340,58 @@ describe('asar package', function() {
       it('returns real path root', function(done) {
         var parent = fs.realpathSync(path.join(fixtures, 'asar'));
         var p = 'a.asar';
-        return fs.realpath(path.join(parent, p), function(err, r) {
+        fs.realpath(path.join(parent, p), function(err, r) {
           assert.equal(err, null);
           assert.equal(r, path.join(parent, p));
-          return done();
+          done();
         });
       });
 
       it('returns real path of a normal file', function(done) {
         var parent = fs.realpathSync(path.join(fixtures, 'asar'));
         var p = path.join('a.asar', 'file1');
-        return fs.realpath(path.join(parent, p), function(err, r) {
+        fs.realpath(path.join(parent, p), function(err, r) {
           assert.equal(err, null);
           assert.equal(r, path.join(parent, p));
-          return done();
+          done();
         });
       });
 
       it('returns real path of a normal directory', function(done) {
         var parent = fs.realpathSync(path.join(fixtures, 'asar'));
         var p = path.join('a.asar', 'dir1');
-        return fs.realpath(path.join(parent, p), function(err, r) {
+        fs.realpath(path.join(parent, p), function(err, r) {
           assert.equal(err, null);
           assert.equal(r, path.join(parent, p));
-          return done();
+          done();
         });
       });
 
       it('returns real path of a linked file', function(done) {
         var parent = fs.realpathSync(path.join(fixtures, 'asar'));
         var p = path.join('a.asar', 'link2', 'link1');
-        return fs.realpath(path.join(parent, p), function(err, r) {
+        fs.realpath(path.join(parent, p), function(err, r) {
           assert.equal(err, null);
           assert.equal(r, path.join(parent, 'a.asar', 'file1'));
-          return done();
+          done();
         });
       });
 
       it('returns real path of a linked directory', function(done) {
         var parent = fs.realpathSync(path.join(fixtures, 'asar'));
         var p = path.join('a.asar', 'link2', 'link2');
-        return fs.realpath(path.join(parent, p), function(err, r) {
+        fs.realpath(path.join(parent, p), function(err, r) {
           assert.equal(err, null);
           assert.equal(r, path.join(parent, 'a.asar', 'dir1'));
-          return done();
+          done();
         });
       });
-      return it('throws ENOENT error when can not find file', function(done) {
+      it('throws ENOENT error when can not find file', function(done) {
         var parent = fs.realpathSync(path.join(fixtures, 'asar'));
         var p = path.join('a.asar', 'not-exist');
-        return fs.realpath(path.join(parent, p), function(err) {
+        fs.realpath(path.join(parent, p), function(err) {
           assert.equal(err.code, 'ENOENT');
-          return done();
+          done();
         });
       });
     });
@@ -414,27 +399,27 @@ describe('asar package', function() {
       it('reads dirs from root', function() {
         var p = path.join(fixtures, 'asar', 'a.asar');
         var dirs = fs.readdirSync(p);
-        return assert.deepEqual(dirs, ['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
+        assert.deepEqual(dirs, ['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
       });
 
       it('reads dirs from a normal dir', function() {
         var p = path.join(fixtures, 'asar', 'a.asar', 'dir1');
         var dirs = fs.readdirSync(p);
-        return assert.deepEqual(dirs, ['file1', 'file2', 'file3', 'link1', 'link2']);
+        assert.deepEqual(dirs, ['file1', 'file2', 'file3', 'link1', 'link2']);
       });
 
       it('reads dirs from a linked dir', function() {
         var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2');
         var dirs = fs.readdirSync(p);
-        return assert.deepEqual(dirs, ['file1', 'file2', 'file3', 'link1', 'link2']);
+        assert.deepEqual(dirs, ['file1', 'file2', 'file3', 'link1', 'link2']);
       });
 
-      return it('throws ENOENT error when can not find file', function() {
+      it('throws ENOENT error when can not find file', function() {
         var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
         var throws = function() {
-          return fs.readdirSync(p);
+          fs.readdirSync(p);
         };
-        return assert.throws(throws, /ENOENT/);
+        assert.throws(throws, /ENOENT/);
       });
     });
 
@@ -444,7 +429,7 @@ describe('asar package', function() {
         fs.readdir(p, function(err, dirs) {
           assert.equal(err, null);
           assert.deepEqual(dirs, ['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
-          return done();
+          done();
         });
       });
 
@@ -453,7 +438,7 @@ describe('asar package', function() {
         fs.readdir(p, function(err, dirs) {
           assert.equal(err, null);
           assert.deepEqual(dirs, ['file1', 'file2', 'file3', 'link1', 'link2']);
-          return done();
+          done();
         });
       });
       it('reads dirs from a linked dir', function(done) {
@@ -461,15 +446,15 @@ describe('asar package', function() {
         fs.readdir(p, function(err, dirs) {
           assert.equal(err, null);
           assert.deepEqual(dirs, ['file1', 'file2', 'file3', 'link1', 'link2']);
-          return done();
+          done();
         });
       });
 
-      return it('throws ENOENT error when can not find file', function(done) {
+      it('throws ENOENT error when can not find file', function(done) {
         var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
-        return fs.readdir(p, function(err) {
+        fs.readdir(p, function(err) {
           assert.equal(err.code, 'ENOENT');
-          return done();
+          done();
         });
       });
     });
@@ -478,7 +463,6 @@ describe('asar package', function() {
       it('opens a normal/linked/under-linked-directory file', function() {
         var buffer, fd, file, j, len, p, ref2, results;
         ref2 = ['file1', 'link1', path.join('link2', 'file1')];
-        results = [];
         for (j = 0, len = ref2.length; j < len; j++) {
           file = ref2[j];
           p = path.join(fixtures, 'asar', 'a.asar', file);
@@ -486,59 +470,57 @@ describe('asar package', function() {
           buffer = new Buffer(6);
           fs.readSync(fd, buffer, 0, 6, 0);
           assert.equal(String(buffer).trim(), 'file1');
-          results.push(fs.closeSync(fd));
+          fs.closeSync(fd);
         }
-        return results;
       });
 
-      return it('throws ENOENT error when can not find file', function() {
+      it('throws ENOENT error when can not find file', function() {
         var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
         var throws = function() {
-          return fs.openSync(p);
+          fs.openSync(p);
         };
-        return assert.throws(throws, /ENOENT/);
+        assert.throws(throws, /ENOENT/);
       });
     });
 
     describe('fs.open', function() {
       it('opens a normal file', function(done) {
         var p = path.join(fixtures, 'asar', 'a.asar', 'file1');
-        return fs.open(p, 'r', function(err, fd) {
-          var buffer;
+        fs.open(p, 'r', function(err, fd) {
           assert.equal(err, null);
-          buffer = new Buffer(6);
-          return fs.read(fd, buffer, 0, 6, 0, function(err) {
+          var buffer = new Buffer(6);
+          fs.read(fd, buffer, 0, 6, 0, function(err) {
             assert.equal(err, null);
             assert.equal(String(buffer).trim(), 'file1');
-            return fs.close(fd, done);
+            fs.close(fd, done);
           });
         });
       });
 
-      return it('throws ENOENT error when can not find file', function(done) {
+      it('throws ENOENT error when can not find file', function(done) {
         var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
-        return fs.open(p, 'r', function(err) {
+        fs.open(p, 'r', function(err) {
           assert.equal(err.code, 'ENOENT');
-          return done();
+          done();
         });
       });
     });
 
     describe('fs.mkdir', function() {
-      return it('throws error when calling inside asar archive', function(done) {
+      it('throws error when calling inside asar archive', function(done) {
         var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
-        return fs.mkdir(p, function(err) {
+        fs.mkdir(p, function(err) {
           assert.equal(err.code, 'ENOTDIR');
-          return done();
+          done();
         });
       });
     });
 
     describe('fs.mkdirSync', function() {
-      return it('throws error when calling inside asar archive', function() {
+      it('throws error when calling inside asar archive', function() {
         var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
-        return assert.throws((function() {
-          return fs.mkdirSync(p);
+        assert.throws((function() {
+          fs.mkdirSync(p);
         }), new RegExp('ENOTDIR'));
       });
     });
@@ -548,19 +530,19 @@ describe('asar package', function() {
         var child = child_process.fork(path.join(fixtures, 'asar', 'a.asar', 'ping.js'));
         child.on('message', function(msg) {
           assert.equal(msg, 'message');
-          return done();
+          done();
         });
-        return child.send('message');
+        child.send('message');
       });
 
-      return it('supports asar in the forked js', function(done) {
+      it('supports asar in the forked js', function(done) {
         var file = path.join(fixtures, 'asar', 'a.asar', 'file1');
         var child = child_process.fork(path.join(fixtures, 'module', 'asar.js'));
         child.on('message', function(content) {
           assert.equal(content, fs.readFileSync(file).toString());
-          return done();
+          done();
         });
-        return child.send(file);
+        child.send(file);
       });
     });
 
@@ -576,14 +558,13 @@ describe('asar package', function() {
         execFile(echo, ['test'], function(error, stdout) {
           assert.equal(error, null);
           assert.equal(stdout, 'test\n');
-          return done();
+          done();
         });
       });
 
-      return xit('execFileSync executes binaries', function() {
-        var output;
-        output = execFileSync(echo, ['test']);
-        return assert.equal(String(output), 'test\n');
+      xit('execFileSync executes binaries', function() {
+        var output = execFileSync(echo, ['test']);
+        assert.equal(String(output), 'test\n');
       });
     });
 
@@ -591,47 +572,45 @@ describe('asar package', function() {
       var internalModuleReadFile = process.binding('fs').internalModuleReadFile;
 
       it('read a normal file', function() {
-        var file1, file2, file3;
-        file1 = path.join(fixtures, 'asar', 'a.asar', 'file1');
+        var file1 = path.join(fixtures, 'asar', 'a.asar', 'file1');
         assert.equal(internalModuleReadFile(file1).toString().trim(), 'file1');
-        file2 = path.join(fixtures, 'asar', 'a.asar', 'file2');
+        var file2 = path.join(fixtures, 'asar', 'a.asar', 'file2');
         assert.equal(internalModuleReadFile(file2).toString().trim(), 'file2');
-        file3 = path.join(fixtures, 'asar', 'a.asar', 'file3');
-        return assert.equal(internalModuleReadFile(file3).toString().trim(), 'file3');
+        var file3 = path.join(fixtures, 'asar', 'a.asar', 'file3');
+        assert.equal(internalModuleReadFile(file3).toString().trim(), 'file3');
       });
 
-      return it('reads a normal file with unpacked files', function() {
-        var p;
-        p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt');
-        return assert.equal(internalModuleReadFile(p).toString().trim(), 'a');
+      it('reads a normal file with unpacked files', function() {
+        var p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt');
+        assert.equal(internalModuleReadFile(p).toString().trim(), 'a');
       });
     });
 
-    return describe('process.noAsar', function() {
+    describe('process.noAsar', function() {
       var errorName = process.platform === 'win32' ? 'ENOENT' : 'ENOTDIR';
 
       beforeEach(function() {
-        return process.noAsar = true;
+        process.noAsar = true;
       });
 
       afterEach(function() {
-        return process.noAsar = false;
+        process.noAsar = false;
       });
 
       it('disables asar support in sync API', function() {
         var file = path.join(fixtures, 'asar', 'a.asar', 'file1');
         var dir = path.join(fixtures, 'asar', 'a.asar', 'dir1');
         assert.throws((function() {
-          return fs.readFileSync(file);
+          fs.readFileSync(file);
         }), new RegExp(errorName));
         assert.throws((function() {
-          return fs.lstatSync(file);
+          fs.lstatSync(file);
         }), new RegExp(errorName));
         assert.throws((function() {
-          return fs.realpathSync(file);
+          fs.realpathSync(file);
         }), new RegExp(errorName));
-        return assert.throws((function() {
-          return fs.readdirSync(dir);
+        assert.throws((function() {
+          fs.readdirSync(dir);
         }), new RegExp(errorName));
       });
 
@@ -639,30 +618,29 @@ describe('asar package', function() {
         var dir, file;
         file = path.join(fixtures, 'asar', 'a.asar', 'file1');
         dir = path.join(fixtures, 'asar', 'a.asar', 'dir1');
-        return fs.readFile(file, function(error) {
+        fs.readFile(file, function(error) {
           assert.equal(error.code, errorName);
-          return fs.lstat(file, function(error) {
+          fs.lstat(file, function(error) {
             assert.equal(error.code, errorName);
-            return fs.realpath(file, function(error) {
+            fs.realpath(file, function(error) {
               assert.equal(error.code, errorName);
-              return fs.readdir(dir, function(error) {
+              fs.readdir(dir, function(error) {
                 assert.equal(error.code, errorName);
-                return done();
+                done();
               });
             });
           });
         });
       });
 
-      return it('treats *.asar as normal file', function() {
-        var asar, content1, content2, originalFs;
-        originalFs = require('original-fs');
-        asar = path.join(fixtures, 'asar', 'a.asar');
-        content1 = fs.readFileSync(asar);
-        content2 = originalFs.readFileSync(asar);
+      it('treats *.asar as normal file', function() {
+        var originalFs = require('original-fs');
+        var asar = path.join(fixtures, 'asar', 'a.asar');
+        var content1 = fs.readFileSync(asar);
+        var content2 = originalFs.readFileSync(asar);
         assert.equal(content1.compare(content2), 0);
-        return assert.throws((function() {
-          return fs.readdirSync(asar);
+        assert.throws((function() {
+          fs.readdirSync(asar);
         }), /ENOTDIR/);
       });
     });
@@ -673,43 +651,43 @@ describe('asar package', function() {
 
     it('can request a file in package', function(done) {
       var p = path.resolve(fixtures, 'asar', 'a.asar', 'file1');
-      return $.get("file://" + p, function(data) {
+      $.get("file://" + p, function(data) {
         assert.equal(data.trim(), 'file1');
-        return done();
+        done();
       });
     });
 
     it('can request a file in package with unpacked files', function(done) {
       var p = path.resolve(fixtures, 'asar', 'unpack.asar', 'a.txt');
-      return $.get("file://" + p, function(data) {
+      $.get("file://" + p, function(data) {
         assert.equal(data.trim(), 'a');
-        return done();
+        done();
       });
     });
 
     it('can request a linked file in package', function(done) {
       var p = path.resolve(fixtures, 'asar', 'a.asar', 'link2', 'link1');
-      return $.get("file://" + p, function(data) {
+      $.get("file://" + p, function(data) {
         assert.equal(data.trim(), 'file1');
-        return done();
+        done();
       });
     });
 
     it('can request a file in filesystem', function(done) {
       var p = path.resolve(fixtures, 'asar', 'file');
-      return $.get("file://" + p, function(data) {
+      $.get("file://" + p, function(data) {
         assert.equal(data.trim(), 'file');
-        return done();
+        done();
       });
     });
 
     it('gets 404 when file is not found', function(done) {
       var p = path.resolve(fixtures, 'asar', 'a.asar', 'no-exist');
-      return $.ajax({
+      $.ajax({
         url: "file://" + p,
         error: function(err) {
           assert.equal(err.status, 404);
-          return done();
+          done();
         }
       });
     });
@@ -717,7 +695,7 @@ describe('asar package', function() {
     it('sets __dirname correctly', function(done) {
       after(function() {
         w.destroy();
-        return ipcMain.removeAllListeners('dirname');
+        ipcMain.removeAllListeners('dirname');
       });
 
       var w = new BrowserWindow({
@@ -733,15 +711,15 @@ describe('asar package', function() {
       });
       ipcMain.once('dirname', function(event, dirname) {
         assert.equal(dirname, path.dirname(p));
-        return done();
+        done();
       });
-      return w.loadURL(u);
+      w.loadURL(u);
     });
 
-    return it('loads script tag in html', function(done) {
+    it('loads script tag in html', function(done) {
       after(function() {
         w.destroy();
-        return ipcMain.removeAllListeners('ping');
+        ipcMain.removeAllListeners('ping');
       });
 
       var w = new BrowserWindow({
@@ -756,9 +734,9 @@ describe('asar package', function() {
         pathname: p
       });
       w.loadURL(u);
-      return ipcMain.once('ping', function(event, message) {
+      ipcMain.once('ping', function(event, message) {
         assert.equal(message, 'pong');
-        return done();
+        done();
       });
     });
   });
@@ -770,17 +748,17 @@ describe('asar package', function() {
       var file, stats;
       file = path.join(fixtures, 'asar', 'a.asar');
       stats = originalFs.statSync(file);
-      return assert(stats.isFile());
+      assert(stats.isFile());
     });
 
-    return it('is available in forked scripts', function(done) {
+    it('is available in forked scripts', function(done) {
       var child;
       child = child_process.fork(path.join(fixtures, 'module', 'original-fs.js'));
       child.on('message', function(msg) {
         assert.equal(msg, 'object');
-        return done();
+        done();
       });
-      return child.send('message');
+      child.send('message');
     });
   });
 
@@ -788,41 +766,39 @@ describe('asar package', function() {
     var gfs = require('graceful-fs');
 
     it('recognize asar archvies', function() {
-      var p;
-      p = path.join(fixtures, 'asar', 'a.asar', 'link1');
-      return assert.equal(gfs.readFileSync(p).toString().trim(), 'file1');
+      var p = path.join(fixtures, 'asar', 'a.asar', 'link1');
+      assert.equal(gfs.readFileSync(p).toString().trim(), 'file1');
     });
-    return it('does not touch global fs object', function() {
-      return assert.notEqual(fs.readdir, gfs.readdir);
+    it('does not touch global fs object', function() {
+      assert.notEqual(fs.readdir, gfs.readdir);
     });
   });
 
   describe('mkdirp module', function() {
     var mkdirp = require('mkdirp');
 
-    return it('throws error when calling inside asar archive', function() {
-      var p;
-      p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
-      return assert.throws((function() {
-        return mkdirp.sync(p);
+    it('throws error when calling inside asar archive', function() {
+      var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
+      assert.throws((function() {
+        mkdirp.sync(p);
       }), new RegExp('ENOTDIR'));
     });
   });
 
-  return describe('native-image', function() {
+  describe('native-image', function() {
     it('reads image from asar archive', function() {
       var p = path.join(fixtures, 'asar', 'logo.asar', 'logo.png');
       var logo = nativeImage.createFromPath(p);
-      return assert.deepEqual(logo.getSize(), {
+      assert.deepEqual(logo.getSize(), {
         width: 55,
         height: 55
       });
     });
 
-    return it('reads image from asar archive with unpacked files', function() {
+    it('reads image from asar archive with unpacked files', function() {
       var p = path.join(fixtures, 'asar', 'unpack.asar', 'atom.png');
       var logo = nativeImage.createFromPath(p);
-      return assert.deepEqual(logo.getSize(), {
+      assert.deepEqual(logo.getSize(), {
         width: 1024,
         height: 1024
       });

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -10,8 +10,8 @@ const ipcMain = remote.require('electron').ipcMain;
 const BrowserWindow = remote.require('electron').BrowserWindow;
 
 describe('asar package', function() {
-  var fixtures;
-  fixtures = path.join(__dirname, 'fixtures');
+  var fixtures = path.join(__dirname, 'fixtures');
+
   describe('node api', function() {
     describe('fs.readFileSync', function() {
       it('does not leak fd', function() {
@@ -21,6 +21,7 @@ describe('asar package', function() {
           readCalls++;
         }
       });
+
       it('reads a normal file', function() {
         var file1, file2, file3;
         file1 = path.join(fixtures, 'asar', 'a.asar', 'file1');
@@ -30,6 +31,7 @@ describe('asar package', function() {
         file3 = path.join(fixtures, 'asar', 'a.asar', 'file3');
         return assert.equal(fs.readFileSync(file3).toString().trim(), 'file3');
       });
+
       it('reads from a empty file', function() {
         var buffer, file;
         file = path.join(fixtures, 'asar', 'empty.asar', 'file1');
@@ -37,11 +39,13 @@ describe('asar package', function() {
         assert.equal(buffer.length, 0);
         return assert.equal(buffer.toString(), '');
       });
+
       it('reads a linked file', function() {
         var p;
         p = path.join(fixtures, 'asar', 'a.asar', 'link1');
         return assert.equal(fs.readFileSync(p).toString().trim(), 'file1');
       });
+
       it('reads a file from linked directory', function() {
         var p;
         p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'file1');
@@ -49,6 +53,7 @@ describe('asar package', function() {
         p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1');
         return assert.equal(fs.readFileSync(p).toString().trim(), 'file1');
       });
+
       it('throws ENOENT error when can not find file', function() {
         var p, throws;
         p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
@@ -57,6 +62,7 @@ describe('asar package', function() {
         };
         return assert.throws(throws, /ENOENT/);
       });
+
       it('passes ENOENT error to callback when can not find file', function() {
         var async, p;
         p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
@@ -67,12 +73,14 @@ describe('asar package', function() {
         });
         return async = true;
       });
+
       return it('reads a normal file with unpacked files', function() {
         var p;
         p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt');
         return assert.equal(fs.readFileSync(p).toString().trim(), 'a');
       });
     });
+
     describe('fs.readFile', function() {
       it('reads a normal file', function(done) {
         var p;
@@ -83,6 +91,7 @@ describe('asar package', function() {
           return done();
         });
       });
+
       it('reads from a empty file', function(done) {
         var p;
         p = path.join(fixtures, 'asar', 'empty.asar', 'file1');
@@ -92,6 +101,7 @@ describe('asar package', function() {
           return done();
         });
       });
+
       it('reads a linked file', function(done) {
         var p;
         p = path.join(fixtures, 'asar', 'a.asar', 'link1');
@@ -101,6 +111,7 @@ describe('asar package', function() {
           return done();
         });
       });
+
       it('reads a file from linked directory', function(done) {
         var p;
         p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1');
@@ -110,6 +121,7 @@ describe('asar package', function() {
           return done();
         });
       });
+
       return it('throws ENOENT error when can not find file', function(done) {
         var p;
         p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
@@ -119,6 +131,7 @@ describe('asar package', function() {
         });
       });
     });
+
     describe('fs.lstatSync', function() {
       it('handles path with trailing slash correctly', function() {
         var p;
@@ -126,6 +139,7 @@ describe('asar package', function() {
         fs.lstatSync(p);
         return fs.lstatSync(p + '/');
       });
+
       it('returns information of root', function() {
         var p, stats;
         p = path.join(fixtures, 'asar', 'a.asar');
@@ -135,6 +149,7 @@ describe('asar package', function() {
         assert.equal(stats.isSymbolicLink(), false);
         return assert.equal(stats.size, 0);
       });
+
       it('returns information of a normal file', function() {
         var file, j, len, p, ref2, results, stats;
         ref2 = ['file1', 'file2', 'file3', path.join('dir1', 'file1'), path.join('link2', 'file1')];
@@ -150,6 +165,7 @@ describe('asar package', function() {
         }
         return results;
       });
+
       it('returns information of a normal directory', function() {
         var file, j, len, p, ref2, results, stats;
         ref2 = ['dir1', 'dir2', 'dir3'];
@@ -165,6 +181,7 @@ describe('asar package', function() {
         }
         return results;
       });
+
       it('returns information of a linked file', function() {
         var file, j, len, p, ref2, results, stats;
         ref2 = ['link1', path.join('dir1', 'link1'), path.join('link2', 'link2')];
@@ -180,6 +197,7 @@ describe('asar package', function() {
         }
         return results;
       });
+
       it('returns information of a linked directory', function() {
         var file, j, len, p, ref2, results, stats;
         ref2 = ['link2', path.join('dir1', 'link2'), path.join('link2', 'link2')];
@@ -195,6 +213,7 @@ describe('asar package', function() {
         }
         return results;
       });
+
       return it('throws ENOENT error when can not find file', function() {
         var file, j, len, p, ref2, results, throws;
         ref2 = ['file4', 'file5', path.join('dir1', 'file4')];
@@ -210,12 +229,13 @@ describe('asar package', function() {
         return results;
       });
     });
+
     describe('fs.lstat', function() {
       it('handles path with trailing slash correctly', function(done) {
-        var p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1');
+        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2', 'file1');
         return fs.lstat(p + '/', done);
       });
+
       it('returns information of root', function(done) {
         var p = path.join(fixtures, 'asar', 'a.asar');
         fs.lstat(p, function(err, stats) {
@@ -227,6 +247,7 @@ describe('asar package', function() {
           return done();
         });
       });
+
       it('returns information of a normal file', function(done) {
         var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'file1');
         fs.lstat(p, function(err, stats) {
@@ -238,6 +259,7 @@ describe('asar package', function() {
           return done();
         });
       });
+
       it('returns information of a normal directory', function(done) {
         var p = path.join(fixtures, 'asar', 'a.asar', 'dir1');
         fs.lstat(p, function(err, stats) {
@@ -249,6 +271,7 @@ describe('asar package', function() {
           return done();
         });
       });
+
       it('returns information of a linked file', function(done) {
         var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link1');
         fs.lstat(p, function(err, stats) {
@@ -260,6 +283,7 @@ describe('asar package', function() {
           return done();
         });
       });
+
       it('returns information of a linked directory', function(done) {
         var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2');
         fs.lstat(p, function(err, stats) {
@@ -271,6 +295,7 @@ describe('asar package', function() {
           return done();
         });
       });
+
       return it('throws ENOENT error when can not find file', function(done) {
         var p = path.join(fixtures, 'asar', 'a.asar', 'file4');
         fs.lstat(p, function(err) {
@@ -279,97 +304,97 @@ describe('asar package', function() {
         });
       });
     });
+
     describe('fs.realpathSync', function() {
       it('returns real path root', function() {
-        var p, parent, r;
-        parent = fs.realpathSync(path.join(fixtures, 'asar'));
-        p = 'a.asar';
-        r = fs.realpathSync(path.join(parent, p));
+        var parent = fs.realpathSync(path.join(fixtures, 'asar'));
+        var p = 'a.asar';
+        var r = fs.realpathSync(path.join(parent, p));
         return assert.equal(r, path.join(parent, p));
       });
+
       it('returns real path of a normal file', function() {
-        var p, parent, r;
-        parent = fs.realpathSync(path.join(fixtures, 'asar'));
-        p = path.join('a.asar', 'file1');
-        r = fs.realpathSync(path.join(parent, p));
+        var parent = fs.realpathSync(path.join(fixtures, 'asar'));
+        var p = path.join('a.asar', 'file1');
+        var r = fs.realpathSync(path.join(parent, p));
         return assert.equal(r, path.join(parent, p));
       });
+
       it('returns real path of a normal directory', function() {
-        var p, parent, r;
-        parent = fs.realpathSync(path.join(fixtures, 'asar'));
-        p = path.join('a.asar', 'dir1');
-        r = fs.realpathSync(path.join(parent, p));
+        var parent = fs.realpathSync(path.join(fixtures, 'asar'));
+        var p = path.join('a.asar', 'dir1');
+        var r = fs.realpathSync(path.join(parent, p));
         return assert.equal(r, path.join(parent, p));
       });
+
       it('returns real path of a linked file', function() {
-        var p, parent, r;
-        parent = fs.realpathSync(path.join(fixtures, 'asar'));
-        p = path.join('a.asar', 'link2', 'link1');
-        r = fs.realpathSync(path.join(parent, p));
+        var parent = fs.realpathSync(path.join(fixtures, 'asar'));
+        var p = path.join('a.asar', 'link2', 'link1');
+        var r = fs.realpathSync(path.join(parent, p));
         return assert.equal(r, path.join(parent, 'a.asar', 'file1'));
       });
+
       it('returns real path of a linked directory', function() {
-        var p, parent, r;
-        parent = fs.realpathSync(path.join(fixtures, 'asar'));
-        p = path.join('a.asar', 'link2', 'link2');
-        r = fs.realpathSync(path.join(parent, p));
+        var parent = fs.realpathSync(path.join(fixtures, 'asar'));
+        var p = path.join('a.asar', 'link2', 'link2');
+        var r = fs.realpathSync(path.join(parent, p));
         return assert.equal(r, path.join(parent, 'a.asar', 'dir1'));
       });
+
       return it('throws ENOENT error when can not find file', function() {
-        var p, parent, throws;
-        parent = fs.realpathSync(path.join(fixtures, 'asar'));
-        p = path.join('a.asar', 'not-exist');
-        throws = function() {
+        var parent = fs.realpathSync(path.join(fixtures, 'asar'));
+        var p = path.join('a.asar', 'not-exist');
+        var throws = function() {
           return fs.realpathSync(path.join(parent, p));
         };
         return assert.throws(throws, /ENOENT/);
       });
     });
+
     describe('fs.realpath', function() {
       it('returns real path root', function(done) {
-        var p, parent;
-        parent = fs.realpathSync(path.join(fixtures, 'asar'));
-        p = 'a.asar';
+        var parent = fs.realpathSync(path.join(fixtures, 'asar'));
+        var p = 'a.asar';
         return fs.realpath(path.join(parent, p), function(err, r) {
           assert.equal(err, null);
           assert.equal(r, path.join(parent, p));
           return done();
         });
       });
+
       it('returns real path of a normal file', function(done) {
-        var p, parent;
-        parent = fs.realpathSync(path.join(fixtures, 'asar'));
-        p = path.join('a.asar', 'file1');
+        var parent = fs.realpathSync(path.join(fixtures, 'asar'));
+        var p = path.join('a.asar', 'file1');
         return fs.realpath(path.join(parent, p), function(err, r) {
           assert.equal(err, null);
           assert.equal(r, path.join(parent, p));
           return done();
         });
       });
+
       it('returns real path of a normal directory', function(done) {
-        var p, parent;
-        parent = fs.realpathSync(path.join(fixtures, 'asar'));
-        p = path.join('a.asar', 'dir1');
+        var parent = fs.realpathSync(path.join(fixtures, 'asar'));
+        var p = path.join('a.asar', 'dir1');
         return fs.realpath(path.join(parent, p), function(err, r) {
           assert.equal(err, null);
           assert.equal(r, path.join(parent, p));
           return done();
         });
       });
+
       it('returns real path of a linked file', function(done) {
-        var p, parent;
-        parent = fs.realpathSync(path.join(fixtures, 'asar'));
-        p = path.join('a.asar', 'link2', 'link1');
+        var parent = fs.realpathSync(path.join(fixtures, 'asar'));
+        var p = path.join('a.asar', 'link2', 'link1');
         return fs.realpath(path.join(parent, p), function(err, r) {
           assert.equal(err, null);
           assert.equal(r, path.join(parent, 'a.asar', 'file1'));
           return done();
         });
       });
+
       it('returns real path of a linked directory', function(done) {
-        var p, parent;
-        parent = fs.realpathSync(path.join(fixtures, 'asar'));
-        p = path.join('a.asar', 'link2', 'link2');
+        var parent = fs.realpathSync(path.join(fixtures, 'asar'));
+        var p = path.join('a.asar', 'link2', 'link2');
         return fs.realpath(path.join(parent, p), function(err, r) {
           assert.equal(err, null);
           assert.equal(r, path.join(parent, 'a.asar', 'dir1'));
@@ -377,9 +402,8 @@ describe('asar package', function() {
         });
       });
       return it('throws ENOENT error when can not find file', function(done) {
-        var p, parent;
-        parent = fs.realpathSync(path.join(fixtures, 'asar'));
-        p = path.join('a.asar', 'not-exist');
+        var parent = fs.realpathSync(path.join(fixtures, 'asar'));
+        var p = path.join('a.asar', 'not-exist');
         return fs.realpath(path.join(parent, p), function(err) {
           assert.equal(err.code, 'ENOENT');
           return done();
@@ -388,32 +412,32 @@ describe('asar package', function() {
     });
     describe('fs.readdirSync', function() {
       it('reads dirs from root', function() {
-        var dirs, p;
-        p = path.join(fixtures, 'asar', 'a.asar');
-        dirs = fs.readdirSync(p);
+        var p = path.join(fixtures, 'asar', 'a.asar');
+        var dirs = fs.readdirSync(p);
         return assert.deepEqual(dirs, ['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
       });
+
       it('reads dirs from a normal dir', function() {
-        var dirs, p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'dir1');
-        dirs = fs.readdirSync(p);
+        var p = path.join(fixtures, 'asar', 'a.asar', 'dir1');
+        var dirs = fs.readdirSync(p);
         return assert.deepEqual(dirs, ['file1', 'file2', 'file3', 'link1', 'link2']);
       });
+
       it('reads dirs from a linked dir', function() {
-        var dirs, p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2');
-        dirs = fs.readdirSync(p);
+        var p = path.join(fixtures, 'asar', 'a.asar', 'link2', 'link2');
+        var dirs = fs.readdirSync(p);
         return assert.deepEqual(dirs, ['file1', 'file2', 'file3', 'link1', 'link2']);
       });
+
       return it('throws ENOENT error when can not find file', function() {
-        var p, throws;
-        p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
-        throws = function() {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
+        var throws = function() {
           return fs.readdirSync(p);
         };
         return assert.throws(throws, /ENOENT/);
       });
     });
+
     describe('fs.readdir', function() {
       it('reads dirs from root', function(done) {
         var p = path.join(fixtures, 'asar', 'a.asar');
@@ -423,6 +447,7 @@ describe('asar package', function() {
           return done();
         });
       });
+
       it('reads dirs from a normal dir', function(done) {
         var p = path.join(fixtures, 'asar', 'a.asar', 'dir1');
         fs.readdir(p, function(err, dirs) {
@@ -439,15 +464,16 @@ describe('asar package', function() {
           return done();
         });
       });
+
       return it('throws ENOENT error when can not find file', function(done) {
-        var p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
+        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
         return fs.readdir(p, function(err) {
           assert.equal(err.code, 'ENOENT');
           return done();
         });
       });
     });
+
     describe('fs.openSync', function() {
       it('opens a normal/linked/under-linked-directory file', function() {
         var buffer, fd, file, j, len, p, ref2, results;
@@ -464,19 +490,19 @@ describe('asar package', function() {
         }
         return results;
       });
+
       return it('throws ENOENT error when can not find file', function() {
-        var p, throws;
-        p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
-        throws = function() {
+        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
+        var throws = function() {
           return fs.openSync(p);
         };
         return assert.throws(throws, /ENOENT/);
       });
     });
+
     describe('fs.open', function() {
       it('opens a normal file', function(done) {
-        var p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'file1');
+        var p = path.join(fixtures, 'asar', 'a.asar', 'file1');
         return fs.open(p, 'r', function(err, fd) {
           var buffer;
           assert.equal(err, null);
@@ -488,48 +514,48 @@ describe('asar package', function() {
           });
         });
       });
+
       return it('throws ENOENT error when can not find file', function(done) {
-        var p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
+        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
         return fs.open(p, 'r', function(err) {
           assert.equal(err.code, 'ENOENT');
           return done();
         });
       });
     });
+
     describe('fs.mkdir', function() {
       return it('throws error when calling inside asar archive', function(done) {
-        var p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
+        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
         return fs.mkdir(p, function(err) {
           assert.equal(err.code, 'ENOTDIR');
           return done();
         });
       });
     });
+
     describe('fs.mkdirSync', function() {
       return it('throws error when calling inside asar archive', function() {
-        var p;
-        p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
+        var p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
         return assert.throws((function() {
           return fs.mkdirSync(p);
         }), new RegExp('ENOTDIR'));
       });
     });
+
     describe('child_process.fork', function() {
       it('opens a normal js file', function(done) {
-        var child;
-        child = child_process.fork(path.join(fixtures, 'asar', 'a.asar', 'ping.js'));
+        var child = child_process.fork(path.join(fixtures, 'asar', 'a.asar', 'ping.js'));
         child.on('message', function(msg) {
           assert.equal(msg, 'message');
           return done();
         });
         return child.send('message');
       });
+
       return it('supports asar in the forked js', function(done) {
-        var child, file;
-        file = path.join(fixtures, 'asar', 'a.asar', 'file1');
-        child = child_process.fork(path.join(fixtures, 'module', 'asar.js'));
+        var file = path.join(fixtures, 'asar', 'a.asar', 'file1');
+        var child = child_process.fork(path.join(fixtures, 'module', 'asar.js'));
         child.on('message', function(content) {
           assert.equal(content, fs.readFileSync(file).toString());
           return done();
@@ -537,6 +563,7 @@ describe('asar package', function() {
         return child.send(file);
       });
     });
+
     describe('child_process.execFile', function() {
       var echo, execFile, execFileSync, ref2;
       if (process.platform !== 'darwin') {
@@ -544,6 +571,7 @@ describe('asar package', function() {
       }
       ref2 = require('child_process'), execFile = ref2.execFile, execFileSync = ref2.execFileSync;
       echo = path.join(fixtures, 'asar', 'echo.asar', 'echo');
+
       it('executes binaries', function(done) {
         execFile(echo, ['test'], function(error, stdout) {
           assert.equal(error, null);
@@ -551,15 +579,17 @@ describe('asar package', function() {
           return done();
         });
       });
+
       return xit('execFileSync executes binaries', function() {
         var output;
         output = execFileSync(echo, ['test']);
         return assert.equal(String(output), 'test\n');
       });
     });
+
     describe('internalModuleReadFile', function() {
-      var internalModuleReadFile;
-      internalModuleReadFile = process.binding('fs').internalModuleReadFile;
+      var internalModuleReadFile = process.binding('fs').internalModuleReadFile;
+
       it('read a normal file', function() {
         var file1, file2, file3;
         file1 = path.join(fixtures, 'asar', 'a.asar', 'file1');
@@ -569,25 +599,28 @@ describe('asar package', function() {
         file3 = path.join(fixtures, 'asar', 'a.asar', 'file3');
         return assert.equal(internalModuleReadFile(file3).toString().trim(), 'file3');
       });
+
       return it('reads a normal file with unpacked files', function() {
         var p;
         p = path.join(fixtures, 'asar', 'unpack.asar', 'a.txt');
         return assert.equal(internalModuleReadFile(p).toString().trim(), 'a');
       });
     });
+
     return describe('process.noAsar', function() {
-      var errorName;
-      errorName = process.platform === 'win32' ? 'ENOENT' : 'ENOTDIR';
+      var errorName = process.platform === 'win32' ? 'ENOENT' : 'ENOTDIR';
+
       beforeEach(function() {
         return process.noAsar = true;
       });
+
       afterEach(function() {
         return process.noAsar = false;
       });
+
       it('disables asar support in sync API', function() {
-        var dir, file;
-        file = path.join(fixtures, 'asar', 'a.asar', 'file1');
-        dir = path.join(fixtures, 'asar', 'a.asar', 'dir1');
+        var file = path.join(fixtures, 'asar', 'a.asar', 'file1');
+        var dir = path.join(fixtures, 'asar', 'a.asar', 'dir1');
         assert.throws((function() {
           return fs.readFileSync(file);
         }), new RegExp(errorName));
@@ -601,6 +634,7 @@ describe('asar package', function() {
           return fs.readdirSync(dir);
         }), new RegExp(errorName));
       });
+
       it('disables asar support in async API', function(done) {
         var dir, file;
         file = path.join(fixtures, 'asar', 'a.asar', 'file1');
@@ -619,6 +653,7 @@ describe('asar package', function() {
           });
         });
       });
+
       return it('treats *.asar as normal file', function() {
         var asar, content1, content2, originalFs;
         originalFs = require('original-fs');
@@ -632,44 +667,44 @@ describe('asar package', function() {
       });
     });
   });
+
   describe('asar protocol', function() {
-    var url;
-    url = require('url');
+    var url = require('url');
+
     it('can request a file in package', function(done) {
-      var p;
-      p = path.resolve(fixtures, 'asar', 'a.asar', 'file1');
+      var p = path.resolve(fixtures, 'asar', 'a.asar', 'file1');
       return $.get("file://" + p, function(data) {
         assert.equal(data.trim(), 'file1');
         return done();
       });
     });
+
     it('can request a file in package with unpacked files', function(done) {
-      var p;
-      p = path.resolve(fixtures, 'asar', 'unpack.asar', 'a.txt');
+      var p = path.resolve(fixtures, 'asar', 'unpack.asar', 'a.txt');
       return $.get("file://" + p, function(data) {
         assert.equal(data.trim(), 'a');
         return done();
       });
     });
+
     it('can request a linked file in package', function(done) {
-      var p;
-      p = path.resolve(fixtures, 'asar', 'a.asar', 'link2', 'link1');
+      var p = path.resolve(fixtures, 'asar', 'a.asar', 'link2', 'link1');
       return $.get("file://" + p, function(data) {
         assert.equal(data.trim(), 'file1');
         return done();
       });
     });
+
     it('can request a file in filesystem', function(done) {
-      var p;
-      p = path.resolve(fixtures, 'asar', 'file');
+      var p = path.resolve(fixtures, 'asar', 'file');
       return $.get("file://" + p, function(data) {
         assert.equal(data.trim(), 'file');
         return done();
       });
     });
+
     it('gets 404 when file is not found', function(done) {
-      var p;
-      p = path.resolve(fixtures, 'asar', 'a.asar', 'no-exist');
+      var p = path.resolve(fixtures, 'asar', 'a.asar', 'no-exist');
       return $.ajax({
         url: "file://" + p,
         error: function(err) {
@@ -678,19 +713,20 @@ describe('asar package', function() {
         }
       });
     });
+
     it('sets __dirname correctly', function(done) {
-      var p, u, w;
       after(function() {
         w.destroy();
         return ipcMain.removeAllListeners('dirname');
       });
-      w = new BrowserWindow({
+
+      var w = new BrowserWindow({
         show: false,
         width: 400,
         height: 400
       });
-      p = path.resolve(fixtures, 'asar', 'web.asar', 'index.html');
-      u = url.format({
+      var p = path.resolve(fixtures, 'asar', 'web.asar', 'index.html');
+      var u = url.format({
         protocol: 'file',
         slashed: true,
         pathname: p
@@ -701,19 +737,20 @@ describe('asar package', function() {
       });
       return w.loadURL(u);
     });
+
     return it('loads script tag in html', function(done) {
-      var p, u, w;
       after(function() {
         w.destroy();
         return ipcMain.removeAllListeners('ping');
       });
-      w = new BrowserWindow({
+
+      var w = new BrowserWindow({
         show: false,
         width: 400,
         height: 400
       });
-      p = path.resolve(fixtures, 'asar', 'script.asar', 'index.html');
-      u = url.format({
+      var p = path.resolve(fixtures, 'asar', 'script.asar', 'index.html');
+      var u = url.format({
         protocol: 'file',
         slashed: true,
         pathname: p
@@ -725,15 +762,17 @@ describe('asar package', function() {
       });
     });
   });
+
   describe('original-fs module', function() {
-    var originalFs;
-    originalFs = require('original-fs');
+    var originalFs = require('original-fs');
+
     it('treats .asar as file', function() {
       var file, stats;
       file = path.join(fixtures, 'asar', 'a.asar');
       stats = originalFs.statSync(file);
       return assert(stats.isFile());
     });
+
     return it('is available in forked scripts', function(done) {
       var child;
       child = child_process.fork(path.join(fixtures, 'module', 'original-fs.js'));
@@ -744,9 +783,10 @@ describe('asar package', function() {
       return child.send('message');
     });
   });
+
   describe('graceful-fs module', function() {
-    var gfs;
-    gfs = require('graceful-fs');
+    var gfs = require('graceful-fs');
+
     it('recognize asar archvies', function() {
       var p;
       p = path.join(fixtures, 'asar', 'a.asar', 'link1');
@@ -756,9 +796,10 @@ describe('asar package', function() {
       return assert.notEqual(fs.readdir, gfs.readdir);
     });
   });
+
   describe('mkdirp module', function() {
-    var mkdirp;
-    mkdirp = require('mkdirp');
+    var mkdirp = require('mkdirp');
+
     return it('throws error when calling inside asar archive', function() {
       var p;
       p = path.join(fixtures, 'asar', 'a.asar', 'not-exist');
@@ -767,20 +808,20 @@ describe('asar package', function() {
       }), new RegExp('ENOTDIR'));
     });
   });
+
   return describe('native-image', function() {
     it('reads image from asar archive', function() {
-      var logo, p;
-      p = path.join(fixtures, 'asar', 'logo.asar', 'logo.png');
-      logo = nativeImage.createFromPath(p);
+      var p = path.join(fixtures, 'asar', 'logo.asar', 'logo.png');
+      var logo = nativeImage.createFromPath(p);
       return assert.deepEqual(logo.getSize(), {
         width: 55,
         height: 55
       });
     });
+
     return it('reads image from asar archive with unpacked files', function() {
-      var logo, p;
-      p = path.join(fixtures, 'asar', 'unpack.asar', 'atom.png');
-      logo = nativeImage.createFromPath(p);
+      var p = path.join(fixtures, 'asar', 'unpack.asar', 'atom.png');
+      var logo = nativeImage.createFromPath(p);
       return assert.deepEqual(logo.getSize(), {
         width: 1024,
         height: 1024

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -15,28 +15,27 @@ describe('chromium feature', function() {
     if (listener != null) {
       window.removeEventListener('message', listener);
     }
-    return listener = null;
+    listener = null;
   });
 
   xdescribe('heap snapshot', function() {
-    return it('does not crash', function() {
-      return process.atomBinding('v8_util').takeHeapSnapshot();
+    it('does not crash', function() {
+      process.atomBinding('v8_util').takeHeapSnapshot();
     });
   });
 
   describe('sending request of http protocol urls', function() {
-    return it('does not crash', function(done) {
-      var server;
+    it('does not crash', function(done) {
       this.timeout(5000);
-      server = http.createServer(function(req, res) {
+
+      var server = http.createServer(function(req, res) {
         res.end();
         server.close();
-        return done();
+        done();
       });
-      return server.listen(0, '127.0.0.1', function() {
-        var port;
-        port = server.address().port;
-        return $.get("http://127.0.0.1:" + port);
+      server.listen(0, '127.0.0.1', function() {
+        var port = server.address().port;
+        $.get("http://127.0.0.1:" + port);
       });
     });
   });
@@ -46,7 +45,7 @@ describe('chromium feature', function() {
     var w = null;
 
     afterEach(function() {
-      return w != null ? w.destroy() : void 0;
+      w != null ? w.destroy() : void 0;
     });
 
     it('is set correctly when window is not shown', function(done) {
@@ -55,41 +54,42 @@ describe('chromium feature', function() {
       });
       w.webContents.on('ipc-message', function(event, args) {
         assert.deepEqual(args, ['hidden', true]);
-        return done();
+        done();
       });
-      return w.loadURL(url);
+      w.loadURL(url);
     });
 
-    return it('is set correctly when window is inactive', function(done) {
+    it('is set correctly when window is inactive', function(done) {
       w = new BrowserWindow({
         show: false
       });
       w.webContents.on('ipc-message', function(event, args) {
         assert.deepEqual(args, ['hidden', false]);
-        return done();
+        done();
       });
       w.showInactive();
-      return w.loadURL(url);
+      w.loadURL(url);
     });
   });
 
   xdescribe('navigator.webkitGetUserMedia', function() {
-    return it('calls its callbacks', function(done) {
+    it('calls its callbacks', function(done) {
       this.timeout(5000);
-      return navigator.webkitGetUserMedia({
+
+      navigator.webkitGetUserMedia({
         audio: true,
         video: false
       }, function() {
-        return done();
+        done();
       }, function() {
-        return done();
+        done();
       });
     });
   });
 
   describe('navigator.language', function() {
-    return it('should not be empty', function() {
-      return assert.notEqual(navigator.language, '');
+    it('should not be empty', function() {
+      assert.notEqual(navigator.language, '');
     });
   });
 
@@ -98,28 +98,28 @@ describe('chromium feature', function() {
     var w = null;
 
     afterEach(function() {
-      return w != null ? w.destroy() : void 0;
+      w != null ? w.destroy() : void 0;
     });
 
-    return it('should register for file scheme', function(done) {
+    it('should register for file scheme', function(done) {
       w = new BrowserWindow({
         show: false
       });
       w.webContents.on('ipc-message', function(event, args) {
         if (args[0] === 'reload') {
-          return w.webContents.reload();
+          w.webContents.reload();
         } else if (args[0] === 'error') {
-          return done('unexpected error : ' + args[1]);
+          done('unexpected error : ' + args[1]);
         } else if (args[0] === 'response') {
           assert.equal(args[1], 'Hello from serviceWorker!');
-          return session.defaultSession.clearStorageData({
+          session.defaultSession.clearStorageData({
             storages: ['serviceworkers']
           }, function() {
-            return done();
+            done();
           });
         }
       });
-      return w.loadURL(url);
+      sw.loadURL(url);
     });
   });
 
@@ -127,11 +127,10 @@ describe('chromium feature', function() {
     this.timeout(20000);
 
     it('returns a BrowserWindowProxy object', function() {
-      var b;
-      b = window.open('about:blank', '', 'show=no');
+      var b = window.open('about:blank', '', 'show=no');
       assert.equal(b.closed, false);
       assert.equal(b.constructor.name, 'BrowserWindowProxy');
-      return b.close();
+      b.close();
     });
 
     it('accepts "node-integration" as feature', function(done) {
@@ -139,10 +138,10 @@ describe('chromium feature', function() {
       listener = function(event) {
         assert.equal(event.data, 'undefined');
         b.close();
-        return done();
+        done();
       };
       window.addEventListener('message', listener);
-      return b = window.open("file://" + fixtures + "/pages/window-opener-node.html", '', 'nodeIntegration=no,show=no');
+      b = window.open("file://" + fixtures + "/pages/window-opener-node.html", '', 'nodeIntegration=no,show=no');
     });
 
     it('inherit options of parent window', function(done) {
@@ -152,13 +151,13 @@ describe('chromium feature', function() {
         ref1 = remote.getCurrentWindow().getSize(), width = ref1[0], height = ref1[1];
         assert.equal(event.data, "size: " + width + " " + height);
         b.close();
-        return done();
+        done();
       };
       window.addEventListener('message', listener);
-      return b = window.open("file://" + fixtures + "/pages/window-open-size.html", '', 'show=no');
+      b = window.open("file://" + fixtures + "/pages/window-open-size.html", '', 'show=no');
     });
 
-    return it('does not override child options', function(done) {
+    it('does not override child options', function(done) {
       var b, size;
       size = {
         width: 350,
@@ -167,45 +166,48 @@ describe('chromium feature', function() {
       listener = function(event) {
         assert.equal(event.data, "size: " + size.width + " " + size.height);
         b.close();
-        return done();
+        done();
       };
       window.addEventListener('message', listener);
-      return b = window.open("file://" + fixtures + "/pages/window-open-size.html", '', "show=no,width=" + size.width + ",height=" + size.height);
+      b = window.open("file://" + fixtures + "/pages/window-open-size.html", '', "show=no,width=" + size.width + ",height=" + size.height);
     });
   });
 
   describe('window.opener', function() {
-    var url, w;
     this.timeout(10000);
-    url = "file://" + fixtures + "/pages/window-opener.html";
-    w = null;
+
+    var url = "file://" + fixtures + "/pages/window-opener.html";
+    var w = null;
+
     afterEach(function() {
-      return w != null ? w.destroy() : void 0;
+      w != null ? w.destroy() : void 0;
     });
+
     it('is null for main window', function(done) {
       w = new BrowserWindow({
         show: false
       });
       w.webContents.on('ipc-message', function(event, args) {
         assert.deepEqual(args, ['opener', null]);
-        return done();
+        done();
       });
-      return w.loadURL(url);
+      w.loadURL(url);
     });
-    return it('is not null for window opened by window.open', function(done) {
+
+    it('is not null for window opened by window.open', function(done) {
       var b;
       listener = function(event) {
         assert.equal(event.data, 'object');
         b.close();
-        return done();
+        done();
       };
       window.addEventListener('message', listener);
-      return b = window.open(url, '', 'show=no');
+      b = window.open(url, '', 'show=no');
     });
   });
 
   describe('window.postMessage', function() {
-    return it('sets the source and origin correctly', function(done) {
+    it('sets the source and origin correctly', function(done) {
       var b, sourceId;
       sourceId = remote.getCurrentWindow().id;
       listener = function(event) {
@@ -218,47 +220,47 @@ describe('chromium feature', function() {
         assert.equal(message.sourceEqualsOpener, true);
         assert.equal(message.sourceId, sourceId);
         assert.equal(event.origin, 'file://');
-        return done();
+        done();
       };
       window.addEventListener('message', listener);
       b = window.open("file://" + fixtures + "/pages/window-open-postMessage.html", '', 'show=no');
-      return BrowserWindow.fromId(b.guestId).webContents.once('did-finish-load', function() {
-        return b.postMessage('testing', '*');
+      BrowserWindow.fromId(b.guestId).webContents.once('did-finish-load', function() {
+        b.postMessage('testing', '*');
       });
     });
   });
 
   describe('window.opener.postMessage', function() {
-    return it('sets source and origin correctly', function(done) {
+    it('sets source and origin correctly', function(done) {
       var b;
       listener = function(event) {
         window.removeEventListener('message', listener);
         b.close();
         assert.equal(event.source, b);
         assert.equal(event.origin, 'file://');
-        return done();
+        done();
       };
       window.addEventListener('message', listener);
-      return b = window.open("file://" + fixtures + "/pages/window-opener-postMessage.html", '', 'show=no');
+      b = window.open("file://" + fixtures + "/pages/window-opener-postMessage.html", '', 'show=no');
     });
   });
 
   describe('creating a Uint8Array under browser side', function() {
-    return it('does not crash', function() {
+    it('does not crash', function() {
       var RUint8Array;
       RUint8Array = remote.getGlobal('Uint8Array');
-      return new RUint8Array;
+      new RUint8Array;
     });
   });
 
   describe('webgl', function() {
-    return it('can be get as context in canvas', function() {
+    it('can be get as context in canvas', function() {
       var webgl;
       if (process.platform === 'linux') {
         return;
       }
       webgl = document.createElement('canvas').getContext('webgl');
-      return assert.notEqual(webgl, null);
+      assert.notEqual(webgl, null);
     });
   });
 
@@ -270,20 +272,20 @@ describe('chromium feature', function() {
       worker.onmessage = function(event) {
         assert.equal(event.data, message);
         worker.terminate();
-        return done();
+        done();
       };
-      return worker.postMessage(message);
+      worker.postMessage(message);
     });
 
-    return it('SharedWorker can work', function(done) {
+    it('SharedWorker can work', function(done) {
       var message, worker;
       worker = new SharedWorker('../fixtures/workers/shared_worker.js');
       message = 'ping';
       worker.port.onmessage = function(event) {
         assert.equal(event.data, message);
-        return done();
+        done();
       };
-      return worker.port.postMessage(message);
+      worker.port.postMessage(message);
     });
   });
 
@@ -291,28 +293,28 @@ describe('chromium feature', function() {
     var iframe = null;
 
     beforeEach(function() {
-      return iframe = document.createElement('iframe');
+      iframe = document.createElement('iframe');
     });
 
     afterEach(function() {
-      return document.body.removeChild(iframe);
+      document.body.removeChild(iframe);
     });
 
-    return it('does not have node integration', function(done) {
+    it('does not have node integration', function(done) {
       iframe.src = "file://" + fixtures + "/pages/set-global.html";
       document.body.appendChild(iframe);
-      return iframe.onload = function() {
+      iframe.onload = function() {
         assert.equal(iframe.contentWindow.test, 'undefined undefined undefined');
-        return done();
+        done();
       };
     });
   });
 
   describe('storage', function() {
-    return it('requesting persitent quota works', function(done) {
-      return navigator.webkitPersistentStorage.requestQuota(1024 * 1024, function(grantedBytes) {
+    it('requesting persitent quota works', function(done) {
+      navigator.webkitPersistentStorage.requestQuota(1024 * 1024, function(grantedBytes) {
         assert.equal(grantedBytes, 1048576);
-        return done();
+        done();
       });
     });
   });
@@ -324,12 +326,12 @@ describe('chromium feature', function() {
 
     afterEach(function() {
       wss.close();
-      return server.close();
+      server.close();
     });
 
-    return it('has user agent', function(done) {
+    it('has user agent', function(done) {
       server = http.createServer();
-      return server.listen(0, '127.0.0.1', function() {
+      server.listen(0, '127.0.0.1', function() {
         var port = server.address().port;
         wss = new WebSocketServer({
           server: server
@@ -337,9 +339,9 @@ describe('chromium feature', function() {
         wss.on('error', done);
         wss.on('connection', function(ws) {
           if (ws.upgradeReq.headers['user-agent']) {
-            return done();
+            done();
           } else {
-            return done('user agent is empty');
+            done('user agent is empty');
           }
         });
         new WebSocket("ws://127.0.0.1:" + port);
@@ -347,7 +349,7 @@ describe('chromium feature', function() {
     });
   });
 
-  return describe('Promise', function() {
+  describe('Promise', function() {
     it('resolves correctly in Node.js calls', function(done) {
       document.registerElement('x-element', {
         prototype: Object.create(HTMLElement.prototype, {
@@ -356,18 +358,17 @@ describe('chromium feature', function() {
           }
         })
       });
-      return setImmediate(function() {
-        var called;
-        called = false;
+      setImmediate(function() {
+        var called = false;
         Promise.resolve().then(function() {
-          return done(called ? void 0 : new Error('wrong sequence'));
+          done(called ? void 0 : new Error('wrong sequence'));
         });
         document.createElement('x-element');
-        return called = true;
+        called = true;
       });
     });
 
-    return it('resolves correctly in Electron calls', function(done) {
+    it('resolves correctly in Electron calls', function(done) {
       document.registerElement('y-element', {
         prototype: Object.create(HTMLElement.prototype, {
           createdCallback: {
@@ -375,14 +376,14 @@ describe('chromium feature', function() {
           }
         })
       });
-      return remote.getGlobal('setImmediate')(function() {
+      remote.getGlobal('setImmediate')(function() {
         var called;
         called = false;
         Promise.resolve().then(function() {
-          return done(called ? void 0 : new Error('wrong sequence'));
+          done(called ? void 0 : new Error('wrong sequence'));
         });
         document.createElement('y-element');
-        return called = true;
+        called = true;
       });
     });
   });

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -211,10 +211,9 @@ describe('chromium feature', function() {
       var b, sourceId;
       sourceId = remote.getCurrentWindow().id;
       listener = function(event) {
-        var message;
         window.removeEventListener('message', listener);
         b.close();
-        message = JSON.parse(event.data);
+        var message = JSON.parse(event.data);
         assert.equal(message.data, 'testing');
         assert.equal(message.origin, 'file://');
         assert.equal(message.sourceEqualsOpener, true);
@@ -247,28 +246,25 @@ describe('chromium feature', function() {
 
   describe('creating a Uint8Array under browser side', function() {
     it('does not crash', function() {
-      var RUint8Array;
-      RUint8Array = remote.getGlobal('Uint8Array');
+      var RUint8Array = remote.getGlobal('Uint8Array');
       new RUint8Array;
     });
   });
 
   describe('webgl', function() {
     it('can be get as context in canvas', function() {
-      var webgl;
       if (process.platform === 'linux') {
         return;
       }
-      webgl = document.createElement('canvas').getContext('webgl');
+      var webgl = document.createElement('canvas').getContext('webgl');
       assert.notEqual(webgl, null);
     });
   });
 
   describe('web workers', function() {
     it('Worker can work', function(done) {
-      var message, worker;
-      worker = new Worker('../fixtures/workers/worker.js');
-      message = 'ping';
+      var worker = new Worker('../fixtures/workers/worker.js');
+      var message = 'ping';
       worker.onmessage = function(event) {
         assert.equal(event.data, message);
         worker.terminate();
@@ -278,9 +274,8 @@ describe('chromium feature', function() {
     });
 
     it('SharedWorker can work', function(done) {
-      var message, worker;
-      worker = new SharedWorker('../fixtures/workers/shared_worker.js');
-      message = 'ping';
+      var worker = new SharedWorker('../fixtures/workers/shared_worker.js');
+      var message = 'ping';
       worker.port.onmessage = function(event) {
         assert.equal(event.data, message);
         done();
@@ -377,8 +372,7 @@ describe('chromium feature', function() {
         })
       });
       remote.getGlobal('setImmediate')(function() {
-        var called;
-        called = false;
+        var called = false;
         Promise.resolve().then(function() {
           done(called ? void 0 : new Error('wrong sequence'));
         });

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -8,20 +8,22 @@ const BrowserWindow = remote.require('electron').BrowserWindow;
 const session = remote.require('electron').session;
 
 describe('chromium feature', function() {
-  var fixtures, listener;
-  fixtures = path.resolve(__dirname, 'fixtures');
-  listener = null;
+  var fixtures = path.resolve(__dirname, 'fixtures');
+  var listener = null;
+
   afterEach(function() {
     if (listener != null) {
       window.removeEventListener('message', listener);
     }
     return listener = null;
   });
+
   xdescribe('heap snapshot', function() {
     return it('does not crash', function() {
       return process.atomBinding('v8_util').takeHeapSnapshot();
     });
   });
+
   describe('sending request of http protocol urls', function() {
     return it('does not crash', function(done) {
       var server;
@@ -38,13 +40,15 @@ describe('chromium feature', function() {
       });
     });
   });
+
   describe('document.hidden', function() {
-    var url, w;
-    url = "file://" + fixtures + "/pages/document-hidden.html";
-    w = null;
+    var url = "file://" + fixtures + "/pages/document-hidden.html";
+    var w = null;
+
     afterEach(function() {
       return w != null ? w.destroy() : void 0;
     });
+
     it('is set correctly when window is not shown', function(done) {
       w = new BrowserWindow({
         show: false
@@ -55,6 +59,7 @@ describe('chromium feature', function() {
       });
       return w.loadURL(url);
     });
+
     return it('is set correctly when window is inactive', function(done) {
       w = new BrowserWindow({
         show: false
@@ -67,6 +72,7 @@ describe('chromium feature', function() {
       return w.loadURL(url);
     });
   });
+
   xdescribe('navigator.webkitGetUserMedia', function() {
     return it('calls its callbacks', function(done) {
       this.timeout(5000);
@@ -80,18 +86,21 @@ describe('chromium feature', function() {
       });
     });
   });
+
   describe('navigator.language', function() {
     return it('should not be empty', function() {
       return assert.notEqual(navigator.language, '');
     });
   });
+
   describe('navigator.serviceWorker', function() {
-    var url, w;
-    url = "file://" + fixtures + "/pages/service-worker/index.html";
-    w = null;
+    var url = "file://" + fixtures + "/pages/service-worker/index.html";
+    var w = null;
+
     afterEach(function() {
       return w != null ? w.destroy() : void 0;
     });
+
     return it('should register for file scheme', function(done) {
       w = new BrowserWindow({
         show: false
@@ -113,8 +122,10 @@ describe('chromium feature', function() {
       return w.loadURL(url);
     });
   });
+
   describe('window.open', function() {
     this.timeout(20000);
+
     it('returns a BrowserWindowProxy object', function() {
       var b;
       b = window.open('about:blank', '', 'show=no');
@@ -122,6 +133,7 @@ describe('chromium feature', function() {
       assert.equal(b.constructor.name, 'BrowserWindowProxy');
       return b.close();
     });
+
     it('accepts "node-integration" as feature', function(done) {
       var b;
       listener = function(event) {
@@ -132,6 +144,7 @@ describe('chromium feature', function() {
       window.addEventListener('message', listener);
       return b = window.open("file://" + fixtures + "/pages/window-opener-node.html", '', 'nodeIntegration=no,show=no');
     });
+
     it('inherit options of parent window', function(done) {
       var b;
       listener = function(event) {
@@ -144,6 +157,7 @@ describe('chromium feature', function() {
       window.addEventListener('message', listener);
       return b = window.open("file://" + fixtures + "/pages/window-open-size.html", '', 'show=no');
     });
+
     return it('does not override child options', function(done) {
       var b, size;
       size = {
@@ -159,6 +173,7 @@ describe('chromium feature', function() {
       return b = window.open("file://" + fixtures + "/pages/window-open-size.html", '', "show=no,width=" + size.width + ",height=" + size.height);
     });
   });
+
   describe('window.opener', function() {
     var url, w;
     this.timeout(10000);
@@ -188,6 +203,7 @@ describe('chromium feature', function() {
       return b = window.open(url, '', 'show=no');
     });
   });
+
   describe('window.postMessage', function() {
     return it('sets the source and origin correctly', function(done) {
       var b, sourceId;
@@ -211,6 +227,7 @@ describe('chromium feature', function() {
       });
     });
   });
+
   describe('window.opener.postMessage', function() {
     return it('sets source and origin correctly', function(done) {
       var b;
@@ -225,6 +242,7 @@ describe('chromium feature', function() {
       return b = window.open("file://" + fixtures + "/pages/window-opener-postMessage.html", '', 'show=no');
     });
   });
+
   describe('creating a Uint8Array under browser side', function() {
     return it('does not crash', function() {
       var RUint8Array;
@@ -232,6 +250,7 @@ describe('chromium feature', function() {
       return new RUint8Array;
     });
   });
+
   describe('webgl', function() {
     return it('can be get as context in canvas', function() {
       var webgl;
@@ -242,6 +261,7 @@ describe('chromium feature', function() {
       return assert.notEqual(webgl, null);
     });
   });
+
   describe('web workers', function() {
     it('Worker can work', function(done) {
       var message, worker;
@@ -254,6 +274,7 @@ describe('chromium feature', function() {
       };
       return worker.postMessage(message);
     });
+
     return it('SharedWorker can work', function(done) {
       var message, worker;
       worker = new SharedWorker('../fixtures/workers/shared_worker.js');
@@ -265,15 +286,18 @@ describe('chromium feature', function() {
       return worker.port.postMessage(message);
     });
   });
+
   describe('iframe', function() {
-    var iframe;
-    iframe = null;
+    var iframe = null;
+
     beforeEach(function() {
       return iframe = document.createElement('iframe');
     });
+
     afterEach(function() {
       return document.body.removeChild(iframe);
     });
+
     return it('does not have node integration', function(done) {
       iframe.src = "file://" + fixtures + "/pages/set-global.html";
       document.body.appendChild(iframe);
@@ -283,6 +307,7 @@ describe('chromium feature', function() {
       };
     });
   });
+
   describe('storage', function() {
     return it('requesting persitent quota works', function(done) {
       return navigator.webkitPersistentStorage.requestQuota(1024 * 1024, function(grantedBytes) {
@@ -291,15 +316,17 @@ describe('chromium feature', function() {
       });
     });
   });
+
   describe('websockets', function() {
-    var WebSocketServer, server, wss;
-    wss = null;
-    server = null;
-    WebSocketServer = ws.Server;
+    var wss = null;
+    var server = null;
+    var WebSocketServer = ws.Server;
+
     afterEach(function() {
       wss.close();
       return server.close();
     });
+
     return it('has user agent', function(done) {
       server = http.createServer();
       return server.listen(0, '127.0.0.1', function() {
@@ -319,6 +346,7 @@ describe('chromium feature', function() {
       });
     });
   });
+
   return describe('Promise', function() {
     it('resolves correctly in Node.js calls', function(done) {
       document.registerElement('x-element', {
@@ -338,6 +366,7 @@ describe('chromium feature', function() {
         return called = true;
       });
     });
+
     return it('resolves correctly in Electron calls', function(done) {
       document.registerElement('y-element', {
         prototype: Object.create(HTMLElement.prototype, {

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -119,7 +119,7 @@ describe('chromium feature', function() {
           });
         }
       });
-      sw.loadURL(url);
+      w.loadURL(url);
     });
   });
 

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -3,14 +3,15 @@ const path = require('path');
 const temp = require('temp');
 
 describe('third-party module', function() {
-  var fixtures;
-  fixtures = path.join(__dirname, 'fixtures');
+  var fixtures = path.join(__dirname, 'fixtures');
   temp.track();
+
   if (process.platform !== 'win32' || process.execPath.toLowerCase().indexOf('\\out\\d\\') === -1) {
     describe('runas', function() {
       it('can be required in renderer', function() {
         return require('runas');
       });
+
       return it('can be required in node binary', function(done) {
         var child, runas;
         runas = path.join(fixtures, 'module', 'runas.js');
@@ -21,6 +22,7 @@ describe('third-party module', function() {
         });
       });
     });
+
     describe('ffi', function() {
       return it('does not crash', function() {
         var ffi, libm;
@@ -32,6 +34,7 @@ describe('third-party module', function() {
       });
     });
   }
+
   return describe('q', function() {
     var Q;
     Q = require('q');

--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -9,40 +9,37 @@ describe('third-party module', function() {
   if (process.platform !== 'win32' || process.execPath.toLowerCase().indexOf('\\out\\d\\') === -1) {
     describe('runas', function() {
       it('can be required in renderer', function() {
-        return require('runas');
+        require('runas');
       });
 
-      return it('can be required in node binary', function(done) {
-        var child, runas;
-        runas = path.join(fixtures, 'module', 'runas.js');
-        child = require('child_process').fork(runas);
-        return child.on('message', function(msg) {
+      it('can be required in node binary', function(done) {
+        var runas = path.join(fixtures, 'module', 'runas.js');
+        var child = require('child_process').fork(runas);
+        child.on('message', function(msg) {
           assert.equal(msg, 'ok');
-          return done();
+          done();
         });
       });
     });
 
     describe('ffi', function() {
-      return it('does not crash', function() {
-        var ffi, libm;
-        ffi = require('ffi');
-        libm = ffi.Library('libm', {
+      it('does not crash', function() {
+        var ffi = require('ffi');
+        var libm = ffi.Library('libm', {
           ceil: ['double', ['double']]
         });
-        return assert.equal(libm.ceil(1.5), 2);
+        assert.equal(libm.ceil(1.5), 2);
       });
     });
   }
 
-  return describe('q', function() {
-    var Q;
-    Q = require('q');
-    return describe('Q.when', function() {
-      return it('emits the fullfil callback', function(done) {
-        return Q(true).then(function(val) {
+  describe('q', function() {
+    var Q = require('q');
+    describe('Q.when', function() {
+      it('emits the fullfil callback', function(done) {
+        Q(true).then(function(val) {
           assert.equal(val, true);
-          return done();
+          done();
         });
       });
     });

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -11,8 +11,7 @@ describe('node feature', function() {
   describe('child_process', function() {
     describe('child_process.fork', function() {
       it('works in current process', function(done) {
-        var child;
-        child = child_process.fork(path.join(fixtures, 'module', 'ping.js'));
+        var child = child_process.fork(path.join(fixtures, 'module', 'ping.js'));
         child.on('message', function(msg) {
           assert.equal(msg, 'message');
           done();
@@ -51,9 +50,8 @@ describe('node feature', function() {
       });
 
       it('works in browser process', function(done) {
-        var child, fork;
-        fork = remote.require('child_process').fork;
-        child = fork(path.join(fixtures, 'module', 'ping.js'));
+        var fork = remote.require('child_process').fork;
+        var child = fork(path.join(fixtures, 'module', 'ping.js'));
         child.on('message', function(msg) {
           assert.equal(msg, 'message');
           done();
@@ -62,8 +60,7 @@ describe('node feature', function() {
       });
 
       it('has String::localeCompare working in script', function(done) {
-        var child;
-        child = child_process.fork(path.join(fixtures, 'module', 'locale-compare.js'));
+        var child = child_process.fork(path.join(fixtures, 'module', 'locale-compare.js'));
         child.on('message', function(msg) {
           assert.deepEqual(msg, [0, -1, 1]);
           done();
@@ -169,14 +166,12 @@ describe('node feature', function() {
     }
 
     it('emit error when connect to a socket path without listeners', function(done) {
-      var child, script, socketPath;
-      socketPath = path.join(os.tmpdir(), 'atom-shell-test.sock');
-      script = path.join(fixtures, 'module', 'create_socket.js');
-      child = child_process.fork(script, [socketPath]);
+      var socketPath = path.join(os.tmpdir(), 'atom-shell-test.sock');
+      var script = path.join(fixtures, 'module', 'create_socket.js');
+      var child = child_process.fork(script, [socketPath]);
       child.on('exit', function(code) {
-        var client;
         assert.equal(code, 0);
-        client = require('net').connect(socketPath);
+        var client = require('net').connect(socketPath);
         client.on('error', function(error) {
           assert.equal(error.code, 'ECONNREFUSED');
           done();
@@ -187,19 +182,17 @@ describe('node feature', function() {
 
   describe('Buffer', function() {
     it('can be created from WebKit external string', function() {
-      var b, p;
-      p = document.createElement('p');
+      var p = document.createElement('p');
       p.innerText = '闲云潭影日悠悠，物换星移几度秋';
-      b = new Buffer(p.innerText);
+      var b = new Buffer(p.innerText);
       assert.equal(b.toString(), '闲云潭影日悠悠，物换星移几度秋');
       assert.equal(Buffer.byteLength(p.innerText), 45);
     });
 
     it('correctly parses external one-byte UTF8 string', function() {
-      var b, p;
-      p = document.createElement('p');
+      var p = document.createElement('p');
       p.innerText = 'Jøhänñéß';
-      b = new Buffer(p.innerText);
+      var b = new Buffer(p.innerText);
       assert.equal(b.toString(), 'Jøhänñéß');
       assert.equal(Buffer.byteLength(p.innerText), 13);
     });

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -9,48 +9,45 @@ describe('node feature', function() {
   var fixtures = path.join(__dirname, 'fixtures');
 
   describe('child_process', function() {
-    return describe('child_process.fork', function() {
+    describe('child_process.fork', function() {
       it('works in current process', function(done) {
         var child;
         child = child_process.fork(path.join(fixtures, 'module', 'ping.js'));
         child.on('message', function(msg) {
           assert.equal(msg, 'message');
-          return done();
+          done();
         });
-        return child.send('message');
+        child.send('message');
       });
 
       it('preserves args', function(done) {
-        var args, child;
-        args = ['--expose_gc', '-test', '1'];
-        child = child_process.fork(path.join(fixtures, 'module', 'process_args.js'), args);
+        var args = ['--expose_gc', '-test', '1'];
+        var child = child_process.fork(path.join(fixtures, 'module', 'process_args.js'), args);
         child.on('message', function(msg) {
           assert.deepEqual(args, msg.slice(2));
-          return done();
+          done();
         });
-        return child.send('message');
+        child.send('message');
       });
 
       it('works in forked process', function(done) {
-        var child;
-        child = child_process.fork(path.join(fixtures, 'module', 'fork_ping.js'));
+        var child = child_process.fork(path.join(fixtures, 'module', 'fork_ping.js'));
         child.on('message', function(msg) {
           assert.equal(msg, 'message');
-          return done();
+          done();
         });
-        return child.send('message');
+        child.send('message');
       });
 
       it('works in forked process when options.env is specifed', function(done) {
-        var child;
-        child = child_process.fork(path.join(fixtures, 'module', 'fork_ping.js'), [], {
+        var child = child_process.fork(path.join(fixtures, 'module', 'fork_ping.js'), [], {
           path: process.env['PATH']
         });
         child.on('message', function(msg) {
           assert.equal(msg, 'message');
-          return done();
+          done();
         });
-        return child.send('message');
+        child.send('message');
       });
 
       it('works in browser process', function(done) {
@@ -59,9 +56,9 @@ describe('node feature', function() {
         child = fork(path.join(fixtures, 'module', 'ping.js'));
         child.on('message', function(msg) {
           assert.equal(msg, 'message');
-          return done();
+          done();
         });
-        return child.send('message');
+        child.send('message');
       });
 
       it('has String::localeCompare working in script', function(done) {
@@ -69,19 +66,18 @@ describe('node feature', function() {
         child = child_process.fork(path.join(fixtures, 'module', 'locale-compare.js'));
         child.on('message', function(msg) {
           assert.deepEqual(msg, [0, -1, 1]);
-          return done();
+          done();
         });
-        return child.send('message');
+        child.send('message');
       });
 
-      return it('has setImmediate working in script', function(done) {
-        var child;
-        child = child_process.fork(path.join(fixtures, 'module', 'set-immediate.js'));
+      it('has setImmediate working in script', function(done) {
+        var child = child_process.fork(path.join(fixtures, 'module', 'set-immediate.js'));
         child.on('message', function(msg) {
           assert.equal(msg, 'ok');
-          return done();
+          done();
         });
-        return child.send('message');
+        child.send('message');
       });
     });
   });
@@ -92,18 +88,17 @@ describe('node feature', function() {
         return;
       }
 
-      return it('does not crash', function(done) {
-        return fs.readFile(__filename, function() {
-          return setTimeout(done, 0);
+      it('does not crash', function(done) {
+        fs.readFile(__filename, function() {
+          setTimeout(done, 0);
         });
       });
     });
 
     describe('throw error in node context', function() {
-      return it('gets caught', function(done) {
-        var error, lsts;
-        error = new Error('boo!');
-        lsts = process.listeners('uncaughtException');
+      it('gets caught', function(done) {
+        var error = new Error('boo!');
+        var lsts = process.listeners('uncaughtException');
         process.removeAllListeners('uncaughtException');
         process.on('uncaughtException', function() {
           var i, len, lst;
@@ -112,28 +107,28 @@ describe('node feature', function() {
             lst = lsts[i];
             process.on('uncaughtException', lst);
           }
-          return done();
+          done();
         });
-        return fs.readFile(__filename, function() {
+        fs.readFile(__filename, function() {
           throw error;
         });
       });
     });
 
     describe('setTimeout called under Chromium event loop in browser process', function() {
-      return it('can be scheduled in time', function(done) {
-        return remote.getGlobal('setTimeout')(done, 0);
+      it('can be scheduled in time', function(done) {
+        remote.getGlobal('setTimeout')(done, 0);
       });
     });
 
-    return describe('setInterval called under Chromium event loop in browser process', function() {
-      return it('can be scheduled in time', function(done) {
+    describe('setInterval called under Chromium event loop in browser process', function() {
+      it('can be scheduled in time', function(done) {
         var clear, interval;
         clear = function() {
           remote.getGlobal('clearInterval')(interval);
-          return done();
+          done();
         };
-        return interval = remote.getGlobal('setInterval')(clear, 10);
+        interval = remote.getGlobal('setInterval')(clear, 10);
       });
     });
   });
@@ -141,27 +136,27 @@ describe('node feature', function() {
   describe('message loop', function() {
     describe('process.nextTick', function() {
       it('emits the callback', function(done) {
-        return process.nextTick(done);
+        process.nextTick(done);
       });
 
-      return it('works in nested calls', function(done) {
-        return process.nextTick(function() {
-          return process.nextTick(function() {
-            return process.nextTick(done);
+      it('works in nested calls', function(done) {
+        process.nextTick(function() {
+          process.nextTick(function() {
+            process.nextTick(done);
           });
         });
       });
     });
 
-    return describe('setImmediate', function() {
+    describe('setImmediate', function() {
       it('emits the callback', function(done) {
-        return setImmediate(done);
+        setImmediate(done);
       });
 
-      return it('works in nested calls', function(done) {
-        return setImmediate(function() {
-          return setImmediate(function() {
-            return setImmediate(done);
+      it('works in nested calls', function(done) {
+        setImmediate(function() {
+          setImmediate(function() {
+            setImmediate(done);
           });
         });
       });
@@ -173,18 +168,18 @@ describe('node feature', function() {
       return;
     }
 
-    return it('emit error when connect to a socket path without listeners', function(done) {
+    it('emit error when connect to a socket path without listeners', function(done) {
       var child, script, socketPath;
       socketPath = path.join(os.tmpdir(), 'atom-shell-test.sock');
       script = path.join(fixtures, 'module', 'create_socket.js');
       child = child_process.fork(script, [socketPath]);
-      return child.on('exit', function(code) {
+      child.on('exit', function(code) {
         var client;
         assert.equal(code, 0);
         client = require('net').connect(socketPath);
-        return client.on('error', function(error) {
+        client.on('error', function(error) {
           assert.equal(error.code, 'ECONNREFUSED');
-          return done();
+          done();
         });
       });
     });
@@ -197,16 +192,16 @@ describe('node feature', function() {
       p.innerText = '闲云潭影日悠悠，物换星移几度秋';
       b = new Buffer(p.innerText);
       assert.equal(b.toString(), '闲云潭影日悠悠，物换星移几度秋');
-      return assert.equal(Buffer.byteLength(p.innerText), 45);
+      assert.equal(Buffer.byteLength(p.innerText), 45);
     });
 
-    return it('correctly parses external one-byte UTF8 string', function() {
+    it('correctly parses external one-byte UTF8 string', function() {
       var b, p;
       p = document.createElement('p');
       p.innerText = 'Jøhänñéß';
       b = new Buffer(p.innerText);
       assert.equal(b.toString(), 'Jøhänñéß');
-      return assert.equal(Buffer.byteLength(p.innerText), 13);
+      assert.equal(Buffer.byteLength(p.innerText), 13);
     });
   });
 

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -6,8 +6,8 @@ const os = require('os');
 const remote = require('electron').remote;
 
 describe('node feature', function() {
-  var fixtures;
-  fixtures = path.join(__dirname, 'fixtures');
+  var fixtures = path.join(__dirname, 'fixtures');
+
   describe('child_process', function() {
     return describe('child_process.fork', function() {
       it('works in current process', function(done) {
@@ -19,6 +19,7 @@ describe('node feature', function() {
         });
         return child.send('message');
       });
+
       it('preserves args', function(done) {
         var args, child;
         args = ['--expose_gc', '-test', '1'];
@@ -29,6 +30,7 @@ describe('node feature', function() {
         });
         return child.send('message');
       });
+
       it('works in forked process', function(done) {
         var child;
         child = child_process.fork(path.join(fixtures, 'module', 'fork_ping.js'));
@@ -38,6 +40,7 @@ describe('node feature', function() {
         });
         return child.send('message');
       });
+
       it('works in forked process when options.env is specifed', function(done) {
         var child;
         child = child_process.fork(path.join(fixtures, 'module', 'fork_ping.js'), [], {
@@ -49,6 +52,7 @@ describe('node feature', function() {
         });
         return child.send('message');
       });
+
       it('works in browser process', function(done) {
         var child, fork;
         fork = remote.require('child_process').fork;
@@ -59,6 +63,7 @@ describe('node feature', function() {
         });
         return child.send('message');
       });
+
       it('has String::localeCompare working in script', function(done) {
         var child;
         child = child_process.fork(path.join(fixtures, 'module', 'locale-compare.js'));
@@ -68,6 +73,7 @@ describe('node feature', function() {
         });
         return child.send('message');
       });
+
       return it('has setImmediate working in script', function(done) {
         var child;
         child = child_process.fork(path.join(fixtures, 'module', 'set-immediate.js'));
@@ -79,17 +85,20 @@ describe('node feature', function() {
       });
     });
   });
+
   describe('contexts', function() {
     describe('setTimeout in fs callback', function() {
       if (process.env.TRAVIS === 'true') {
         return;
       }
+
       return it('does not crash', function(done) {
         return fs.readFile(__filename, function() {
           return setTimeout(done, 0);
         });
       });
     });
+
     describe('throw error in node context', function() {
       return it('gets caught', function(done) {
         var error, lsts;
@@ -110,11 +119,13 @@ describe('node feature', function() {
         });
       });
     });
+
     describe('setTimeout called under Chromium event loop in browser process', function() {
       return it('can be scheduled in time', function(done) {
         return remote.getGlobal('setTimeout')(done, 0);
       });
     });
+
     return describe('setInterval called under Chromium event loop in browser process', function() {
       return it('can be scheduled in time', function(done) {
         var clear, interval;
@@ -126,11 +137,13 @@ describe('node feature', function() {
       });
     });
   });
+
   describe('message loop', function() {
     describe('process.nextTick', function() {
       it('emits the callback', function(done) {
         return process.nextTick(done);
       });
+
       return it('works in nested calls', function(done) {
         return process.nextTick(function() {
           return process.nextTick(function() {
@@ -139,10 +152,12 @@ describe('node feature', function() {
         });
       });
     });
+
     return describe('setImmediate', function() {
       it('emits the callback', function(done) {
         return setImmediate(done);
       });
+
       return it('works in nested calls', function(done) {
         return setImmediate(function() {
           return setImmediate(function() {
@@ -152,10 +167,12 @@ describe('node feature', function() {
       });
     });
   });
+
   describe('net.connect', function() {
     if (process.platform !== 'darwin') {
       return;
     }
+
     return it('emit error when connect to a socket path without listeners', function(done) {
       var child, script, socketPath;
       socketPath = path.join(os.tmpdir(), 'atom-shell-test.sock');
@@ -172,6 +189,7 @@ describe('node feature', function() {
       });
     });
   });
+
   describe('Buffer', function() {
     it('can be created from WebKit external string', function() {
       var b, p;
@@ -181,6 +199,7 @@ describe('node feature', function() {
       assert.equal(b.toString(), '闲云潭影日悠悠，物换星移几度秋');
       return assert.equal(Buffer.byteLength(p.innerText), 45);
     });
+
     return it('correctly parses external one-byte UTF8 string', function() {
       var b, p;
       p = document.createElement('p');

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -95,8 +95,7 @@ describe('<webview> tag', function() {
 
   describe('preload attribute', function() {
     it('loads the script before other scripts in window', function(done) {
-      var listener;
-      listener = function(e) {
+      var listener = function(e) {
         assert.equal(e.message, 'function object object');
         webview.removeEventListener('console-message', listener);
         done();
@@ -118,15 +117,14 @@ describe('<webview> tag', function() {
     });
 
     it('receives ipc message in preload script', function(done) {
-      var listener, listener2, message;
-      message = 'boom!';
-      listener = function(e) {
+      var message = 'boom!';
+      var listener = function(e) {
         assert.equal(e.channel, 'pong');
         assert.deepEqual(e.args, [message]);
         webview.removeEventListener('ipc-message', listener);
         done();
       };
-      listener2 = function() {
+      var listener2 = function() {
         webview.send('ping', message);
         webview.removeEventListener('did-finish-load', listener2);
       };
@@ -140,9 +138,8 @@ describe('<webview> tag', function() {
 
   describe('httpreferrer attribute', function() {
     it('sets the referrer url', function(done) {
-      var listener, referrer;
-      referrer = 'http://github.com/';
-      listener = function(e) {
+      var referrer = 'http://github.com/';
+      var listener = function(e) {
         assert.equal(e.message, referrer);
         webview.removeEventListener('console-message', listener);
         done();
@@ -156,9 +153,8 @@ describe('<webview> tag', function() {
 
   describe('useragent attribute', function() {
     it('sets the user agent', function(done) {
-      var listener, referrer;
-      referrer = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko';
-      listener = function(e) {
+      var referrer = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko';
+      var listener = function(e) {
         assert.equal(e.message, referrer);
         webview.removeEventListener('console-message', listener);
         done();
@@ -172,10 +168,9 @@ describe('<webview> tag', function() {
 
   describe('disablewebsecurity attribute', function() {
     it('does not disable web security when not set', function(done) {
-      var encoded, listener, src;
-      src = "<script src='file://" + __dirname + "/static/jquery-2.0.3.min.js'></script> <script>console.log('ok');</script>";
-      encoded = btoa(unescape(encodeURIComponent(src)));
-      listener = function(e) {
+      var src = "<script src='file://" + __dirname + "/static/jquery-2.0.3.min.js'></script> <script>console.log('ok');</script>";
+      var encoded = btoa(unescape(encodeURIComponent(src)));
+      var listener = function(e) {
         assert(/Not allowed to load local resource/.test(e.message));
         webview.removeEventListener('console-message', listener);
         done();
@@ -186,10 +181,9 @@ describe('<webview> tag', function() {
     });
 
     it('disables web security when set', function(done) {
-      var encoded, listener, src;
-      src = "<script src='file://" + __dirname + "/static/jquery-2.0.3.min.js'></script> <script>console.log('ok');</script>";
-      encoded = btoa(unescape(encodeURIComponent(src)));
-      listener = function(e) {
+      var src = "<script src='file://" + __dirname + "/static/jquery-2.0.3.min.js'></script> <script>console.log('ok');</script>";
+      var encoded = btoa(unescape(encodeURIComponent(src)));
+      var listener = function(e) {
         assert.equal(e.message, 'ok');
         webview.removeEventListener('console-message', listener);
         done();
@@ -223,8 +217,7 @@ describe('<webview> tag', function() {
     });
 
     it('isolates storage for different id', function(done) {
-      var listener;
-      listener = function(e) {
+      var listener = function(e) {
         assert.equal(e.message, " 0");
         webview.removeEventListener('console-message', listener);
         done();
@@ -237,8 +230,7 @@ describe('<webview> tag', function() {
     });
 
     it('uses current session storage when no id is provided', function(done) {
-      var listener;
-      listener = function(e) {
+      var listener = function(e) {
         assert.equal(e.message, "one 1");
         webview.removeEventListener('console-message', listener);
         done();
@@ -252,8 +244,7 @@ describe('<webview> tag', function() {
 
   describe('allowpopups attribute', function() {
     it('can not open new window when not set', function(done) {
-      var listener;
-      listener = function(e) {
+      var listener = function(e) {
         assert.equal(e.message, 'null');
         webview.removeEventListener('console-message', listener);
         done();
@@ -264,8 +255,7 @@ describe('<webview> tag', function() {
     });
 
     it('can open new window when set', function(done) {
-      var listener;
-      listener = function(e) {
+      var listener = function(e) {
         assert.equal(e.message, 'window');
         webview.removeEventListener('console-message', listener);
         done();
@@ -327,9 +317,8 @@ describe('<webview> tag', function() {
   describe('page-favicon-updated event', function() {
     it('emits when favicon urls are received', function(done) {
       webview.addEventListener('page-favicon-updated', function(e) {
-        var pageUrl;
         assert.equal(e.favicons.length, 2);
-        pageUrl = process.platform === 'win32' ? 'file:///C:/favicon.png' : 'file:///favicon.png';
+        var pageUrl = process.platform === 'win32' ? 'file:///C:/favicon.png' : 'file:///favicon.png';
         assert.equal(e.favicons[0], pageUrl);
         done();
       });
@@ -350,10 +339,9 @@ describe('<webview> tag', function() {
   });
 
   describe('did-navigate event', function() {
-    var p, pageUrl;
-    p = path.join(fixtures, 'pages', 'webview-will-navigate.html');
+    var p = path.join(fixtures, 'pages', 'webview-will-navigate.html');
     p = p.replace(/\\/g, '/');
-    pageUrl = url.format({
+    var pageUrl = url.format({
       protocol: 'file',
       slashes: true,
       pathname: p
@@ -370,10 +358,9 @@ describe('<webview> tag', function() {
   });
   describe('did-navigate-in-page event', function() {
     it('emits when an anchor link is clicked', function(done) {
-      var p, pageUrl;
-      p = path.join(fixtures, 'pages', 'webview-did-navigate-in-page.html');
+      var p = path.join(fixtures, 'pages', 'webview-did-navigate-in-page.html');
       p = p.replace(/\\/g, '/');
-      pageUrl = url.format({
+      var pageUrl = url.format({
         protocol: 'file',
         slashes: true,
         pathname: p
@@ -396,10 +383,9 @@ describe('<webview> tag', function() {
     });
 
     it('emits when window.location.hash is changed', function(done) {
-      var p, pageUrl;
-      p = path.join(fixtures, 'pages', 'webview-did-navigate-in-page-with-hash.html');
+      var p = path.join(fixtures, 'pages', 'webview-did-navigate-in-page-with-hash.html');
       p = p.replace(/\\/g, '/');
-      pageUrl = url.format({
+      var pageUrl = url.format({
         protocol: 'file',
         slashes: true,
         pathname: p
@@ -425,8 +411,7 @@ describe('<webview> tag', function() {
 
   describe('devtools-opened event', function() {
     it('should fire when webview.openDevTools() is called', function(done) {
-      var listener;
-      listener = function() {
+      var listener = function() {
         webview.removeEventListener('devtools-opened', listener);
         webview.closeDevTools();
         done();
@@ -442,12 +427,11 @@ describe('<webview> tag', function() {
 
   describe('devtools-closed event', function() {
     it('should fire when webview.closeDevTools() is called', function(done) {
-      var listener, listener2;
-      listener2 = function() {
+      var listener2 = function() {
         webview.removeEventListener('devtools-closed', listener2);
         done();
       };
-      listener = function() {
+      var listener = function() {
         webview.removeEventListener('devtools-opened', listener);
         webview.closeDevTools();
       };
@@ -463,8 +447,7 @@ describe('<webview> tag', function() {
 
   describe('devtools-focused event', function() {
     it('should fire when webview.openDevTools() is called', function(done) {
-      var listener;
-      listener = function() {
+      var listener = function() {
         webview.removeEventListener('devtools-focused', listener);
         webview.closeDevTools();
         done();
@@ -480,13 +463,12 @@ describe('<webview> tag', function() {
 
   describe('<webview>.reload()', function() {
     it('should emit beforeunload handler', function(done) {
-      var listener, listener2;
-      listener = function(e) {
+      var listener = function(e) {
         assert.equal(e.channel, 'onbeforeunload');
         webview.removeEventListener('ipc-message', listener);
         done();
       };
-      listener2 = function() {
+      var listener2 = function() {
         webview.reload();
         webview.removeEventListener('did-finish-load', listener2);
       };
@@ -500,8 +482,7 @@ describe('<webview> tag', function() {
 
   describe('<webview>.clearHistory()', function() {
     it('should clear the navigation history', function(done) {
-      var listener;
-      listener = function(e) {
+      var listener = function(e) {
         assert.equal(e.channel, 'history');
         assert.equal(e.args[0], 2);
         assert(webview.canGoBack());
@@ -518,14 +499,12 @@ describe('<webview> tag', function() {
   });
 
   describe('basic auth', function() {
-    var auth;
-    auth = require('basic-auth');
+    var auth = require('basic-auth');
+
     it('should authenticate with correct credentials', function(done) {
-      var message, server;
-      message = 'Authenticated';
-      server = http.createServer(function(req, res) {
-        var credentials;
-        credentials = auth(req);
+      var message = 'Authenticated';
+      var server = http.createServer(function(req, res) {
+        var credentials = auth(req);
         if (credentials.name === 'test' && credentials.pass === 'test') {
           res.end(message);
         } else {
@@ -534,8 +513,7 @@ describe('<webview> tag', function() {
         server.close();
       });
       server.listen(0, '127.0.0.1', function() {
-        var port;
-        port = server.address().port;
+        var port = server.address().port;
         webview.addEventListener('ipc-message', function(e) {
           assert.equal(e.channel, message);
           done();
@@ -549,11 +527,9 @@ describe('<webview> tag', function() {
 
   describe('dom-ready event', function() {
     it('emits when document is loaded', function(done) {
-      var server;
-      server = http.createServer(function() {});
+      var server = http.createServer(function() {});
       server.listen(0, '127.0.0.1', function() {
-        var port;
-        port = server.address().port;
+        var port = server.address().port;
         webview.addEventListener('dom-ready', function() {
           done();
         });
@@ -575,14 +551,12 @@ describe('<webview> tag', function() {
     }
 
     it('should support user gesture', function(done) {
-      var listener, listener2;
-      listener = function() {
+      var listener = function() {
         webview.removeEventListener('enter-html-full-screen', listener);
         done();
       };
-      listener2 = function() {
-        var jsScript;
-        jsScript = 'document.getElementsByTagName("video")[0].webkitRequestFullScreen()';
+      var listener2 = function() {
+        var jsScript = 'document.getElementsByTagName("video")[0].webkitRequestFullScreen()';
         webview.executeJavaScript(jsScript, true);
         webview.removeEventListener('did-finish-load', listener2);
       };
@@ -634,8 +608,7 @@ describe('<webview> tag', function() {
 
   describe('media-started-playing media-paused events', function() {
     it('emits when audio starts and stops playing', function(done) {
-      var audioPlayed;
-      audioPlayed = false;
+      var audioPlayed = false;
       webview.addEventListener('media-started-playing', function() {
         audioPlayed = true;
       });
@@ -650,9 +623,8 @@ describe('<webview> tag', function() {
 
   describe('found-in-page event', function() {
     it('emits when a request is made', function(done) {
-      var listener, listener2, requestId;
-      requestId = null;
-      listener = function(e) {
+      var requestId = null;
+      var listener = function(e) {
         assert.equal(e.result.requestId, requestId);
         if (e.result.finalUpdate) {
           assert.equal(e.result.matches, 3);
@@ -660,7 +632,7 @@ describe('<webview> tag', function() {
           done();
         }
       };
-      listener2 = function() {
+      var listener2 = function() {
         requestId = webview.findInPage("virtual");
       };
       webview.addEventListener('found-in-page', listener);


### PR DESCRIPTION
* Remove extraneous `return` statements
* Separate describes, its, before, afters with newlines
* Use `const` for requires
* Cleanup `var` definitions

Refs #4065 