### PR TITLE
Match default app styles to website styles

### DIFF
--- a/atom/browser/default_app/index.html
+++ b/atom/browser/default_app/index.html
@@ -33,7 +33,7 @@
 
     pre, code {
       font-family: "Menlo","Lucida Console",monospace;
-      border: 1px solid #ddd;
+      border: 1px solid #076274;
       background-color: #076274;
       color: #C5F3FC;
       border-radius: 3px;

--- a/atom/browser/default_app/index.html
+++ b/atom/browser/default_app/index.html
@@ -46,10 +46,10 @@
     }
 
     #holder {
-      border: 4px dashed #ccc;
+      border: 2px dashed #448691;
       margin: 0 auto;
       height: 300px;
-      color: #ccc;
+      color: #45828E;
       font-size: 40px;
       line-height: 300px;
       text-align: center;

--- a/atom/browser/default_app/index.html
+++ b/atom/browser/default_app/index.html
@@ -98,7 +98,7 @@
   <div class="container">
 
     <p>
-    To run your app with Electron, execute the following command under your
+    To run your app with Electron, execute the following command in your
     Console (or Terminal):
     </p>
 

--- a/atom/browser/default_app/index.html
+++ b/atom/browser/default_app/index.html
@@ -107,7 +107,10 @@
 
     <p>
     The <code>path-to-your-app</code> should be the path to your own Electron
-    app, you can read the
+    app.
+    </p>
+
+    <p>You can read the
     <script>
       document.write(
         `<a href='https://github.com/atom/electron/blob/v${process.versions.electron}/docs/tutorial/quick-start.md'>quick start</a>`

--- a/atom/browser/default_app/index.html
+++ b/atom/browser/default_app/index.html
@@ -85,7 +85,7 @@
 
   <h2>
     <script>
-      document.write(`Welcome to Electron (v${process.versions.electron})`)
+      document.write(`Welcome to Electron v${process.versions.electron}`)
     </script>
   </h2>
 

--- a/atom/browser/default_app/index.html
+++ b/atom/browser/default_app/index.html
@@ -92,7 +92,7 @@
 
   <h2>
     <script>
-      document.write(`Welcome to Electron v${process.versions.electron}`)
+      document.write(`Welcome to Electron ${process.versions.electron}`)
     </script>
   </h2>
 

--- a/atom/browser/default_app/index.html
+++ b/atom/browser/default_app/index.html
@@ -3,23 +3,23 @@
   <title>Electron</title>
   <style>
     body {
-      color: #555;
-      font-family: 'Open Sans',Helvetica,Arial,sans-serif;
+      color: #45828E;
+      background-color: #A5ECFA;
+      font-family: 'Helvetica Neue', 'Open Sans', Helvetica, Arial, sans-serif;
       padding: 30px;
     }
 
     h2 {
-      color: #2b6cc2;
-      font-family: "Crimson Text",Georgia,serif;
       font-weight: 400;
       line-height: 1.1;
       letter-spacing: -0.015em;
     }
 
     a {
-      color: #2b6cc2;
+      color: #39AEC6;
       text-decoration: none;
     }
+
     a:hover {
       text-decoration: underline;
     }
@@ -27,7 +27,8 @@
     pre, code {
       font-family: "Menlo","Lucida Console",monospace;
       border: 1px solid #ddd;
-      background-color: #f8f8f8;
+      background-color: #076274;
+      color: #C5F3FC;
       border-radius: 3px;
     }
 
@@ -37,6 +38,11 @@
       line-height: 19px;
       overflow: auto;
       padding: 6px 10px;
+    }
+
+    code {
+      padding: 1px 4px 1px 4px;
+      font-size: 13px;
     }
 
     #holder {
@@ -49,6 +55,7 @@
       text-align: center;
       -webkit-user-select: none;
     }
+
     #holder.hover {
       border: 4px dashed #999;
       color: #eee;

--- a/atom/browser/default_app/index.html
+++ b/atom/browser/default_app/index.html
@@ -64,8 +64,7 @@
     }
 
     #holder.hover {
-      border: 4px dashed #999;
-      color: #eee;
+      background-color: #7BDCEF;
     }
   </style>
 </head>

--- a/atom/browser/default_app/index.html
+++ b/atom/browser/default_app/index.html
@@ -6,13 +6,20 @@
       color: #45828E;
       background-color: #A5ECFA;
       font-family: 'Helvetica Neue', 'Open Sans', Helvetica, Arial, sans-serif;
-      padding: 30px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .container {
+      padding: 15px 30px;
     }
 
     h2 {
+      background-color: #76C7D7;
+      color: #FAF7F3;
       font-weight: 400;
-      line-height: 1.1;
-      letter-spacing: -0.015em;
+      padding: 15px 30px;
+      margin: 0;
     }
 
     a {
@@ -89,36 +96,40 @@
     </script>
   </h2>
 
-  <p>
-  To run your app with Electron, execute the following command under your
-  Console (or Terminal):
-  </p>
+  <div class="container">
 
-  <script>document.write('<pre>' + command + '</pre>')</script>
+    <p>
+    To run your app with Electron, execute the following command under your
+    Console (or Terminal):
+    </p>
 
-  <p>
-  The <code>path-to-your-app</code> should be the path to your own Electron
-  app, you can read the
-  <script>
-    document.write(
-      `<a href='https://github.com/atom/electron/blob/v${process.versions.electron}/docs/tutorial/quick-start.md'>quick start</a>`
-    );
-  </script>
-  guide in Electron's
-  <script>
-    document.write(
-      `<a href='https://github.com/atom/electron/tree/v${process.versions.electron}/docs#readme'>docs</a>`
-    );
-  </script>
-  on how to write one.
-  </p>
+    <script>document.write('<pre>' + command + '</pre>')</script>
 
-  <p>
-  Or you can just drag your app here to run it:
-  </p>
+    <p>
+    The <code>path-to-your-app</code> should be the path to your own Electron
+    app, you can read the
+    <script>
+      document.write(
+        `<a href='https://github.com/atom/electron/blob/v${process.versions.electron}/docs/tutorial/quick-start.md'>quick start</a>`
+      );
+    </script>
+    guide in Electron's
+    <script>
+      document.write(
+        `<a href='https://github.com/atom/electron/tree/v${process.versions.electron}/docs#readme'>docs</a>`
+      );
+    </script>
+    on how to write one.
+    </p>
 
-  <div id="holder">
-    Drag your app here to run it
+    <p>
+    Or you can just drag your app here to run it:
+    </p>
+
+    <div id="holder">
+      Drag your app here to run it
+    </div>
+
   </div>
 
   <script>

--- a/atom/browser/default_app/index.html
+++ b/atom/browser/default_app/index.html
@@ -121,7 +121,7 @@
         `<a href='https://github.com/atom/electron/tree/v${process.versions.electron}/docs#readme'>docs</a>`
       );
     </script>
-    on how to write one.
+    to learn how to write one.
     </p>
 
     <p>


### PR DESCRIPTION
Tweak the default app to look more like http://electron.atom.io/

Also some minor copy edits as well.

### Before

<img width="801" alt="screen shot 2016-02-17 at 10 21 56 am" src="https://cloud.githubusercontent.com/assets/671378/13119928/503327d8-d560-11e5-8c05-152a34ec0123.png">

### After

<img width="801" alt="screen shot 2016-02-17 at 10 20 36 am" src="https://cloud.githubusercontent.com/assets/671378/13119936/56c8a186-d560-11e5-8a9c-d3c45f8fa9bf.png">

/cc @jlord @simurai 