### PR TITLE
Changed session to app to reflect rest of document

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -156,7 +156,7 @@ certificate you should prevent the default behavior with
 `event.preventDefault()` and call `callback(true)`.
 
 ```javascript
-session.on('certificate-error', function(event, webContents, url, error, certificate, callback) {
+app.on('certificate-error', function(event, webContents, url, error, certificate, callback) {
   if (url == "https://github.com") {
     // Verification logic.
     event.preventDefault();


### PR DESCRIPTION
Technically it isn't wrong if you assign ```require('electron').app;``` to session instead of app. But it could be confusing for those that don't catch it especially since all the other examples use app.