### PR TITLE
protocol: respect requests from partition

### DIFF
--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -28,33 +28,6 @@ Protocol::Protocol(AtomBrowserContext* browser_context)
   CHECK(job_factory_);
 }
 
-mate::ObjectTemplateBuilder Protocol::GetObjectTemplateBuilder(
-    v8::Isolate* isolate) {
-  return mate::ObjectTemplateBuilder(isolate)
-      .SetMethod("registerStandardSchemes", &Protocol::RegisterStandardSchemes)
-      .SetMethod("registerServiceWorkerSchemes",
-                 &Protocol::RegisterServiceWorkerSchemes)
-      .SetMethod("registerStringProtocol",
-                 &Protocol::RegisterProtocol<URLRequestStringJob>)
-      .SetMethod("registerBufferProtocol",
-                 &Protocol::RegisterProtocol<URLRequestBufferJob>)
-      .SetMethod("registerFileProtocol",
-                 &Protocol::RegisterProtocol<URLRequestAsyncAsarJob>)
-      .SetMethod("registerHttpProtocol",
-                 &Protocol::RegisterProtocol<URLRequestFetchJob>)
-      .SetMethod("unregisterProtocol", &Protocol::UnregisterProtocol)
-      .SetMethod("isProtocolHandled", &Protocol::IsProtocolHandled)
-      .SetMethod("interceptStringProtocol",
-                 &Protocol::InterceptProtocol<URLRequestStringJob>)
-      .SetMethod("interceptBufferProtocol",
-                 &Protocol::InterceptProtocol<URLRequestBufferJob>)
-      .SetMethod("interceptFileProtocol",
-                 &Protocol::InterceptProtocol<URLRequestAsyncAsarJob>)
-      .SetMethod("interceptHttpProtocol",
-                 &Protocol::InterceptProtocol<URLRequestFetchJob>)
-      .SetMethod("uninterceptProtocol", &Protocol::UninterceptProtocol);
-}
-
 void Protocol::RegisterStandardSchemes(
     const std::vector<std::string>& schemes) {
   atom::AtomBrowserClient::SetCustomSchemes(schemes);
@@ -153,21 +126,34 @@ mate::Handle<Protocol> Protocol::Create(
   return mate::CreateHandle(isolate, new Protocol(browser_context));
 }
 
+// static
+void Protocol::BuildPrototype(v8::Isolate* isolate,
+                              v8::Local<v8::ObjectTemplate> prototype) {
+  mate::ObjectTemplateBuilder(isolate, prototype)
+      .SetMethod("registerStandardSchemes", &Protocol::RegisterStandardSchemes)
+      .SetMethod("registerServiceWorkerSchemes",
+                 &Protocol::RegisterServiceWorkerSchemes)
+      .SetMethod("registerStringProtocol",
+                 &Protocol::RegisterProtocol<URLRequestStringJob>)
+      .SetMethod("registerBufferProtocol",
+                 &Protocol::RegisterProtocol<URLRequestBufferJob>)
+      .SetMethod("registerFileProtocol",
+                 &Protocol::RegisterProtocol<URLRequestAsyncAsarJob>)
+      .SetMethod("registerHttpProtocol",
+                 &Protocol::RegisterProtocol<URLRequestFetchJob>)
+      .SetMethod("unregisterProtocol", &Protocol::UnregisterProtocol)
+      .SetMethod("isProtocolHandled", &Protocol::IsProtocolHandled)
+      .SetMethod("interceptStringProtocol",
+                 &Protocol::InterceptProtocol<URLRequestStringJob>)
+      .SetMethod("interceptBufferProtocol",
+                 &Protocol::InterceptProtocol<URLRequestBufferJob>)
+      .SetMethod("interceptFileProtocol",
+                 &Protocol::InterceptProtocol<URLRequestAsyncAsarJob>)
+      .SetMethod("interceptHttpProtocol",
+                 &Protocol::InterceptProtocol<URLRequestFetchJob>)
+      .SetMethod("uninterceptProtocol", &Protocol::UninterceptProtocol);
+}
+
 }  // namespace api
 
 }  // namespace atom
-
-namespace {
-
-void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
-                v8::Local<v8::Context> context, void* priv) {
-  v8::Isolate* isolate = context->GetIsolate();
-  mate::Dictionary dict(isolate, exports);
-  auto browser_context = static_cast<atom::AtomBrowserContext*>(
-      atom::AtomBrowserMainParts::Get()->browser_context());
-  dict.Set("protocol", atom::api::Protocol::Create(isolate, browser_context));
-}
-
-}  // namespace
-
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(atom_browser_protocol, Initialize)

--- a/atom/browser/api/atom_api_protocol.h
+++ b/atom/browser/api/atom_api_protocol.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <vector>
 
+#include "atom/browser/api/trackable_object.h"
 #include "atom/browser/net/atom_url_request_job_factory.h"
 #include "base/callback.h"
 #include "base/containers/scoped_ptr_hash_map.h"
@@ -30,7 +31,7 @@ class AtomURLRequestJobFactory;
 
 namespace api {
 
-class Protocol : public mate::Wrappable {
+class Protocol : public mate::TrackableObject<Protocol> {
  public:
   using Handler =
       base::Callback<void(const net::URLRequest*, v8::Local<v8::Value>)>;
@@ -40,12 +41,12 @@ class Protocol : public mate::Wrappable {
   static mate::Handle<Protocol> Create(
       v8::Isolate* isolate, AtomBrowserContext* browser_context);
 
+  // mate::TrackableObject:
+  static void BuildPrototype(v8::Isolate* isolate,
+                             v8::Local<v8::ObjectTemplate> prototype);
+
  protected:
   explicit Protocol(AtomBrowserContext* browser_context);
-
-  // mate::Wrappable implementations:
-  virtual mate::ObjectTemplateBuilder GetObjectTemplateBuilder(
-      v8::Isolate* isolate);
 
  private:
   // Possible errors.

--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -9,6 +9,7 @@
 
 #include "atom/browser/api/atom_api_cookies.h"
 #include "atom/browser/api/atom_api_download_item.h"
+#include "atom/browser/api/atom_api_protocol.h"
 #include "atom/browser/api/atom_api_web_contents.h"
 #include "atom/browser/api/atom_api_web_request.h"
 #include "atom/browser/api/save_page_handler.h"
@@ -443,6 +444,14 @@ v8::Local<v8::Value> Session::Cookies(v8::Isolate* isolate) {
   return v8::Local<v8::Value>::New(isolate, cookies_);
 }
 
+v8::Local<v8::Value> Session::Protocol(v8::Isolate* isolate) {
+  if (protocol_.IsEmpty()) {
+    auto handle = atom::api::Protocol::Create(isolate, browser_context());
+    protocol_.Reset(isolate, handle.ToV8());
+  }
+  return v8::Local<v8::Value>::New(isolate, protocol_);
+}
+
 v8::Local<v8::Value> Session::WebRequest(v8::Isolate* isolate) {
   if (web_request_.IsEmpty()) {
     auto handle = atom::api::WebRequest::Create(isolate, browser_context());
@@ -490,6 +499,7 @@ void Session::BuildPrototype(v8::Isolate* isolate,
                  &Session::SetPermissionRequestHandler)
       .SetMethod("clearHostResolverCache", &Session::ClearHostResolverCache)
       .SetProperty("cookies", &Session::Cookies)
+      .SetProperty("protocol", &Session::Protocol)
       .SetProperty("webRequest", &Session::WebRequest);
 }
 

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -80,10 +80,12 @@ class Session: public mate::TrackableObject<Session>,
                                    mate::Arguments* args);
   void ClearHostResolverCache(mate::Arguments* args);
   v8::Local<v8::Value> Cookies(v8::Isolate* isolate);
+  v8::Local<v8::Value> Protocol(v8::Isolate* isolate);
   v8::Local<v8::Value> WebRequest(v8::Isolate* isolate);
 
   // Cached object.
   v8::Global<v8::Value> cookies_;
+  v8::Global<v8::Value> protocol_;
   v8::Global<v8::Value> web_request_;
 
   scoped_refptr<AtomBrowserContext> browser_context_;

--- a/atom/browser/api/lib/protocol.js
+++ b/atom/browser/api/lib/protocol.js
@@ -19,10 +19,6 @@ var logAndThrow = function(callback, message) {
   }
 };
 
-protocol.fromPartition = function(partition) {
-  return session.fromPartition(partition).protocol;
-};
-
 protocol.registerProtocol = function(scheme, handler, callback) {
   return logAndThrow(callback, 'registerProtocol API has been replaced by the register[File/Http/Buffer/String]Protocol API family, please switch to the new APIs.');
 };

--- a/atom/browser/api/lib/protocol.js
+++ b/atom/browser/api/lib/protocol.js
@@ -4,7 +4,10 @@ if (!app.isReady()) {
   throw new Error('Can not initialize protocol module before app is ready');
 }
 
-const protocol = process.atomBinding('protocol').protocol;
+const session = require('electron').session;
+
+// Returns the protocol property for default session.
+const protocol = session.defaultSession.protocol;
 
 // Warn about removed APIs.
 var logAndThrow = function(callback, message) {
@@ -14,6 +17,10 @@ var logAndThrow = function(callback, message) {
   } else {
     throw new Error(message);
   }
+};
+
+protocol.fromPartition = function(partition) {
+  return session.fromPartition(partition).protocol;
 };
 
 protocol.registerProtocol = function(scheme, handler, callback) {

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -41,7 +41,6 @@ REFERENCE_MODULE(atom_browser_download_item);
 REFERENCE_MODULE(atom_browser_menu);
 REFERENCE_MODULE(atom_browser_power_monitor);
 REFERENCE_MODULE(atom_browser_power_save_blocker);
-REFERENCE_MODULE(atom_browser_protocol);
 REFERENCE_MODULE(atom_browser_global_shortcut);
 REFERENCE_MODULE(atom_browser_session);
 REFERENCE_MODULE(atom_browser_tray);

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -523,3 +523,25 @@ The `listener` will be called with `listener(details)` when an error occurs.
   * `timestamp` Double
   * `fromCache` Boolean
   * `error` String - The error description.
+
+#### `ses.protocol`
+
+Returns an instance of [protocol](protocol.md) module for this session.
+
+```javascript
+const electron = require('electron');
+const app = electron.app;
+const session = electron.session;
+const path = require('path');
+
+app.on('ready', function() {
+    const protocol = session.fromPartition(partitionName).protocol;
+    protocol.registerFileProtocol('atom', function(request, callback) {
+      var url = request.url.substr(7);
+      callback({path: path.normalize(__dirname + '/' + url)});
+    }, function (error) {
+      if (error)
+        console.error('Failed to register protocol')
+    });
+});
+```

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -3,6 +3,7 @@ const http = require('http');
 const path = require('path');
 const qs = require('querystring');
 const remote = require('electron').remote;
+const BrowserWindow = remote.require('electron').BrowserWindow;
 const protocol = remote.require('electron').protocol;
 
 describe('protocol module', function() {
@@ -812,6 +813,56 @@ describe('protocol module', function() {
         assert.notEqual(error, null);
         done();
       });
+    });
+  });
+
+  describe('protocol.fromPartition', function() {
+    var partitionName = 'temp';
+    var tempProtocol = protocol.fromPartition(partitionName);
+    var w = null;
+
+    beforeEach(function() {
+      if (w != null) {
+        w.destroy();
+      }
+      w = new BrowserWindow({
+        show: false,
+        width: 400,
+        height: 400,
+        webPreferences: {
+          partition: partitionName
+        }
+      });
+    });
+
+    afterEach(function() {
+      if (w != null) {
+        w.destroy();
+      }
+      w = null;
+    });
+
+    it('handles requests from a partition', function(done) {
+      var handler = function(error, callback) {
+        callback({
+          data: text
+        });
+      };
+      tempProtocol.registerStringProtocol(protocolName, handler, function(error) {
+        if (error) {
+          return done(error);
+        }
+        protocol.isProtocolHandled(protocolName, function(result) {
+          assert.equal(result, false);
+        });
+        tempProtocol.isProtocolHandled(protocolName, function(result) {
+          assert.equal(result, true);
+        });
+      });
+      w.webContents.on('did-finish-load', function() {
+        done();
+      });
+      w.loadURL(protocolName + "://fake-host");
     });
   });
 });

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -5,6 +5,7 @@ const qs = require('querystring');
 const remote = require('electron').remote;
 const BrowserWindow = remote.require('electron').BrowserWindow;
 const protocol = remote.require('electron').protocol;
+const session = remote.require('electron').session;
 
 describe('protocol module', function() {
   var protocolName = 'sp';
@@ -818,7 +819,7 @@ describe('protocol module', function() {
 
   describe('protocol.fromPartition', function() {
     var partitionName = 'temp';
-    var tempProtocol = protocol.fromPartition(partitionName);
+    var tempProtocol = session.fromPartition(partitionName).protocol;
     var w = null;
 
     beforeEach(function() {
@@ -852,17 +853,18 @@ describe('protocol module', function() {
         if (error) {
           return done(error);
         }
+
         protocol.isProtocolHandled(protocolName, function(result) {
           assert.equal(result, false);
         });
         tempProtocol.isProtocolHandled(protocolName, function(result) {
           assert.equal(result, true);
+          w.webContents.on('did-finish-load', function() {
+            done();
+          });
+          w.loadURL(protocolName + "://fake-host");
         });
       });
-      w.webContents.on('did-finish-load', function() {
-        done();
-      });
-      w.loadURL(protocolName + "://fake-host");
     });
   });
 });


### PR DESCRIPTION
Protocol module currently doesnt respect partitions. This just adds a `fromPartition` method similar to `session`, internally `protocol` is now wired as a property of `session`.