### PR TITLE
Keep prototype chain in remote objects

### DIFF
--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 const path = require('path');
 
@@ -95,6 +97,41 @@ describe('ipc module', function() {
       var contents1 = remote.getCurrentWindow().webContents;
       var contents2 = remote.getCurrentWebContents();
       assert(contents1 == contents2);
+    });
+  });
+
+  describe('remote class', function() {
+    let cl = remote.require(path.join(fixtures, 'module', 'class.js'));
+    let base = cl.base;
+    let derived = cl.derived;
+
+    it('can get methods', function() {
+      assert.equal(base.method(), 'method');
+    });
+
+    it('can get properties', function() {
+      assert.equal(base.readonly, 'readonly');
+    });
+
+    it('can change properties', function() {
+      assert.equal(base.value, 'old');
+      base.value = 'new';
+      assert.equal(base.value, 'new');
+      base.value = 'old';
+    });
+
+    it('has unenumerable methods', function() {
+      assert(!base.hasOwnProperty('method'));
+      assert(Object.getPrototypeOf(base).hasOwnProperty('method'));
+    });
+
+    it('keeps prototype chain in derived class', function() {
+      assert.equal(derived.method(), 'method');
+      assert.equal(derived.readonly, 'readonly');
+      assert(!derived.hasOwnProperty('method'));
+      let proto = Object.getPrototypeOf(derived);
+      assert(!proto.hasOwnProperty('method'));
+      assert(Object.getPrototypeOf(proto).hasOwnProperty('method'));
     });
   });
 

--- a/spec/fixtures/module/class.js
+++ b/spec/fixtures/module/class.js
@@ -1,0 +1,29 @@
+'use strict';
+
+let value = 'old';
+
+class BaseClass {
+  method() {
+    return 'method';
+  }
+
+  get readonly() {
+    return 'readonly';
+  }
+
+  get value() {
+    return value;
+  }
+
+  set value(val) {
+    value = val;
+  }
+}
+
+class DerivedClass extends BaseClass {
+}
+
+module.exports = {
+  base: new BaseClass,
+  derived: new DerivedClass,
+}


### PR DESCRIPTION
Instead of simply listing all enumerable methods of an object, `remote` object now just adds getters for own properties, but also carries the original prototype chain.

Fix #4066.