### PR TITLE
Fix crash in mate::Converter<const net::URLRequest*>::ToV8

### DIFF
--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -27,7 +27,9 @@ v8::Local<v8::Value> Converter<const net::URLRequest*>::ToV8(
     v8::Isolate* isolate, const net::URLRequest* val) {
   scoped_ptr<base::DictionaryValue> dict(new base::DictionaryValue);
   dict->SetString("method", val->method());
-  dict->SetStringWithoutPathExpansion("url", val->url().spec());
+  std::string url;
+  if (!val->url_chain().empty()) url = val->url().spec();
+  dict->SetStringWithoutPathExpansion("url", url);
   dict->SetString("referrer", val->referrer());
   scoped_ptr<base::ListValue> list(new base::ListValue);
   atom::GetUploadData(list.get(), val);


### PR DESCRIPTION
The net::URLRequest::url() method calls vector<GURL>::back(), which is undefined when the url_chain is empty

This fixes bug #4591