### PR TITLE
Fix link to FAQ in documentation

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -208,4 +208,4 @@ $ cd electron-quick-start
 $ npm install && npm start
 ```
 
-[share-data]: ../faq/electron-faq.md#how-to-share-data-between-web-pages
+[share-data]: ../../faq/electron-faq#how-to-share-data-between-web-pages


### PR DESCRIPTION
Fixes a broken link to the FAQ in the Quick Start tutorial.

This change breaks the linkage when the tutorial is viewed in Github but my guess is having a correct link on http://electron.atom.io/ takes precedence.

Cheers! :v: