### PR TITLE
linux: optionaly allow building x64 targets with sysroot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /external_binaries/
 /out/
 /vendor/brightray/vendor/download/
+/vendor/debian_wheezy_amd64-sysroot/
 /vendor/debian_wheezy_arm-sysroot/
 /vendor/debian_wheezy_i386-sysroot/
 /vendor/python_26/

--- a/script/install-sysroot.py
+++ b/script/install-sysroot.py
@@ -134,7 +134,11 @@ def main():
     print 'Unknown architecture: %s' % target_arch
     assert(False)
 
-  url = '%s/%s/%s/%s' % (URL_PREFIX, URL_PATH, revision, tarball_filename)
+  if options.url:
+    url = options.url
+    tarball_sha1sum = options.revision
+  else:
+    url = '%s/%s/%s/%s' % (URL_PREFIX, URL_PATH, revision, tarball_filename)
 
   stamp = os.path.join(sysroot, '.stamp')
   if os.path.exists(stamp):
@@ -153,11 +157,12 @@ def main():
   sys.stdout.flush()
   sys.stderr.flush()
   subprocess.check_call(['curl', '--fail', '-L', url, '-o', tarball])
-  sha1sum = GetSha1(tarball)
-  if sha1sum != tarball_sha1sum:
-    print 'Tarball sha1sum is wrong.'
-    print 'Expected %s, actual: %s' % (tarball_sha1sum, sha1sum)
-    return 1
+  if tarball_sha1sum:
+    sha1sum = GetSha1(tarball)
+    if sha1sum != tarball_sha1sum:
+      print 'Tarball sha1sum is wrong.'
+      print 'Expected %s, actual: %s' % (tarball_sha1sum, sha1sum)
+      return 1
   subprocess.check_call(['tar', 'xf', tarball, '-C', sysroot])
   os.remove(tarball)
 
@@ -173,5 +178,9 @@ if __name__ == '__main__':
                                         'Linux builds')
   parser.add_option('--arch', type='choice', choices=valid_archs,
                     help='Sysroot architecture: %s' % ', '.join(valid_archs))
+  parser.add_option('--url', default=None,
+                    help='The URL to download sysroot image.')
+  parser.add_option('--revision', default=None,
+                    help='SHA1 hash of the sysroot image tarball.')
   options, _ = parser.parse_args()
   sys.exit(main())

--- a/script/update.py
+++ b/script/update.py
@@ -60,12 +60,18 @@ def run_gyp(target_arch, component):
     mas_build = 1
   else:
     mas_build = 0
+  # Whether to use sysroot image.
+  if os.environ.has_key('USE_SYSROOT'):
+    use_sysroot = 1
+  else:
+    use_sysroot = 0
   defines = [
     '-Dlibchromiumcontent_component={0}'.format(component),
     '-Dtarget_arch={0}'.format(target_arch),
     '-Dhost_arch={0}'.format(get_host_arch()),
     '-Dlibrary=static_library',
     '-Dmas_build={0}'.format(mas_build),
+    '-Duse_sysroot={0}'.format(use_sysroot)
   ]
   return subprocess.call([python, gyp, '-f', 'ninja', '--depth', '.',
                           'atom.gyp', '-Icommon.gypi'] + defines, env=env)

--- a/toolchain.gypi
+++ b/toolchain.gypi
@@ -113,7 +113,7 @@
     }],
 
     # Setup sysroot environment.
-    ['OS=="linux" and target_arch in ["arm", "ia32"]', {
+    ['OS=="linux" and target_arch in ["arm", "ia32", "x64"] and use_sysroot', {
       'variables': {
         'conditions': [
           ['target_arch=="arm"', {
@@ -123,6 +123,9 @@
           }],
           ['target_arch=="ia32"', {
             'sysroot': '<(source_root)/vendor/debian_wheezy_i386-sysroot',
+          }],
+          ['target_arch=="x64"', {
+            'sysroot': '<(source_root)/vendor/debian_wheezy_amd64-sysroot',
           }],
         ],
       },


### PR DESCRIPTION
Related https://github.com/atom/electron/issues/4626

Target OS: archlinux x64

building with wheezy 64 bit image resulted in some undefined symbols with glib module. So changed to jessie build which had the required version of glib, https://github.com/deepak1556/debian-sysroot-image-creator . Building content layer with the jessie build resulted in some ODR violation, other than that things worked. So there might be some hiccup when shifting to use sysroot for x64.