### PR TITLE
Always call done callback in enumerateDevices spec

### DIFF
--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -94,10 +94,13 @@ describe('chromium feature', function() {
 
     it('can return labels of enumerated devices', function(done) {
       navigator.mediaDevices.enumerateDevices().then((devices) => {
-        const result = devices.some((device) => !!device.label);
-        if (result)
+        const labels = devices.map((device) => device.label);
+        const labelFound = labels.some((label) => !!label);
+        if (labelFound)
           done();
-      });
+        else
+          done('No device labels found: ' + JSON.stringify(labels));
+      }).catch(done);
     });
   });
 

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -7,6 +7,8 @@ const remote = require('electron').remote;
 const BrowserWindow = remote.require('electron').BrowserWindow;
 const session = remote.require('electron').session;
 
+const isCI = remote.getGlobal('isCi');
+
 describe('chromium feature', function() {
   var fixtures = path.resolve(__dirname, 'fixtures');
   var listener = null;
@@ -89,6 +91,9 @@ describe('chromium feature', function() {
 
   describe('navigator.mediaDevices', function() {
     if (process.env.TRAVIS === 'true') {
+      return;
+    }
+    if (isCI && process.platform === 'linux') {
       return;
     }
 


### PR DESCRIPTION
Seeing this error on Linux CI:

```
not ok 247 chromium feature navigator.mediaDevices can return labels of enumerated devices
  Error: timeout of 2000ms exceeded
```

Tweaking the spec to always call the `done` callback to get more details on the error and prevent the timeout message from showing on failures.

Refs https://github.com/atom/electron/pull/4616