### PR TITLE
Make remote member functions writable/configurable

### DIFF
--- a/atom/browser/lib/rpc-server.js
+++ b/atom/browser/lib/rpc-server.js
@@ -16,7 +16,7 @@ const FUNCTION_PROPERTIES = [
 let rendererFunctions = {};
 
 // Return the description of object's members:
-let getObjectMemebers = function(object) {
+let getObjectMembers = function(object) {
   let names = Object.getOwnPropertyNames(object);
   // For Function, we should not override following properties even though they
   // are "own" properties.
@@ -46,7 +46,7 @@ let getObjectPrototype = function(object) {
   if (proto === null || proto === Object.prototype)
     return null;
   return {
-    members: getObjectMemebers(proto),
+    members: getObjectMembers(proto),
     proto: getObjectPrototype(proto),
   };
 };
@@ -101,7 +101,7 @@ var valueToMeta = function(sender, value, optimizeSimpleObject) {
     // passed to renderer we would assume the renderer keeps a reference of
     // it.
     meta.id = objectsRegistry.add(sender, value);
-    meta.members = getObjectMemebers(value);
+    meta.members = getObjectMembers(value);
     meta.proto = getObjectPrototype(value);
   } else if (meta.type === 'buffer') {
     meta.value = Array.prototype.slice.call(value, 0);

--- a/atom/renderer/api/lib/remote.js
+++ b/atom/renderer/api/lib/remote.js
@@ -111,6 +111,7 @@ let setObjectMembers = function(object, metaId, members) {
         }
       };
       descriptor.writable = true;
+      descriptor.configurable = true;
       descriptor.value = remoteMemberFunction;
     } else if (member.type === 'get') {
       descriptor.get = function() {

--- a/atom/renderer/api/lib/remote.js
+++ b/atom/renderer/api/lib/remote.js
@@ -110,6 +110,7 @@ let setObjectMembers = function(object, metaId, members) {
           return metaToValue(ret);
         }
       };
+      descriptor.writable = true;
       descriptor.value = remoteMemberFunction;
     } else if (member.type === 'get') {
       descriptor.get = function() {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -63,6 +63,14 @@ describe('ipc module', function() {
       var obj = new call.constructor;
       assert.equal(obj.test, 'test');
     });
+
+    it('can reassign its member functions', function() {
+      var remoteFunctions = remote.require(path.join(fixtures, 'module', 'function.js'));
+      assert.equal(remoteFunctions.aFunction(), 1127);
+
+      remoteFunctions.aFunction = function () { return 1234; };
+      assert.equal(remoteFunctions.aFunction(), 1234);
+    });
   });
 
   describe('remote value in browser', function() {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -70,6 +70,8 @@ describe('ipc module', function() {
 
       remoteFunctions.aFunction = function () { return 1234; };
       assert.equal(remoteFunctions.aFunction(), 1234);
+
+      assert.equal(delete remoteFunctions.aFunction, true);
     });
   });
 

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -64,7 +64,7 @@ describe('ipc module', function() {
       assert.equal(obj.test, 'test');
     });
 
-    it('can reassign its member functions', function() {
+    it('can reassign and delete its member functions', function() {
       var remoteFunctions = remote.require(path.join(fixtures, 'module', 'function.js'));
       assert.equal(remoteFunctions.aFunction(), 1127);
 

--- a/spec/fixtures/module/function.js
+++ b/spec/fixtures/module/function.js
@@ -1,0 +1,1 @@
+exports.aFunction = function() { return 1127; };


### PR DESCRIPTION
Set `writable` and `configurable` to `true` for the descriptor used for remote member functions.

This seems to restore the behavior pre #4568 where you could re-assign and remove remote member functions such as `require('electron').remote.dialog.showErrorBox`

/cc @zcbenz 

Closes #4636 