### PR TITLE
Respect initial resizable window option on Linux

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -115,6 +115,12 @@ void NativeWindow::InitFromOptions(const mate::Dictionary& options) {
   } else {
     SetSizeConstraints(size_constraints);
   }
+#if defined(USE_X11)
+  bool resizable;
+  if (options.Get(options::kResizable, &resizable)) {
+    SetResizable(resizable);
+  }
+#endif
 #if defined(OS_WIN) || defined(USE_X11)
   bool closable;
   if (options.Get(options::kClosable, &closable)) {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -124,6 +124,7 @@ NativeWindowViews::NativeWindowViews(
 #if defined(OS_WIN)
   // On Windows we rely on the CanResize() to indicate whether window can be
   // resized, and it should be set before window is created.
+  options.Get(options::kResizable, &resizable_);
   options.Get(options::kMinimizable, &minimizable_);
   options.Get(options::kMaximizable, &maximizable_);
 #endif

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -120,11 +120,11 @@ NativeWindowViews::NativeWindowViews(
       minimizable_(true) {
   options.Get(options::kTitle, &title_);
   options.Get(options::kAutoHideMenuBar, &menu_bar_autohide_);
+  options.Get(options::kResizable, &resizable_);
 
 #if defined(OS_WIN)
   // On Windows we rely on the CanResize() to indicate whether window can be
   // resized, and it should be set before window is created.
-  options.Get(options::kResizable, &resizable_);
   options.Get(options::kMinimizable, &minimizable_);
   options.Get(options::kMaximizable, &maximizable_);
 #endif

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -218,6 +218,12 @@ NativeWindowViews::NativeWindowViews(
   std::string window_type;
   if (options.Get(options::kType, &window_type))
     SetWindowType(GetAcceleratedWidget(), window_type);
+
+  if (!resizable_) {
+    gfx::Size content_size = GetContentSize();
+    SetContentSizeConstraints(
+        extensions::SizeConstraints(content_size, content_size));
+  }
 #endif
 
   // Add web view.

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -120,7 +120,6 @@ NativeWindowViews::NativeWindowViews(
       minimizable_(true) {
   options.Get(options::kTitle, &title_);
   options.Get(options::kAutoHideMenuBar, &menu_bar_autohide_);
-  options.Get(options::kResizable, &resizable_);
 
 #if defined(OS_WIN)
   // On Windows we rely on the CanResize() to indicate whether window can be
@@ -218,12 +217,6 @@ NativeWindowViews::NativeWindowViews(
   std::string window_type;
   if (options.Get(options::kType, &window_type))
     SetWindowType(GetAcceleratedWidget(), window_type);
-
-  if (!resizable_) {
-    gfx::Size content_size = GetContentSize();
-    SetContentSizeConstraints(
-        extensions::SizeConstraints(content_size, content_size));
-  }
 #endif
 
   // Add web view.

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -527,6 +527,24 @@ describe('browser-window module', function() {
     });
   });
 
+  describe('window states', function () {
+    describe('resizable state', function() {
+      it('can be changed with resizable option', function() {
+        w.destroy();
+        w = new BrowserWindow({show: false, resizable: false});
+        assert.equal(w.isResizable(), false);
+      });
+
+      it('can be changed with setResizable method', function() {
+        assert.equal(w.isResizable(), true);
+        w.setResizable(false);
+        assert.equal(w.isResizable(), false);
+        w.setResizable(true);
+        assert.equal(w.isResizable(), true);
+      });
+    });
+  })
+
   describe('window states', function() {
     // Not implemented on Linux.
     if (process.platform == 'linux')
@@ -622,22 +640,6 @@ describe('browser-window module', function() {
         assert.equal(w.isClosable(), false);
         w.setClosable(true);
         assert.equal(w.isClosable(), true);
-      });
-    });
-
-    describe('resizable state', function() {
-      it('can be changed with resizable option', function() {
-        w.destroy();
-        w = new BrowserWindow({show: false, resizable: false});
-        assert.equal(w.isResizable(), false);
-      });
-
-      it('can be changed with setResizable method', function() {
-        assert.equal(w.isResizable(), true);
-        w.setResizable(false);
-        assert.equal(w.isResizable(), false);
-        w.setResizable(true);
-        assert.equal(w.isResizable(), true);
       });
     });
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -543,7 +543,7 @@ describe('browser-window module', function() {
         assert.equal(w.isResizable(), true);
       });
     });
-  })
+  });
 
   describe('window states', function() {
     // Not implemented on Linux.

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -527,7 +527,7 @@ describe('browser-window module', function() {
     });
   });
 
-  describe('window states', function () {
+  describe('window states', function() {
     describe('resizable state', function() {
       it('can be changed with resizable option', function() {
         w.destroy();

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -545,7 +545,7 @@ describe('browser-window module', function() {
     });
   });
 
-  describe('window states', function() {
+  describe('window states (excluding Linux)', function() {
     // Not implemented on Linux.
     if (process.platform == 'linux')
       return;


### PR DESCRIPTION
Respect initial `resizable` BrowserWindow option on Linux.

Closes #4544