### PR TITLE
Remove CoffeeScript from styleguide

### DIFF
--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -2,8 +2,8 @@
 
 These are the style guidelines for coding in Electron.
 
-You can run `npm run lint` to show all coding style issues detected by `cpplint`
-and `eslint`.
+You can run `npm run lint` to show any style issues detected by `cpplint` and
+`eslint`.
 
 ## C++ and Python
 

--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -17,17 +17,23 @@ document. The document mentions some special types, scoped types (that
 automatically release their memory when going out of scope), logging mechanisms
 etc.
 
-## CoffeeScript
-
-For CoffeeScript, we follow GitHub's [Style
-Guide](https://github.com/styleguide/javascript) and the following rules:
+## JavaScript
 
 * Files should **NOT** end with new line, because we want to match Google's
   styles.
 * File names should be concatenated with `-` instead of `_`, e.g.
-  `file-name.coffee` rather than `file_name.coffee`, because in
+  `file-name.js` rather than `file_name.js`, because in
   [github/atom](https://github.com/github/atom) module names are usually in
-  the `module-name` form. This rule only applies to `.coffee` files.
+  the `module-name` form. This rule only applies to `.js` files.
+* Use newer ES6/ES2015 syntax where appropriate
+  * [`const`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const)
+    for requires and other constants
+  * [`let`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let)
+    for defining variables
+  * [Arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+    instead of `function () { }`
+  * [Template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
+    instead of string concatenation using `+`
 
 ## API Names
 

--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -2,6 +2,9 @@
 
 These are the style guidelines for coding in Electron.
 
+You can run `npm run lint` to show all coding style issues detected by `cpplint`
+and `eslint`.
+
 ## C++ and Python
 
 For C++ and Python, we follow Chromium's [Coding

--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -19,6 +19,8 @@ etc.
 
 ## JavaScript
 
+* Use a two space indent, no hard tabs.
+* End lines with a `;`
 * Files should **NOT** end with new line, because we want to match Google's
   styles.
 * File names should be concatenated with `-` instead of `_`, e.g.


### PR DESCRIPTION
Update the `CoffeeScript` section to be `JavaScript` instead and mention es6/es2015 things that should be used going forward with links to MDN.

Closes #4692