### PR TITLE
Map missing selectors to roles

### DIFF
--- a/atom/browser/api/lib/menu-item.js
+++ b/atom/browser/api/lib/menu-item.js
@@ -11,7 +11,8 @@ rolesMap = {
   paste: 'paste',
   selectall: 'selectAll',
   minimize: 'minimize',
-  close: 'close'
+  close: 'close',
+  delete: 'delete'
 };
 
 // Maps methods that should be called directly on the BrowserWindow instance

--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -37,6 +37,7 @@ Role kRolesMap[] = {
   { @selector(selectAll:), "selectall" },
   { @selector(performMiniaturize:), "minimize" },
   { @selector(performClose:), "close" },
+  { @selector(performZoom:), "zoom" },
 };
 
 }  // namespace

--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -32,7 +32,7 @@ Role kRolesMap[] = {
   { @selector(cut:), "cut" },
   { @selector(copy:), "copy" },
   { @selector(paste:), "paste" },
-  { @selector(delete:), "delete"},
+  { @selector(delete:), "delete" },
   { @selector(pasteAndMatchStyle:), "paste-and-match-style" },
   { @selector(selectAll:), "selectall" },
   { @selector(performMiniaturize:), "minimize" },

--- a/atom/browser/ui/cocoa/atom_menu_controller.mm
+++ b/atom/browser/ui/cocoa/atom_menu_controller.mm
@@ -32,6 +32,8 @@ Role kRolesMap[] = {
   { @selector(cut:), "cut" },
   { @selector(copy:), "copy" },
   { @selector(paste:), "paste" },
+  { @selector(delete:), "delete"},
+  { @selector(pasteAndMatchStyle:), "paste-and-match-style" },
   { @selector(selectAll:), "selectall" },
   { @selector(performMiniaturize:), "minimize" },
   { @selector(performClose:), "close" },


### PR DESCRIPTION
So it's entirely possible that I'm doing this Entirely Wrong, buuut I noticed that (the [apparently deprecated](https://github.com/atom/electron/pull/3554)) `selector`s, used only on OS X, don't map completely to their replacements in `role`. Specifically, `pasteAndMatchStyle` and `delete` don't seem to map to anything. There may be other mappings we're missing here too, which I'd be happy to add. :smile: 