### PR TITLE
Document 'app.focus()'

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -248,14 +248,6 @@ This method guarantees that all `beforeunload` and `unload` event handlers are
 correctly executed. It is possible that a window cancels the quitting by
 returning `false` in the `beforeunload` event handler.
 
-### `app.hide()` _OS X_
-
-Hides all application windows without minimizing them.
-
-### `app.show()` _OS X_
-
-Shows application windows after they were hidden. Does not automatically focus them.
-
 ### `app.exit(exitCode)`
 
 * `exitCode` Integer
@@ -264,6 +256,18 @@ Exits immediately with `exitCode`.
 
 All windows will be closed immediately without asking user and the `before-quit`
 and `will-quit` events will not be emitted.
+
+### `app.focus()`
+
+On Linux, focuses on the first visible window. On OS X, makes the application the active app. On Windows, focuses on the application's first window.
+
+### `app.hide()` _OS X_
+
+Hides all application windows without minimizing them.
+
+### `app.show()` _OS X_
+
+Shows application windows after they were hidden. Does not automatically focus them.
 
 ### `app.getAppPath()`
 


### PR DESCRIPTION
`app.focus()` was missing from the docs.