### PR TITLE
Use arrow functions instead of CoffeeScript this wrapper functions

### DIFF
--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const deprecate = require('electron').deprecate;
 const session = require('electron').session;
 const Menu = require('electron').Menu;
@@ -89,11 +91,9 @@ deprecate.rename(app, 'terminate', 'quit');
 deprecate.event(app, 'finish-launching', 'ready', function() {
 
   // give default app a chance to setup default menu.
-  return setImmediate((function(_this) {
-    return function() {
-      return _this.emit('finish-launching');
-    };
-  })(this));
+  setImmediate(() => {
+    this.emit('finish-launching');
+  });
 });
 
 deprecate.event(app, 'activate-with-no-open-windows', 'activate', function(event, hasVisibleWindows) {

--- a/lib/browser/api/auto-updater/auto-updater-win.js
+++ b/lib/browser/api/auto-updater/auto-updater-win.js
@@ -28,30 +28,28 @@ AutoUpdater.prototype.checkForUpdates = function() {
     return this.emitError('Can not find Squirrel');
   }
   this.emit('checking-for-update');
-  return squirrelUpdate.download(this.updateURL, (function(_this) {
-    return function(error, update) {
+  squirrelUpdate.download(this.updateURL, (error, update) => {
+    if (error != null) {
+      return this.emitError(error);
+    }
+    if (update == null) {
+      return this.emit('update-not-available');
+    }
+    this.emit('update-available');
+    squirrelUpdate.update(this.updateURL, (error) => {
+      var date, releaseNotes, version;
       if (error != null) {
-        return _this.emitError(error);
+        return this.emitError(error);
       }
-      if (update == null) {
-        return _this.emit('update-not-available');
-      }
-      _this.emit('update-available');
-      return squirrelUpdate.update(_this.updateURL, function(error) {
-        var date, releaseNotes, version;
-        if (error != null) {
-          return _this.emitError(error);
-        }
-        releaseNotes = update.releaseNotes, version = update.version;
+      releaseNotes = update.releaseNotes, version = update.version;
 
-        // Following information is not available on Windows, so fake them.
-        date = new Date;
-        return _this.emit('update-downloaded', {}, releaseNotes, version, date, _this.updateURL, function() {
-          return _this.quitAndInstall();
-        });
+      // Following information is not available on Windows, so fake them.
+      date = new Date;
+      this.emit('update-downloaded', {}, releaseNotes, version, date, this.updateURL, () => {
+        this.quitAndInstall();
       });
-    };
-  })(this));
+    });
+  });
 };
 
 // Private: Emit both error object and message, this is to keep compatibility

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const ipcMain = require('electron').ipcMain;
 const deprecate = require('electron').deprecate;
 const EventEmitter = require('events').EventEmitter;
@@ -33,19 +35,19 @@ BrowserWindow.prototype._init = function() {
   // window.resizeTo(...)
   // window.moveTo(...)
   this.webContents.on('move', (event, size) => {
-    return this.setBounds(size);
+    this.setBounds(size);
   });
 
   // Hide the auto-hide menu when webContents is focused.
   this.webContents.on('activate', () => {
     if (process.platform !== 'darwin' && this.isMenuBarAutoHide() && this.isMenuBarVisible()) {
-      return this.setMenuBarVisibility(false);
+      this.setMenuBarVisibility(false);
     }
   });
 
   // Forward the crashed event.
   this.webContents.on('crashed', () => {
-    return this.emit('crashed');
+    this.emit('crashed');
   });
 
   // Change window title to page title.

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -69,29 +69,29 @@ BrowserWindow.prototype._init = function() {
   // Though this hack is only needed on OS X when the app is launched from
   // Finder, we still do it on all platforms in case of other bugs we don't know.
   this.webContents.once('load-url', function() {
-    return this.focus();
+    this.focus();
   });
 
   // Redirect focus/blur event to app instance too.
   this.on('blur', (event) => {
-    return app.emit('browser-window-blur', event, this);
+    app.emit('browser-window-blur', event, this);
   });
   this.on('focus', (event) => {
-    return app.emit('browser-window-focus', event, this);
+    app.emit('browser-window-focus', event, this);
   });
 
   // Evented visibilityState changes
   this.on('show', () => {
-    return this.webContents.send('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized());
+    this.webContents.send('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized());
   });
   this.on('hide', () => {
-    return this.webContents.send('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized());
+    this.webContents.send('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized());
   });
   this.on('minimize', () => {
-    return this.webContents.send('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized());
+    this.webContents.send('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized());
   });
   this.on('restore', () => {
-    return this.webContents.send('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized());
+    this.webContents.send('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', this.isVisible(), this.isMinimized());
   });
 
   // Notify the creation of the window.
@@ -99,15 +99,15 @@ BrowserWindow.prototype._init = function() {
 
   // Be compatible with old APIs.
   this.webContents.on('devtools-focused', () => {
-    return this.emit('devtools-focused');
+    this.emit('devtools-focused');
   });
   this.webContents.on('devtools-opened', () => {
-    return this.emit('devtools-opened');
+    this.emit('devtools-opened');
   });
   this.webContents.on('devtools-closed', () => {
-    return this.emit('devtools-closed');
+    this.emit('devtools-closed');
   });
-  return Object.defineProperty(this, 'devToolsWebContents', {
+  Object.defineProperty(this, 'devToolsWebContents', {
     enumerable: true,
     configurable: false,
     get: function() {

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var MenuItem, methodInBrowserWindow, nextCommandId, rolesMap;
 
 nextCommandId = 0;
@@ -51,28 +53,25 @@ MenuItem = (function() {
       throw new Error("Unknown menu type " + this.type);
     }
     this.commandId = ++nextCommandId;
-    this.click = (function(_this) {
-      return function(focusedWindow) {
-
-        // Manually flip the checked flags when clicked.
-        var methodName, ref1, ref2;
-        if ((ref1 = _this.type) === 'checkbox' || ref1 === 'radio') {
-          _this.checked = !_this.checked;
+    this.click = (focusedWindow) => {
+      // Manually flip the checked flags when clicked.
+      var methodName, ref1, ref2;
+      if ((ref1 = this.type) === 'checkbox' || ref1 === 'radio') {
+        this.checked = !this.checked;
+      }
+      if (this.role && rolesMap[this.role] && process.platform !== 'darwin' && (focusedWindow != null)) {
+        methodName = rolesMap[this.role];
+        if (methodInBrowserWindow[methodName]) {
+          return focusedWindow[methodName]();
+        } else {
+          return (ref2 = focusedWindow.webContents) != null ? ref2[methodName]() : void 0;
         }
-        if (_this.role && rolesMap[_this.role] && process.platform !== 'darwin' && (focusedWindow != null)) {
-          methodName = rolesMap[_this.role];
-          if (methodInBrowserWindow[methodName]) {
-            return focusedWindow[methodName]();
-          } else {
-            return (ref2 = focusedWindow.webContents) != null ? ref2[methodName]() : void 0;
-          }
-        } else if (typeof click === 'function') {
-          return click(_this, focusedWindow);
-        } else if (typeof _this.selector === 'string' && process.platform === 'darwin') {
-          return Menu.sendActionToFirstResponder(_this.selector);
-        }
-      };
-    })(this);
+      } else if (typeof click === 'function') {
+        return click(this, focusedWindow);
+      } else if (typeof this.selector === 'string' && process.platform === 'darwin') {
+        return Menu.sendActionToFirstResponder(this.selector);
+      }
+    };
   }
 
   MenuItem.prototype.overrideProperty = function(name, defaultValue) {

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -122,7 +122,6 @@ Menu.prototype._init = function() {
       // Make sure radio groups have at least one menu item seleted.
       var checked, group, id, j, len, radioItem, ref1;
       ref1 = this.groupsMap;
-      results = [];
       for (id in ref1) {
         group = ref1[id];
         checked = false;
@@ -137,7 +136,7 @@ Menu.prototype._init = function() {
         if (!checked) {
           v8Util.setHiddenValue(group[0], 'checked', true);
         }
-      };
+      }
     }
   };
 };

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -112,7 +112,7 @@ Menu.prototype._init = function() {
     },
     getIconForCommandId: (commandId) => {
       var command = this.commandsMap[commandId];
-      return command != null ? command.icon : void 0;
+      return command != null ? command.icon : undefined;
     },
     executeCommand: (commandId) => {
       var command = this.commandsMap[commandId];

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const BrowserWindow = require('electron').BrowserWindow;
 const MenuItem = require('electron').MenuItem;
 const EventEmitter = require('events').EventEmitter;
@@ -92,65 +94,51 @@ Menu.prototype._init = function() {
   this.groupsMap = {};
   this.items = [];
   return this.delegate = {
-    isCommandIdChecked: (function(_this) {
-      return function(commandId) {
-        var ref1;
-        return (ref1 = _this.commandsMap[commandId]) != null ? ref1.checked : void 0;
-      };
-    })(this),
-    isCommandIdEnabled: (function(_this) {
-      return function(commandId) {
-        var ref1;
-        return (ref1 = _this.commandsMap[commandId]) != null ? ref1.enabled : void 0;
-      };
-    })(this),
-    isCommandIdVisible: (function(_this) {
-      return function(commandId) {
-        var ref1;
-        return (ref1 = _this.commandsMap[commandId]) != null ? ref1.visible : void 0;
-      };
-    })(this),
-    getAcceleratorForCommandId: (function(_this) {
-      return function(commandId) {
-        var ref1;
-        return (ref1 = _this.commandsMap[commandId]) != null ? ref1.accelerator : void 0;
-      };
-    })(this),
-    getIconForCommandId: (function(_this) {
-      return function(commandId) {
-        var ref1;
-        return (ref1 = _this.commandsMap[commandId]) != null ? ref1.icon : void 0;
-      };
-    })(this),
-    executeCommand: (function(_this) {
-      return function(commandId) {
-        var ref1;
-        return (ref1 = _this.commandsMap[commandId]) != null ? ref1.click(BrowserWindow.getFocusedWindow()) : void 0;
-      };
-    })(this),
-    menuWillShow: (function(_this) {
-      return function() {
-
-        // Make sure radio groups have at least one menu item seleted.
-        var checked, group, id, j, len, radioItem, ref1;
-        ref1 = _this.groupsMap;
-        for (id in ref1) {
-          group = ref1[id];
-          checked = false;
-          for (j = 0, len = group.length; j < len; j++) {
-            radioItem = group[j];
-            if (!radioItem.checked) {
-              continue;
-            }
-            checked = true;
-            break;
+    isCommandIdChecked: (commandId) => {
+      var command = this.commandsMap[commandId];
+      return command != null ? command.checked : undefined;
+    },
+    isCommandIdEnabled: (commandId) => {
+      var command = this.commandsMap[commandId];
+      return command != null ? command.enabled : undefined;
+    },
+    isCommandIdVisible: (commandId) => {
+      var command = this.commandsMap[commandId];
+      return command != null ? command.visible : undefined;
+    },
+    getAcceleratorForCommandId: (commandId) => {
+      var command = this.commandsMap[commandId];
+      return command != null ? command.accelerator : undefined;
+    },
+    getIconForCommandId: (commandId) => {
+      var command = this.commandsMap[commandId];
+      return command != null ? command.icon : void 0;
+    },
+    executeCommand: (commandId) => {
+      var command = this.commandsMap[commandId];
+      return command != null ? command.click(BrowserWindow.getFocusedWindow()) : undefined;
+    },
+    menuWillShow: () => {
+      // Make sure radio groups have at least one menu item seleted.
+      var checked, group, id, j, len, radioItem, ref1;
+      ref1 = this.groupsMap;
+      results = [];
+      for (id in ref1) {
+        group = ref1[id];
+        checked = false;
+        for (j = 0, len = group.length; j < len; j++) {
+          radioItem = group[j];
+          if (!radioItem.checked) {
+            continue;
           }
-          if (!checked) {
-            v8Util.setHiddenValue(group[0], 'checked', true);
-          }
+          checked = true;
+          break;
+        }
+        if (!checked) {
+          v8Util.setHiddenValue(group[0], 'checked', true);
         }
       };
-    })(this)
+    }
   };
 };
 
@@ -208,19 +196,17 @@ Menu.prototype.insert = function(pos, item) {
         get: function() {
           return v8Util.getHiddenValue(item, 'checked');
         },
-        set: (function(_this) {
-          return function() {
-            var j, len, otherItem, ref1;
-            ref1 = _this.groupsMap[item.groupId];
-            for (j = 0, len = ref1.length; j < len; j++) {
-              otherItem = ref1[j];
-              if (otherItem !== item) {
-                v8Util.setHiddenValue(otherItem, 'checked', false);
-              }
+        set: () => {
+          var j, len, otherItem, ref1;
+          ref1 = this.groupsMap[item.groupId];
+          for (j = 0, len = ref1.length; j < len; j++) {
+            otherItem = ref1[j];
+            if (otherItem !== item) {
+              v8Util.setHiddenValue(otherItem, 'checked', false);
             }
-            return v8Util.setHiddenValue(item, 'checked', true);
-          };
-        })(this)
+          }
+          return v8Util.setHiddenValue(item, 'checked', true);
+        }
       });
       this.insertRadioItem(pos, item.commandId, item.label, item.groupId);
   }

--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const ipcMain = require('electron').ipcMain;
 
 var slice = [].slice;
@@ -30,40 +32,33 @@ var NavigationController = (function() {
       this.currentIndex++;
       this.history.push(this.webContents._getURL());
     }
-    this.webContents.on('navigation-entry-commited', (function(_this) {
-      return function(event, url, inPage, replaceEntry) {
-        var currentEntry;
-        if (_this.inPageIndex > -1 && !inPage) {
-
-          // Navigated to a new page, clear in-page mark.
-          _this.inPageIndex = -1;
-        } else if (_this.inPageIndex === -1 && inPage) {
-
-          // Started in-page navigations.
-          _this.inPageIndex = _this.currentIndex;
+    this.webContents.on('navigation-entry-commited', (event, url, inPage, replaceEntry) => {
+      var currentEntry;
+      if (this.inPageIndex > -1 && !inPage) {
+        // Navigated to a new page, clear in-page mark.
+        this.inPageIndex = -1;
+      } else if (this.inPageIndex === -1 && inPage) {
+        // Started in-page navigations.
+        this.inPageIndex = this.currentIndex;
+      }
+      if (this.pendingIndex >= 0) {
+        // Go to index.
+        this.currentIndex = this.pendingIndex;
+        this.pendingIndex = -1;
+        return this.history[this.currentIndex] = url;
+      } else if (replaceEntry) {
+        // Non-user initialized navigation.
+        return this.history[this.currentIndex] = url;
+      } else {
+        // Normal navigation. Clear history.
+        this.history = this.history.slice(0, this.currentIndex + 1);
+        currentEntry = this.history[this.currentIndex];
+        if ((currentEntry != null ? currentEntry.url : void 0) !== url) {
+          this.currentIndex++;
+          return this.history.push(url);
         }
-        if (_this.pendingIndex >= 0) {
-
-          // Go to index.
-          _this.currentIndex = _this.pendingIndex;
-          _this.pendingIndex = -1;
-          return _this.history[_this.currentIndex] = url;
-        } else if (replaceEntry) {
-
-          // Non-user initialized navigation.
-          return _this.history[_this.currentIndex] = url;
-        } else {
-
-          // Normal navigation. Clear history.
-          _this.history = _this.history.slice(0, _this.currentIndex + 1);
-          currentEntry = _this.history[_this.currentIndex];
-          if ((currentEntry != null ? currentEntry.url : void 0) !== url) {
-            _this.currentIndex++;
-            return _this.history.push(url);
-          }
-        }
-      };
-    })(this));
+      }
+    });
   }
 
   NavigationController.prototype.loadURL = function(url, options) {

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -153,35 +153,28 @@ let wrapWebContents = function(webContents) {
 
   // This error occurs when host could not be found.
   webContents.on('did-fail-provisional-load', function() {
-    var args;
-    args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
+    var args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
 
     // Calling loadURL during this event might cause crash, so delay the event
     // until next tick.
-    return setImmediate((function(_this) {
-      return function() {
-        return _this.emit.apply(_this, ['did-fail-load'].concat(slice.call(args)));
-      };
-    })(this));
+    setImmediate(() => {
+      this.emit.apply(this, ['did-fail-load'].concat(slice.call(args)));
+    });
   });
 
   // Delays the page-title-updated event to next tick.
   webContents.on('-page-title-updated', function() {
-    var args;
-    args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
-    return setImmediate((function(_this) {
-      return function() {
-        return _this.emit.apply(_this, ['page-title-updated'].concat(slice.call(args)));
-      };
-    })(this));
+    var args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
+    setImmediate(() => {
+      this.emit.apply(this, ['page-title-updated'].concat(slice.call(args)));
+    });
   });
 
   // Deprecated.
   deprecate.rename(webContents, 'loadUrl', 'loadURL');
   deprecate.rename(webContents, 'getUrl', 'getURL');
   deprecate.event(webContents, 'page-title-set', 'page-title-updated', function() {
-    var args;
-    args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
+    var args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
     return this.emit.apply(this, ['page-title-set'].concat(slice.call(args)));
   });
   return webContents.printToPDF = function(options, callback) {

--- a/lib/common/api/crash-reporter.js
+++ b/lib/common/api/crash-reporter.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const os = require('os');
 const path = require('path');
 const spawn = require('child_process').spawn;
@@ -52,11 +54,9 @@ var CrashReporter = (function() {
       deprecate.log('submitURL is now a required option to crashReporter.start');
       return;
     }
-    start = (function(_this) {
-      return function() {
-        return binding.start(_this.productName, companyName, submitURL, autoSubmit, ignoreSystemCrashHandler, extra);
-      };
-    })(this);
+    start = () => {
+      binding.start(this.productName, companyName, submitURL, autoSubmit, ignoreSystemCrashHandler, extra);
+    };
     if (process.platform === 'win32') {
       args = ["--reporter-url=" + submitURL, "--application-name=" + this.productName, "--v=1"];
       env = {

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const ipcRenderer = require('electron').ipcRenderer;
 const remote = require('electron').remote;
 
@@ -37,12 +39,10 @@ var BrowserWindowProxy = (function() {
   function BrowserWindowProxy(guestId1) {
     this.guestId = guestId1;
     this.closed = false;
-    ipcRenderer.once("ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSED_" + this.guestId, (function(_this) {
-      return function() {
-        BrowserWindowProxy.remove(_this.guestId);
-        return (_this.closed = true);
-      };
-    })(this));
+    ipcRenderer.once("ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSED_" + this.guestId, () => {
+      BrowserWindowProxy.remove(this.guestId);
+      this.closed = true;
+    });
   }
 
   BrowserWindowProxy.prototype.close = function() {
@@ -182,7 +182,7 @@ if (process.openerId != null) {
 
 ipcRenderer.on('ATOM_RENDERER_WINDOW_VISIBILITY_CHANGE', function (event, isVisible, isMinimized) {
   var hasChanged = _isVisible != isVisible || _isMinimized != isMinimized;
-  
+
   if (hasChanged) {
     _isVisible = isVisible;
     _isMinimized = isMinimized;

--- a/lib/renderer/web-view/web-view-attributes.js
+++ b/lib/renderer/web-view/web-view-attributes.js
@@ -44,16 +44,12 @@ class WebViewAttribute {
   // Defines this attribute as a property on the webview node.
   defineProperty() {
     return Object.defineProperty(this.webViewImpl.webviewNode, this.name, {
-      get: (function(_this) {
-        return function() {
-          return _this.getValue();
-        };
-      })(this),
-      set: (function(_this) {
-        return function(value) {
-          return _this.setValue(value);
-        };
-      })(this),
+      get: () => {
+        return this.getValue();
+      },
+      set: (value) => {
+        return this.setValue(value);
+      },
       enumerable: true
     });
   }
@@ -203,20 +199,18 @@ class SrcAttribute extends WebViewAttribute {
   // spawns off a new process.
   setupMutationObserver() {
     var params;
-    this.observer = new MutationObserver((function(_this) {
-      return function(mutations) {
-        var i, len, mutation, newValue, oldValue;
-        for (i = 0, len = mutations.length; i < len; i++) {
-          mutation = mutations[i];
-          oldValue = mutation.oldValue;
-          newValue = _this.getValue();
-          if (oldValue !== newValue) {
-            return;
-          }
-          _this.handleMutation(oldValue, newValue);
+    this.observer = new MutationObserver((mutations) => {
+      var i, len, mutation, newValue, oldValue;
+      for (i = 0, len = mutations.length; i < len; i++) {
+        mutation = mutations[i];
+        oldValue = mutation.oldValue;
+        newValue = this.getValue();
+        if (oldValue !== newValue) {
+          return;
         }
-      };
-    })(this));
+        this.handleMutation(oldValue, newValue);
+      }
+    });
     params = {
       attributes: true,
       attributeOldValue: true,

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -86,25 +86,22 @@ var WebViewImpl = (function() {
 
   WebViewImpl.prototype.setupFocusPropagation = function() {
     if (!this.webviewNode.hasAttribute('tabIndex')) {
-
       // <webview> needs a tabIndex in order to be focusable.
       // TODO(fsamuel): It would be nice to avoid exposing a tabIndex attribute
       // to allow <webview> to be focusable.
       // See http://crbug.com/231664.
       this.webviewNode.setAttribute('tabIndex', -1);
     }
-    this.webviewNode.addEventListener('focus', (function(_this) {
-      return function() {
-        // Focus the BrowserPlugin when the <webview> takes focus.
-        return _this.browserPluginNode.focus();
-      };
-    })(this));
-    return this.webviewNode.addEventListener('blur', (function(_this) {
-      return function() {
-        // Blur the BrowserPlugin when the <webview> loses focus.
-        return _this.browserPluginNode.blur();
-      };
-    })(this));
+
+    // Focus the BrowserPlugin when the <webview> takes focus.
+    this.webviewNode.addEventListener('focus', () => {
+      this.browserPluginNode.focus();
+    });
+
+    // Blur the BrowserPlugin when the <webview> loses focus.
+    this.webviewNode.addEventListener('blur', () => {
+      this.browserPluginNode.blur();
+    });
   };
 
 
@@ -178,11 +175,9 @@ var WebViewImpl = (function() {
   };
 
   WebViewImpl.prototype.createGuest = function() {
-    return guestViewInternal.createGuest(this.buildParams(), (function(_this) {
-      return function(event, guestInstanceId) {
-        return _this.attachWindow(guestInstanceId);
-      };
-    })(this));
+    return guestViewInternal.createGuest(this.buildParams(), (event, guestInstanceId) => {
+      this.attachWindow(guestInstanceId);
+    });
   };
 
   WebViewImpl.prototype.dispatchEvent = function(webViewEvent) {
@@ -195,22 +190,18 @@ var WebViewImpl = (function() {
     var propertyName;
     propertyName = 'on' + eventName.toLowerCase();
     return Object.defineProperty(this.webviewNode, propertyName, {
-      get: (function(_this) {
-        return function() {
-          return _this.on[propertyName];
-        };
-      })(this),
-      set: (function(_this) {
-        return function(value) {
-          if (_this.on[propertyName]) {
-            _this.webviewNode.removeEventListener(eventName, _this.on[propertyName]);
-          }
-          _this.on[propertyName] = value;
-          if (value) {
-            return _this.webviewNode.addEventListener(eventName, value);
-          }
-        };
-      })(this),
+      get: () => {
+        this.on[propertyName];
+      },
+      set: (value) => {
+        if (this.on[propertyName]) {
+          this.webviewNode.removeEventListener(eventName, this.on[propertyName]);
+        }
+        this.on[propertyName] = value;
+        if (value) {
+          return this.webviewNode.addEventListener(eventName, value);
+        }
+      },
       enumerable: true
     });
   };

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -191,7 +191,7 @@ var WebViewImpl = (function() {
     propertyName = 'on' + eventName.toLowerCase();
     return Object.defineProperty(this.webviewNode, propertyName, {
       get: () => {
-        this.on[propertyName];
+        return this.on[propertyName];
       },
       set: (value) => {
         if (this.on[propertyName]) {


### PR DESCRIPTION
Use JavaScript [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) to clean up old CoffeeScript `this` wrappers.

Also cleaned up a few old returns that weren't intentional.

### Before

```js
this.webContents.on('move', (function(_this) {
  return function(event, size) {
    return _this.setBounds(size);
  };
})(this));
```

### After

```js
this.webContents.on('move', (event, size) => {
  this.setBounds(size);
});
```

Refs #4065 