### PR TITLE
Remove unneeded results collecting/returning

### DIFF
--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -267,7 +267,6 @@ Menu.prototype._callMenuWillShow = function() {
 var applicationMenu = null;
 
 Menu.setApplicationMenu = function(menu) {
-  var j, len, results, w, windows;
   if (!(menu === null || menu.constructor === Menu)) {
     throw new TypeError('Invalid menu');
   }
@@ -279,15 +278,11 @@ Menu.setApplicationMenu = function(menu) {
       return;
     }
     menu._callMenuWillShow();
-    return bindings.setApplicationMenu(menu);
+    bindings.setApplicationMenu(menu);
   } else {
-    windows = BrowserWindow.getAllWindows();
-    results = [];
-    for (j = 0, len = windows.length; j < len; j++) {
-      w = windows[j];
-      results.push(w.setMenu(menu));
-    }
-    return results;
+    BrowserWindow.getAllWindows().forEach(function(window) {
+      window.setMenu(menu);
+    });
   }
 };
 

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -249,19 +249,14 @@ Menu.prototype.insert = function(pos, item) {
 
 // Force menuWillShow to be called
 Menu.prototype._callMenuWillShow = function() {
-  var item, j, len, ref1, ref2, results;
-  if ((ref1 = this.delegate) != null) {
-    ref1.menuWillShow();
+  if (this.delegate != null) {
+    this.delegate.menuWillShow();
   }
-  ref2 = this.items;
-  results = [];
-  for (j = 0, len = ref2.length; j < len; j++) {
-    item = ref2[j];
+  this.items.forEach(function(item) {
     if (item.submenu != null) {
-      results.push(item.submenu._callMenuWillShow());
+      item.submenu._callMenuWillShow();
     }
-  }
-  return results;
+  });
 };
 
 var applicationMenu = null;

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -132,9 +132,8 @@ Menu.prototype._init = function() {
       return function() {
 
         // Make sure radio groups have at least one menu item seleted.
-        var checked, group, id, j, len, radioItem, ref1, results;
+        var checked, group, id, j, len, radioItem, ref1;
         ref1 = _this.groupsMap;
-        results = [];
         for (id in ref1) {
           group = ref1[id];
           checked = false;
@@ -147,12 +146,9 @@ Menu.prototype._init = function() {
             break;
           }
           if (!checked) {
-            results.push(v8Util.setHiddenValue(group[0], 'checked', true));
-          } else {
-            results.push(void 0);
+            v8Util.setHiddenValue(group[0], 'checked', true);
           }
         }
-        return results;
       };
     })(this)
   };

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -24,14 +24,12 @@
 
   // Clean cache on quit.
   process.on('exit', function() {
-    var archive, p, results;
-    results = [];
+    var archive, p;
     for (p in cachedArchives) {
       if (!hasProp.call(cachedArchives, p)) continue;
       archive = cachedArchives[p];
-      results.push(archive.destroy());
+      archive.destroy();
     }
-    return results;
   });
 
   // Separate asar package's path from full path.

--- a/lib/renderer/web-view/web-view-attributes.js
+++ b/lib/renderer/web-view/web-view-attributes.js
@@ -297,7 +297,6 @@ class BlinkFeaturesAttribute extends WebViewAttribute {
 
 // Sets up all of the webview attributes.
 WebViewImpl.prototype.setupWebViewAttributes = function() {
-  var attribute, autosizeAttributes, i, len, results;
   this.attributes = {};
   this.attributes[webViewConstants.ATTRIBUTE_ALLOWTRANSPARENCY] = new AllowTransparencyAttribute(this);
   this.attributes[webViewConstants.ATTRIBUTE_AUTOSIZE] = new AutosizeAttribute(this);
@@ -311,11 +310,9 @@ WebViewImpl.prototype.setupWebViewAttributes = function() {
   this.attributes[webViewConstants.ATTRIBUTE_ALLOWPOPUPS] = new BooleanAttribute(webViewConstants.ATTRIBUTE_ALLOWPOPUPS, this);
   this.attributes[webViewConstants.ATTRIBUTE_PRELOAD] = new PreloadAttribute(this);
   this.attributes[webViewConstants.ATTRIBUTE_BLINKFEATURES] = new BlinkFeaturesAttribute(this);
-  autosizeAttributes = [webViewConstants.ATTRIBUTE_MAXHEIGHT, webViewConstants.ATTRIBUTE_MAXWIDTH, webViewConstants.ATTRIBUTE_MINHEIGHT, webViewConstants.ATTRIBUTE_MINWIDTH];
-  results = [];
-  for (i = 0, len = autosizeAttributes.length; i < len; i++) {
-    attribute = autosizeAttributes[i];
-    results.push(this.attributes[attribute] = new AutosizeDimensionAttribute(attribute, this));
-  }
-  return results;
+
+  const autosizeAttributes = [webViewConstants.ATTRIBUTE_MAXHEIGHT, webViewConstants.ATTRIBUTE_MAXWIDTH, webViewConstants.ATTRIBUTE_MINHEIGHT, webViewConstants.ATTRIBUTE_MINWIDTH];
+  autosizeAttributes.forEach((attribute) => {
+    this.attributes[attribute] = new AutosizeDimensionAttribute(attribute, this);
+  });
 };


### PR DESCRIPTION
There were some arrays being collected and returned automatically by CoffeeScript when a function ended with a `for` loop.

Several of these didn't actually need to be returned and this pull request removes those instances.