### PR TITLE
🐛 override blur method from BrowserWindowProxy

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -102,6 +102,10 @@ ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', function(event, guest
 ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', function() {
   var args, guestId, method, ref1;
   guestId = arguments[1], method = arguments[2], args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
+  // when a BrowserWindowProxy tries to blur, have the BrowserWindow blurWebView
+  if (method === 'blur') {
+    method = 'blurWebView';
+  }
   return (ref1 = BrowserWindow.fromId(guestId)) != null ? ref1[method].apply(ref1, args) : void 0;
 });
 


### PR DESCRIPTION
First attempt to fix #4724. `BrowserWindow` which does not have a `blur` method so use the `blurWebView` method that exists instead.