### PR TITLE
Print warning when remote object doesn't exist

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -5,6 +5,7 @@ const deprecate = require('electron').deprecate;
 const ipcMain = require('electron').ipcMain;
 const NavigationController = require('electron').NavigationController;
 const Menu = require('electron').Menu;
+const objectsRegistry = require('../objects-registry');
 
 const binding = process.atomBinding('web_contents');
 const debuggerBinding = process.atomBinding('debugger');
@@ -72,6 +73,12 @@ let wrapWebContents = function(webContents) {
   // Every remote callback from renderer process would add a listenter to the
   // render-view-deleted event, so ignore the listenters warning.
   webContents.setMaxListeners(0);
+
+  // Cleanup the remote objects referenced by this webContents when it is
+  // reloaded or navigated.
+  webContents.once('render-view-deleted', (event, id) => {
+    objectsRegistry.clear(id);
+  });
 
   // WebContents::send(channel, args..)
   webContents.send = function() {

--- a/lib/browser/objects-registry.js
+++ b/lib/browser/objects-registry.js
@@ -26,10 +26,6 @@ class ObjectsRegistry {
     let owner = this.owners[webContentsId];
     if (!owner) {
       owner = this.owners[webContentsId] = new Set();
-      // Clear the storage when webContents is reloaded/navigated.
-      webContents.once('render-view-deleted', (event, id) => {
-        this.clear(id);
-      });
     }
     if (!owner.has(id)) {
       owner.add(id);

--- a/lib/browser/objects-registry.js
+++ b/lib/browser/objects-registry.js
@@ -37,7 +37,12 @@ class ObjectsRegistry {
 
   // Get an object according to its ID.
   get(id) {
-    return this.storage[id].object;
+    let pointer = this.storage[id];
+    if (pointer == null) {
+      console.warn(`There is no remote object with ID ${id}.`);
+      return null;
+    }
+    return pointer.object;
   }
 
   // Dereference an object according to its ID.
@@ -82,7 +87,7 @@ class ObjectsRegistry {
     pointer.count -= 1;
     if (pointer.count === 0) {
       v8Util.deleteHiddenValue(pointer.object, 'atomId');
-      return delete this.storage[id];
+      delete this.storage[id];
     }
   }
 }


### PR DESCRIPTION
Refs #4733.

Instead of throwing exception we just print warning when an unexist remote object is requested, in case it is just a rare situation.