### PR TITLE
Fix libffmpeg.dylib path for install_name_tool

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -489,7 +489,7 @@
               'action': [
                 'install_name_tool',
                 '-change',
-                '@loader_path/libffmpeg.dylib',
+                '/usr/local/lib/libffmpeg.dylib',
                 '@rpath/libffmpeg.dylib',
                 '${BUILT_PRODUCTS_DIR}/<(product_name) Framework.framework/Versions/A/<(product_name) Framework',
               ],


### PR DESCRIPTION
I had to do this because we ran into the same problem on brave/electron
Fixed https://github.com/atom/electron/issues/4765 for us.
