### PR TITLE
Added support for window.location on window.open windows

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -101,8 +101,8 @@ ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', function(event, guest
 
 ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', function() {
   var args, guestId, method, ref1;
-  guestId = arguments[1], method = arguments[2], args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
-  return (ref1 = BrowserWindow.fromId(guestId)) != null ? ref1[method].apply(ref1, args) : void 0;
+  event = arguments[0], guestId = arguments[1], method = arguments[2], args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
+  return event.returnValue = (ref1 = BrowserWindow.fromId(guestId)) != null ? ref1[method].apply(ref1, args) : void 0;
 });
 
 ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', function(event, guestId, message, targetOrigin, sourceOrigin) {

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -57,6 +57,15 @@ var BrowserWindowProxy = (function() {
     return ipcRenderer.send('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'blur');
   };
 
+  Object.defineProperty(BrowserWindowProxy.prototype, 'location', {
+    get: function() {
+      return ipcRenderer.sendSync('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'getURL');
+    },
+    set: function(url) {
+      return ipcRenderer.sendSync('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', this.guestId, 'loadURL', url);
+    }
+  });
+
   BrowserWindowProxy.prototype.postMessage = function(message, targetOrigin) {
     if (targetOrigin == null) {
       targetOrigin = '*';

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -193,6 +193,32 @@ describe('chromium feature', function() {
       window.addEventListener('message', listener);
       b = window.open("file://" + fixtures + "/pages/window-open-size.html", '', "show=no,width=" + size.width + ",height=" + size.height);
     });
+
+    it('defines a window.location getter', function(done) {
+      var b, targetURL;
+      targetURL = "file://" + fixtures + "/pages/base-page.html";
+      b = window.open(targetURL);
+      BrowserWindow.fromId(b.guestId).webContents.once('did-finish-load', function() {
+        assert.equal(b.location, targetURL);
+        b.close();
+        done();
+      });
+    });
+
+    it('defines a window.location setter', function(done) {
+      // Load a page that definitely won't redirect
+      var b;
+      b = window.open("about:blank");
+      BrowserWindow.fromId(b.guestId).webContents.once('did-finish-load', function() {
+        // When it loads, redirect
+        b.location = "file://" + fixtures + "/pages/base-page.html";
+        BrowserWindow.fromId(b.guestId).webContents.once('did-finish-load', function() {
+          // After our second redirect, cleanup and callback
+          b.close();
+          done();
+        });
+      });
+    });
   });
 
   describe('window.opener', function() {


### PR DESCRIPTION
I'm attempting to get Karma running with Electron. I have been trying to work around Electron's lack of `window.location` support for child windows but realized we could support it easily (Karma uses this for restarting test runs).

In this PR:

- Updated `guest-window-manager` to support synchronous IPC requests
- Added `window.location` getter/setter properties
- Added tests

**Notes:**

As I was opening this PR, I realized that the getter property isn't as exact as it should be. We are missing a few things:

- Same-origin policy restriction; in a normal browser, only windows on the same origin can see each others locations. Although, a parent can set a child's URL to whatever it wants
- Object with lots of keys (e.g. `href`, `hostname`). If this is too complex, then we can reduce the PR to a `location` setter
    - I believe we should be able to simply use `url.parse` but want to verify