### PR TITLE
Convert NativeImage instances to OS-specific representations

### DIFF
--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -198,7 +198,8 @@ mate::ObjectTemplateBuilder NativeImage::GetObjectTemplateBuilder(
     template_.Reset(isolate, mate::ObjectTemplateBuilder(isolate)
         .SetMethod("toPng", &NativeImage::ToPNG)
         .SetMethod("toJpeg", &NativeImage::ToJPEG)
-        .SetMethod("asNativeRepresentation", &NativeImage::AsNativeRepresentation)
+        .SetMethod("asNativeRepresentation",
+          &NativeImage::AsNativeRepresentation)
         .SetMethod("toDataURL", &NativeImage::ToDataURL)
         .SetMethod("toDataUrl", &NativeImage::ToDataURL)  // deprecated.
         .SetMethod("isEmpty", &NativeImage::IsEmpty)
@@ -236,28 +237,30 @@ std::string NativeImage::ToDataURL() {
   return data_url;
 }
 
-v8::Local<v8::Value> NativeImage::AsNativeRepresentation(v8::Isolate* isolate, mate::Arguments* args) {
+v8::Local<v8::Value> NativeImage::AsNativeRepresentation(
+    v8::Isolate* isolate,
+    mate::Arguments* args) {
   NativeRepresentation desiredRep = NativeRepresentation::INVALID;
   void* ptr = nullptr;
   std::string type;
-  
+
   if (!args->GetNext(&type)) {
     args->ThrowError();
     goto out;
   }
-  
+
   for (const NativeRepresentationPair& item : kNativeRepresentations) {
     if (type.compare(item.name) == 0) {
       desiredRep = item.rep;
       break;
     }
   }
-  
+
   if (desiredRep == NativeRepresentation::INVALID) {
     args->ThrowError();
     goto out;
   }
-  
+
   switch (desiredRep) {
 #if defined(OS_MACOSX)
   case NativeRepresentation::AS_NSIMAGE:
@@ -268,9 +271,9 @@ v8::Local<v8::Value> NativeImage::AsNativeRepresentation(v8::Isolate* isolate, m
     args->ThrowError();
     break;
   }
-  
+
 out:
-  
+
   return node::Buffer::Copy(
     isolate,
     reinterpret_cast<char*>(ptr),

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -184,8 +184,8 @@ mate::ObjectTemplateBuilder NativeImage::GetObjectTemplateBuilder(
     template_.Reset(isolate, mate::ObjectTemplateBuilder(isolate)
         .SetMethod("toPng", &NativeImage::ToPNG)
         .SetMethod("toJpeg", &NativeImage::ToJPEG)
-        .SetMethod("asNativeRepresentation",
-          &NativeImage::AsNativeRepresentation)
+        .SetMethod("getNativeHandle",
+          &NativeImage::GetNativeHandle)
         .SetMethod("toDataURL", &NativeImage::ToDataURL)
         .SetMethod("toDataUrl", &NativeImage::ToDataURL)  // deprecated.
         .SetMethod("isEmpty", &NativeImage::IsEmpty)
@@ -223,7 +223,7 @@ std::string NativeImage::ToDataURL() {
   return data_url;
 }
 
-v8::Local<v8::Value> NativeImage::AsNativeRepresentation(
+v8::Local<v8::Value> NativeImage::GetNativeHandle(
     v8::Isolate* isolate,
     mate::Arguments* args) {
 #if defined(OS_MACOSX)

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -226,10 +226,11 @@ std::string NativeImage::ToDataURL() {
 v8::Local<v8::Value> NativeImage::GetNativeHandle(
     v8::Isolate* isolate,
     mate::Arguments* args) {
+void* ptr = NULL;
 #if defined(OS_MACOSX)
-  void* ptr = reinterpret_cast<void*>(image_.AsNSImage());
+  ptr = reinterpret_cast<void*>(image_.AsNSImage());
 #else
-  args.ThrowError();
+  args->ThrowError();
   return v8::Undefined(isolate);
 #endif
 

--- a/atom/common/api/atom_api_native_image.cc
+++ b/atom/common/api/atom_api_native_image.cc
@@ -267,6 +267,7 @@ v8::Local<v8::Value> NativeImage::AsNativeRepresentation(
     ptr = reinterpret_cast<void*>(image_.AsNSImage());
     break;
 #endif
+  case NativeRepresentation::INVALID:
   default:
     args->ThrowError();
     break;

--- a/atom/common/api/atom_api_native_image.h
+++ b/atom/common/api/atom_api_native_image.h
@@ -61,7 +61,9 @@ class NativeImage : public mate::Wrappable {
  private:
   v8::Local<v8::Value> ToPNG(v8::Isolate* isolate);
   v8::Local<v8::Value> ToJPEG(v8::Isolate* isolate, int quality);
-  v8::Local<v8::Value> AsNativeRepresentation(v8::Isolate* isolate, mate::Arguments* args);
+  v8::Local<v8::Value> AsNativeRepresentation(
+    v8::Isolate* isolate,
+    mate::Arguments* args);
   std::string ToDataURL();
   bool IsEmpty();
   gfx::Size GetSize();

--- a/atom/common/api/atom_api_native_image.h
+++ b/atom/common/api/atom_api_native_image.h
@@ -61,6 +61,7 @@ class NativeImage : public mate::Wrappable {
  private:
   v8::Local<v8::Value> ToPNG(v8::Isolate* isolate);
   v8::Local<v8::Value> ToJPEG(v8::Isolate* isolate, int quality);
+  v8::Local<v8::Value> AsNativeRepresentation(v8::Isolate* isolate, mate::Arguments* args);
   std::string ToDataURL();
   bool IsEmpty();
   gfx::Size GetSize();

--- a/atom/common/api/atom_api_native_image.h
+++ b/atom/common/api/atom_api_native_image.h
@@ -61,7 +61,7 @@ class NativeImage : public mate::Wrappable {
  private:
   v8::Local<v8::Value> ToPNG(v8::Isolate* isolate);
   v8::Local<v8::Value> ToJPEG(v8::Isolate* isolate, int quality);
-  v8::Local<v8::Value> AsNativeRepresentation(
+  v8::Local<v8::Value> GetNativeHandle(
     v8::Isolate* isolate,
     mate::Arguments* args);
   std::string ToDataURL();

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -133,12 +133,11 @@ Returns a [Buffer][buffer] that contains the image's `JPEG` encoded data.
 
 Returns the data URL of the image.
 
-### `image.asNativeRepresentation(type)`
+### `image.getNativeHandle()`
 
 Returns a pointer to an underlying native type (encoded as a [Buffer][buffer]) which can be used with native APIs. Note that in many cases, this pointer is a weak pointer to the underlying native image not a copy, so you _must_ ensure that the associated `nativeImage` instance is kept around.
 
-* `type` String (**required**) - one of:
-  * `nsimage` - (OS X only) a pointer to an `NSImage`
+Returns a [Buffer][buffer] that represents a pointer to a native type - on OS X, this type is an NSImage object.
 
 ### `image.isEmpty()`
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -133,6 +133,13 @@ Returns a [Buffer][buffer] that contains the image's `JPEG` encoded data.
 
 Returns the data URL of the image.
 
+### `image.asNativeRepresentation(type)`
+
+Returns a pointer to an underlying native type (encoded as a [Buffer][buffer]) which can be used with native APIs. Note that in many cases, this pointer is a weak pointer to the underlying native image not a copy, so you _must_ ensure that the associated `nativeImage` instance is kept around.
+
+* `type` String (**required**) - one of:
+  * `nsimage` - (OS X only) a pointer to an `NSImage`
+
 ### `image.isEmpty()`
 
 Returns a boolean whether the image is empty.

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -45,7 +45,7 @@ describe('nativeImage module', () => {
       assert.equal(nsimage.length, 8);
 
       // If all bytes are null, that's Bad
-      assert.equal(nsimage.reduce((acc,x) => acc || (x != 0)), true);
+      assert.equal(!!nsimage.reduce((acc,x) => acc || (x != 0)), true);
     });
   });
 });

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -34,5 +34,32 @@ describe('nativeImage module', () => {
       assert.equal(image.getSize().height, 190);
       assert.equal(image.getSize().width, 538);
     });
+
+    it('Gets an NSImage pointer on OS X', () => {
+      if (process.platform !== 'darwin') return;
+
+      const imagePath = `${path.join(__dirname, 'fixtures', 'api')}${path.sep}..${path.sep}${path.join('assets', 'logo.png')}`;
+      const image = nativeImage.createFromPath(imagePath);
+      const nsimage = image.asNativeRepresentation('nsimage');
+
+      assert.equal(nsimage.length, 8);
+
+      // If all bytes are null, that's Bad
+      assert.equal(nsimage.reduce((acc,x) => acc || (x != 0)), true);
+    });
+
+    it('Throws when asNativeRepresentation gets a bogus value', () => {
+      const imagePath = `${path.join(__dirname, 'fixtures', 'api')}${path.sep}..${path.sep}${path.join('assets', 'logo.png')}`;
+      const image = nativeImage.createFromPath(imagePath);
+
+      let shouldDie = true;
+      try {
+        image.asNativeRepresentation('__foobar__');
+      } catch (e) {
+        shouldDie = false;
+      }
+
+      assert.equal(shouldDie, false);
+    });
   });
 });

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -40,26 +40,12 @@ describe('nativeImage module', () => {
 
       const imagePath = `${path.join(__dirname, 'fixtures', 'api')}${path.sep}..${path.sep}${path.join('assets', 'logo.png')}`;
       const image = nativeImage.createFromPath(imagePath);
-      const nsimage = image.asNativeRepresentation('nsimage');
+      const nsimage = image.getNativeHandle();
 
       assert.equal(nsimage.length, 8);
 
       // If all bytes are null, that's Bad
       assert.equal(nsimage.reduce((acc,x) => acc || (x != 0)), true);
-    });
-
-    it('Throws when asNativeRepresentation gets a bogus value', () => {
-      const imagePath = `${path.join(__dirname, 'fixtures', 'api')}${path.sep}..${path.sep}${path.join('assets', 'logo.png')}`;
-      const image = nativeImage.createFromPath(imagePath);
-
-      let shouldDie = true;
-      try {
-        image.asNativeRepresentation('__foobar__');
-      } catch (e) {
-        shouldDie = false;
-      }
-
-      assert.equal(shouldDie, false);
     });
   });
 });

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -45,7 +45,7 @@ describe('nativeImage module', () => {
       assert.equal(nsimage.length, 8);
 
       // If all bytes are null, that's Bad
-      assert.equal(!!nsimage.reduce((acc,x) => acc || (x != 0)), true);
+      assert.equal(nsimage.reduce((acc,x) => acc || (x != 0), false), true);
     });
   });
 });


### PR DESCRIPTION
This PR adds a new `asNativeRepresentation` method to `NativeImage` which allows you to get an underlying image object that you can pass to native APIs. Right now only OS X is implemented but I've set it up so that we can add other operating systems later (others aren't so easy because Windows has more than one image representation format, etc etc)