### PR TITLE
Automatically set app user model ID

### DIFF
--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -78,6 +78,35 @@ app.on('quit', function(event, exitCode) {
   return process.emit('exit', exitCode);
 });
 
+if (process.platform === 'win32') {
+  // If we are a Squirrel.Windows-installed app, set app user model ID
+  // so that users don't have to do this.
+  //
+  // Squirrel packages are always of the form:
+  //
+  // PACKAGE-NAME
+  // - Update.exe
+  // - app-VERSION
+  //   - OUREXE.exe
+  //
+  // Squirrel itself will always set the shortcut's App User Model ID to the
+  // form `com.squirrel.PACKAGE-NAME.OUREXE`. We need to call
+  // app.setAppUserModelId with a matching identifier so that renderer processes
+  // will inherit this value.
+  var updateDotExe = path.join(
+    path.dirname(process.execPath),
+    '..',
+    'update.exe');
+
+  if (fs.statSyncNoException(updateDotExe)) {
+    var packageDir = path.dirname(path.resolve(updateDotExe));
+    var packageName = path.basename(packageDir);
+    var exeName = path.basename(process.execPath).replace(/\.exe$/i, '');
+
+    app.setAppUserModelId(`com.squirrel.${packageName}.${exeName}`);
+  }
+}
+
 // Map process.exit to app.exit, which quits gracefully.
 process.exit = app.exit;
 


### PR DESCRIPTION
We shouldn't ask users to figure out this piece of Windows Arcana when they're using Squirrel, let's just do it automatically.

## TODO:

- [x] Make sure this works