### PR TITLE
More info for crash reporter form type and payload

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -54,7 +54,7 @@ ID.
 
 ## crash-reporter Payload
 
-The crash reporter will send the following data to the `submitURL` as `POST`:
+The crash reporter will send the following data to the `submitURL` as a `multipart/form-data` `POST`:
 
 * `ver` String - The version of Electron.
 * `platform` String - e.g. 'win32'.
@@ -66,6 +66,6 @@ The crash reporter will send the following data to the `submitURL` as `POST`:
 * `prod` String - Name of the underlying product. In this case Electron.
 * `_companyName` String - The company name in the `crashReporter` `options`
   object.
-* `upload_file_minidump` File - The crash report as file.
+* `upload_file_minidump` File - The crash report as file, a binary.
 * All level one properties of the `extra` object in the `crashReporter`.
   `options` object


### PR DESCRIPTION
Can someone also explain to me what to do with the .dmp file? From a quick google search it looks like it's a windows format file and cannot be viewed on osx?