### PR TITLE
Report deprecated BrowserWindow options

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -52,6 +52,11 @@ namespace api {
 
 namespace {
 
+// The DeprecatedOptionsCheckCallback funtion which is implemented in JavaScript
+using DeprecatedOptionsCheckCallback =
+    base::Callback<std::string(v8::Local<v8::Value>)>;
+DeprecatedOptionsCheckCallback g_deprecated_options_check;
+
 void OnCapturePageDone(
     v8::Isolate* isolate,
     const base::Callback<void(const gfx::Image&)>& callback,
@@ -289,6 +294,13 @@ mate::Wrappable* Window::New(v8::Isolate* isolate, mate::Arguments* args) {
   mate::Dictionary options;
   if (!(args->Length() == 1 && args->GetNext(&options))) {
     options = mate::Dictionary::CreateEmpty(isolate);
+  }
+
+  std::string deprecation_message = g_deprecated_options_check.Run(
+      options.GetHandle());
+  if (deprecation_message.length() > 0) {
+    args->ThrowError(deprecation_message);
+    return nullptr;
   }
 
   return new Window(isolate, options);
@@ -797,6 +809,10 @@ v8::Local<v8::Value> Window::From(v8::Isolate* isolate,
     return v8::Null(isolate);
 }
 
+void SetDeprecatedOptionsCheck(const DeprecatedOptionsCheckCallback& callback) {
+  g_deprecated_options_check = callback;
+}
+
 }  // namespace api
 
 }  // namespace atom
@@ -816,6 +832,9 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                            &mate::TrackableObject<Window>::FromWeakMapID);
   browser_window.SetMethod("getAllWindows",
                            &mate::TrackableObject<Window>::GetAll);
+  browser_window.SetMethod("_setDeprecatedOptionsCheck",
+                           &atom::api::SetDeprecatedOptionsCheck);
+
 
   mate::Dictionary dict(isolate, exports);
   dict.Set("BrowserWindow", browser_window);

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -52,7 +52,7 @@ namespace api {
 
 namespace {
 
-// The DeprecatedOptionsCheckCallback funtion which is implemented in JavaScript
+// This function is implemented in JavaScript
 using DeprecatedOptionsCheckCallback =
     base::Callback<std::string(v8::Local<v8::Value>)>;
 DeprecatedOptionsCheckCallback g_deprecated_options_check;

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -832,12 +832,11 @@ void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> unused,
                            &mate::TrackableObject<Window>::FromWeakMapID);
   browser_window.SetMethod("getAllWindows",
                            &mate::TrackableObject<Window>::GetAll);
-  browser_window.SetMethod("_setDeprecatedOptionsCheck",
-                           &atom::api::SetDeprecatedOptionsCheck);
-
 
   mate::Dictionary dict(isolate, exports);
   dict.Set("BrowserWindow", browser_window);
+  dict.SetMethod("_setDeprecatedOptionsCheck",
+                 &atom::api::SetDeprecatedOptionsCheck);
 }
 
 }  // namespace

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -8,7 +8,6 @@ const BrowserWindow = process.atomBinding('window').BrowserWindow;
 BrowserWindow.prototype.__proto__ = EventEmitter.prototype;
 
 BrowserWindow.prototype._init = function() {
-
   // avoid recursive require.
   var app, menu;
   app = require('electron').app;
@@ -239,5 +238,57 @@ BrowserWindow.prototype.getPageTitle = deprecate('getPageTitle', 'webContents.ge
   var ref1;
   return (ref1 = this.webContents) != null ? ref1.getTitle() : void 0;
 });
+
+const isDeprecatedKey = function(key) {
+  return key.indexOf('-') >= 0;
+};
+
+// Map deprecated key with hyphens to camel case key
+const getNonDeprecatedKey = function(deprecatedKey) {
+  return deprecatedKey.replace(/-./g, function(match) {
+    return match[1].toUpperCase();
+  });
+};
+
+// TODO Remove for 1.0
+const checkForDeprecatedOptions = function(options) {
+  if (!options) return '';
+
+  let keysToCheck = Object.keys(options);
+  if (options.webPreferences) {
+    keysToCheck = keysToCheck.concat(Object.keys(options.webPreferences));
+  }
+
+  // Check options for keys with hypens in them
+  let deprecatedKey = keysToCheck.filter(isDeprecatedKey)[0];
+  if (deprecatedKey) {
+    try {
+      deprecate.warn(deprecatedKey, getNonDeprecatedKey(deprecatedKey));
+    } catch (error) {
+      // Return error message so it can be rethrown via C++
+      return error.message;
+    }
+  }
+
+  let webPreferenceOption;
+  if (options.hasOwnProperty('nodeIntegration')) {
+    webPreferenceOption = 'nodeIntegration';
+  } else if (options.hasOwnProperty('preload')) {
+    webPreferenceOption = 'preload';
+  } else if (options.hasOwnProperty('zoomFactor')) {
+    webPreferenceOption = 'zoomFactor';
+  }
+  if (webPreferenceOption) {
+    try {
+      deprecate.log(`Setting ${webPreferenceOption} on options is deprecated. Set it on options.webPreferences instead.`);
+    } catch (error) {
+      // Return error message so it can be rethrown via C++
+      return error.message;
+    }
+  }
+
+  return '';
+};
+BrowserWindow._setDeprecatedOptionsCheck(checkForDeprecatedOptions);
 
 module.exports = BrowserWindow;

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -259,7 +259,7 @@ const checkForDeprecatedOptions = function(options) {
     keysToCheck = keysToCheck.concat(Object.keys(options.webPreferences));
   }
 
-  // Check options for keys with hypens in them
+  // Check options for keys with hyphens in them
   let deprecatedKey = keysToCheck.filter(isDeprecatedKey)[0];
   if (deprecatedKey) {
     try {

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -280,7 +280,7 @@ const checkForDeprecatedOptions = function(options) {
   }
   if (webPreferenceOption) {
     try {
-      deprecate.log(`options.${webPreferenceOption} is deprecated. Use options.webPreferences.${webPreferenceOption} instead.`);
+      deprecate.warn(`options.${webPreferenceOption}`, `options.webPreferences.${webPreferenceOption}`);
     } catch (error) {
       // Return error message so it can be rethrown via C++
       return error.message;

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -280,7 +280,7 @@ const checkForDeprecatedOptions = function(options) {
   }
   if (webPreferenceOption) {
     try {
-      deprecate.log(`Setting ${webPreferenceOption} on options is deprecated. Set it on options.webPreferences instead.`);
+      deprecate.log(`options.${webPreferenceOption} is deprecated. Use options.webPreferences.${webPreferenceOption} instead.`);
     } catch (error) {
       // Return error message so it can be rethrown via C++
       return error.message;

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -3,7 +3,7 @@
 const ipcMain = require('electron').ipcMain;
 const deprecate = require('electron').deprecate;
 const EventEmitter = require('events').EventEmitter;
-const BrowserWindow = process.atomBinding('window').BrowserWindow;
+const {BrowserWindow, _setDeprecatedOptionsCheck} = process.atomBinding('window');
 
 BrowserWindow.prototype.__proto__ = EventEmitter.prototype;
 
@@ -289,6 +289,6 @@ const checkForDeprecatedOptions = function(options) {
 
   return '';
 };
-BrowserWindow._setDeprecatedOptionsCheck(checkForDeprecatedOptions);
+_setDeprecatedOptionsCheck(checkForDeprecatedOptions);
 
 module.exports = BrowserWindow;

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -132,7 +132,7 @@ app.once('ready', function() {
     return delete extensionInfoMap[name];
   };
 
-  // Load persistented extensions when devtools is opened.
+  // Load persisted extensions when devtools is opened.
   init = BrowserWindow.prototype._init;
   return BrowserWindow.prototype._init = function() {
     init.call(this);

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -101,6 +101,7 @@ window.open = function(url, frameName, features) {
   }
   options = {};
   ints = ['x', 'y', 'width', 'height', 'min-width', 'max-width', 'min-height', 'max-height', 'zoom-factor'];
+  const webPreferences = ['zoom-factor', 'zoomFactor', 'node-integration', 'nodeIntegration', 'preload'];
 
   // Make sure to get rid of excessive whitespace in the property name
   ref1 = features.split(/,\s*/);
@@ -109,7 +110,15 @@ window.open = function(url, frameName, features) {
     ref2 = feature.split(/\s*=/);
     name = ref2[0];
     value = ref2[1];
-    options[name] = value === 'yes' || value === '1' ? true : value === 'no' || value === '0' ? false : value;
+    value = value === 'yes' || value === '1' ? true : value === 'no' || value === '0' ? false : value;
+    if (webPreferences.includes(name)) {
+      if (options.webPreferences == null) {
+        options.webPreferences = {};
+      }
+      options.webPreferences[name] = value;
+    } else {
+      options[name] = value;
+    }
   }
   if (options.left) {
     if (options.x == null) {

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -100,6 +100,8 @@ window.open = function(url, frameName, features) {
     features = '';
   }
   options = {};
+
+  // TODO remove hyphenated options in both of the following arrays for 1.0
   ints = ['x', 'y', 'width', 'height', 'min-width', 'max-width', 'min-height', 'minHeight', 'max-height', 'maxHeight', 'zoom-factor', 'zoomFactor'];
   const webPreferences = ['zoom-factor', 'zoomFactor', 'node-integration', 'nodeIntegration', 'preload'];
 

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -100,7 +100,7 @@ window.open = function(url, frameName, features) {
     features = '';
   }
   options = {};
-  ints = ['x', 'y', 'width', 'height', 'min-width', 'max-width', 'min-height', 'max-height', 'zoom-factor'];
+  ints = ['x', 'y', 'width', 'height', 'min-width', 'max-width', 'min-height', 'minHeight', 'max-height', 'maxHeight', 'zoom-factor', 'zoomFactor'];
   const webPreferences = ['zoom-factor', 'zoomFactor', 'node-integration', 'nodeIntegration', 'preload'];
 
   // Make sure to get rid of excessive whitespace in the property name

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -763,21 +763,20 @@ describe('browser-window module', function() {
   describe('deprecated options', function() {
     it('throws a deprecation error for option keys using hyphens instead of camel case', function() {
       assert.throws(function () {
-        new BrowserWindow({'min-width': 500})
+        new BrowserWindow({'min-width': 500});
       }, 'min-width is deprecated. Use minWidth instead.');
     });
 
     it('throws a deprecation error for webPreference keys using hyphens instead of camel case', function() {
       assert.throws(function () {
-        new BrowserWindow({webPreferences: {'node-integration': false}})
+        new BrowserWindow({webPreferences: {'node-integration': false}});
       }, 'node-integration is deprecated. Use nodeIntegration instead.');
     });
 
     it('throws a deprecation error for option keys that should be set on webPreferences', function() {
       assert.throws(function () {
-        new BrowserWindow({zoomFactor: 1})
+        new BrowserWindow({zoomFactor: 1});
       }, 'Setting zoomFactor on options is deprecated. Set it on options.webPreferences instead.');
     });
-  })
-
+  });
 });

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -759,4 +759,25 @@ describe('browser-window module', function() {
       });
     });
   });
+
+  describe('deprecated options', function() {
+    it('throws a deprecation error for option keys using hyphens instead of camel case', function() {
+      assert.throws(function () {
+        new BrowserWindow({'min-width': 500})
+      }, 'min-width is deprecated. Use minWidth instead.');
+    });
+
+    it('throws a deprecation error for webPreference keys using hyphens instead of camel case', function() {
+      assert.throws(function () {
+        new BrowserWindow({webPreferences: {'node-integration': false}})
+      }, 'node-integration is deprecated. Use nodeIntegration instead.');
+    });
+
+    it('throws a deprecation error for option keys that should be set on webPreferences', function() {
+      assert.throws(function () {
+        new BrowserWindow({zoomFactor: 1})
+      }, 'Setting zoomFactor on options is deprecated. Set it on options.webPreferences instead.');
+    });
+  })
+
 });

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -776,7 +776,7 @@ describe('browser-window module', function() {
     it('throws a deprecation error for option keys that should be set on webPreferences', function() {
       assert.throws(function () {
         new BrowserWindow({zoomFactor: 1});
-      }, 'Setting zoomFactor on options is deprecated. Set it on options.webPreferences instead.');
+      }, 'options.zoomFactor is deprecated. Use options.webPreferences.zoomFactor instead.');
     });
   });
 });

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -155,7 +155,7 @@ describe('chromium feature', function() {
       b.close();
     });
 
-    it('accepts "node-integration" as feature', function(done) {
+    it('accepts "nodeIntegration" as feature', function(done) {
       var b;
       listener = function(event) {
         assert.equal(event.data, 'undefined');

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -82,8 +82,8 @@ app.on('ready', function() {
     show: false,
     width: 800,
     height: 600,
-    'web-preferences': {
-      javascript: true  // Test whether web-preferences crashes.
+    webPreferences: {
+      javascript: true  // Test whether web preferences crashes.
     },
   });
   window.loadURL(url.format({


### PR DESCRIPTION
This pull request reports deprecations for `BrowserWindow` options that use hyphens instead of camel case and also options that should be set on `options.webPreferences` instead of directly on `options.

Read http://blog.atom.io/2015/11/17/electron-api-changes.html for more details about the `BrowserWindow` options changes in general.

### New Messages

- `min-width is deprecated. Use minWidth instead.`
- `node-integration is deprecated. Use nodeIntegration instead.`
- `options.zoomFactor is deprecated. Use options.webPreferences.zoomFactor instead.`

/cc @zcbenz thanks for the tip on how to pass a JavaScript function to C++ and call it there, it really helped :+1:

/cc @jlord @zeke :eyes: