### PR TITLE
[wip] Remove CoffeeScript ref variables

### DIFF
--- a/lib/browser/api/app.js
+++ b/lib/browser/api/app.js
@@ -55,18 +55,14 @@ app.getAppPath = function() {
 };
 
 // Routes the events to webContents.
-var ref1 = ['login', 'certificate-error', 'select-client-certificate'];
-var fn = function(name) {
-  return app.on(name, function() {
-    var args, event, webContents;
-    event = arguments[0], webContents = arguments[1], args = 3 <= arguments.length ? slice.call(arguments, 2) : [];
+['login', 'certificate-error', 'select-client-certificate'].forEach(function(name) {
+  app.on(name, function() {
+    const event = arguments[0];
+    const webContents = arguments[1];
+    const args = 3 <= arguments.length ? slice.call(arguments, 2) : [];
     return webContents.emit.apply(webContents, [name, event].concat(slice.call(args)));
   });
-};
-var i, len;
-for (i = 0, len = ref1.length; i < len; i++) {
-  fn(ref1[i]);
-}
+});
 
 // Deprecated.
 

--- a/lib/browser/api/auto-updater/squirrel-update-win.js
+++ b/lib/browser/api/auto-updater/squirrel-update-win.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
 const spawn = require('child_process').spawn;
@@ -65,14 +67,17 @@ exports.processStart = function() {
 // Download the releases specified by the URL and write new results to stdout.
 exports.download = function(updateURL, callback) {
   return spawnUpdate(['--download', updateURL], false, function(error, stdout) {
-    var json, ref, ref1, update;
     if (error != null) {
       return callback(error);
     }
+
+    let update;
     try {
       // Last line of output is the JSON details about the releases
-      json = stdout.trim().split('\n').pop();
-      update = (ref = JSON.parse(json)) != null ? (ref1 = ref.releasesToApply) != null ? typeof ref1.pop === "function" ? ref1.pop() : void 0 : void 0 : void 0;
+      let json = JSON.parse(stdout.trim().split('\n').pop());
+      if (json != null && json.releasesToApply != null && typeof json.releasesToApply.pop === "function") {
+        update = json.releasesToApply.pop();
+      }
     } catch (jsonError) {
       return callback("Invalid result:\n" + stdout);
     }

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -132,14 +132,14 @@ BrowserWindow.fromWebContents = function(webContents) {
   return BrowserWindow.getAllWindows().find(function(window) {
     const contents = window.webContents;
     return contents != null ? contents.equal(webContents) : false;
-  })
+  });
 };
 
 BrowserWindow.fromDevToolsWebContents = function(webContents) {
   return BrowserWindow.getAllWindows().find(function(window) {
     const devToolsWebContents = window.devToolsWebContents;
     return devToolsWebContents != null ? devToolsWebContents.equal(webContents) : false;
-  })
+  });
 };
 
 // Helpers.

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -129,25 +129,17 @@ BrowserWindow.getFocusedWindow = function() {
 };
 
 BrowserWindow.fromWebContents = function(webContents) {
-  var i, len, ref1, window, windows;
-  windows = BrowserWindow.getAllWindows();
-  for (i = 0, len = windows.length; i < len; i++) {
-    window = windows[i];
-    if ((ref1 = window.webContents) != null ? ref1.equal(webContents) : void 0) {
-      return window;
-    }
-  }
+  return BrowserWindow.getAllWindows().find(function(window) {
+    const contents = window.webContents;
+    return contents != null ? contents.equal(webContents) : false;
+  })
 };
 
 BrowserWindow.fromDevToolsWebContents = function(webContents) {
-  var i, len, ref1, window, windows;
-  windows = BrowserWindow.getAllWindows();
-  for (i = 0, len = windows.length; i < len; i++) {
-    window = windows[i];
-    if ((ref1 = window.devToolsWebContents) != null ? ref1.equal(webContents) : void 0) {
-      return window;
-    }
-  }
+  return BrowserWindow.getAllWindows().find(function(window) {
+    const devToolsWebContents = window.devToolsWebContents;
+    return devToolsWebContents != null ? devToolsWebContents.equal(webContents) : false;
+  })
 };
 
 // Helpers.
@@ -231,13 +223,11 @@ deprecate.rename(BrowserWindow, 'loadUrl', 'loadURL');
 deprecate.rename(BrowserWindow, 'getUrl', 'getURL');
 
 BrowserWindow.prototype.executeJavaScriptInDevTools = deprecate('executeJavaScriptInDevTools', 'devToolsWebContents.executeJavaScript', function(code) {
-  var ref1;
-  return (ref1 = this.devToolsWebContents) != null ? ref1.executeJavaScript(code) : void 0;
+  return this.devToolsWebContents != null ? this.devToolsWebContents.executeJavaScript(code) : undefined;
 });
 
 BrowserWindow.prototype.getPageTitle = deprecate('getPageTitle', 'webContents.getTitle', function() {
-  var ref1;
-  return (ref1 = this.webContents) != null ? ref1.getTitle() : void 0;
+  return this.webContents != null ? this.webContents.getTitle() : undefined;
 });
 
 module.exports = BrowserWindow;

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -131,14 +131,14 @@ BrowserWindow.getFocusedWindow = function() {
 BrowserWindow.fromWebContents = function(webContents) {
   return BrowserWindow.getAllWindows().find(function(window) {
     const contents = window.webContents;
-    return contents != null ? contents.equal(webContents) : false;
+    return contents != null && contents.equal(webContents);
   });
 };
 
 BrowserWindow.fromDevToolsWebContents = function(webContents) {
   return BrowserWindow.getAllWindows().find(function(window) {
     const devToolsWebContents = window.devToolsWebContents;
-    return devToolsWebContents != null ? devToolsWebContents.equal(webContents) : false;
+    return devToolsWebContents != null && devToolsWebContents.equal(webContents);
   });
 };
 

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -137,7 +137,7 @@ module.exports = {
     // Choose a default button to get selected when dialog is cancelled.
     if (options.cancelId == null) {
       options.cancelId = 0;
-      for (let i = 0; i = options.buttons.length; i++) {
+      for (let i = 0; i < options.buttons.length; i++) {
         let text = options.buttons[i];
         let lowerCaseText = text.toLowerCase();
         if (lowerCaseText === 'cancel' || lowerCaseText === 'no') {

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const app = require('electron').app;
 const BrowserWindow = require('electron').BrowserWindow;
 const binding = process.atomBinding('dialog');
@@ -42,25 +44,22 @@ var checkAppInitialized = function() {
 
 module.exports = {
   showOpenDialog: function() {
-    var args, callback, options, prop, properties, ref1, value, window, wrappedCallback;
-    args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
+    const args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
     checkAppInitialized();
-    ref1 = parseArgs.apply(null, args), window = ref1[0], options = ref1[1], callback = ref1[2];
-    if (options == null) {
-      options = {
-        title: 'Open',
-        properties: ['openFile']
-      };
-    }
+
+    const parsedArgs = parseArgs.apply(null, args);
+    const window = parsedArgs[0];
+    const options = parsedArgs[1] != null ? parsedArgs[1] : { title: 'Open', properties: ['openFile'] };
+    const callback = parsedArgs[2];
     if (options.properties == null) {
       options.properties = ['openFile'];
     }
     if (!Array.isArray(options.properties)) {
       throw new TypeError('Properties need to be array');
     }
-    properties = 0;
-    for (prop in fileDialogProperties) {
-      value = fileDialogProperties[prop];
+    let properties = 0;
+    for (let prop in fileDialogProperties) {
+      let value = fileDialogProperties[prop];
       if (includes.call(options.properties, prop)) {
         properties |= value;
       }
@@ -74,21 +73,19 @@ module.exports = {
     if (options.filters == null) {
       options.filters = [];
     }
-    wrappedCallback = typeof callback === 'function' ? function(success, result) {
+    const wrappedCallback = typeof callback === 'function' ? function(success, result) {
       return callback(success ? result : void 0);
     } : null;
     return binding.showOpenDialog(String(options.title), String(options.defaultPath), options.filters, properties, window, wrappedCallback);
   },
   showSaveDialog: function() {
-    var args, callback, options, ref1, window, wrappedCallback;
-    args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
+    const args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
     checkAppInitialized();
-    ref1 = parseArgs.apply(null, args), window = ref1[0], options = ref1[1], callback = ref1[2];
-    if (options == null) {
-      options = {
-        title: 'Save'
-      };
-    }
+
+    const parsedArgs = parseArgs.apply(null, args);
+    const window = parsedArgs[0];
+    const options = parsedArgs[1] != null ? parseArgs[1] : { title: 'Save' };
+    const callback = parsedArgs[2];
     if (options.title == null) {
       options.title = '';
     }
@@ -98,25 +95,23 @@ module.exports = {
     if (options.filters == null) {
       options.filters = [];
     }
-    wrappedCallback = typeof callback === 'function' ? function(success, result) {
+    const wrappedCallback = typeof callback === 'function' ? function(success, result) {
       return callback(success ? result : void 0);
     } : null;
     return binding.showSaveDialog(String(options.title), String(options.defaultPath), options.filters, window, wrappedCallback);
   },
   showMessageBox: function() {
-    var args, callback, flags, i, j, len, messageBoxType, options, ref1, ref2, ref3, text, window;
-    args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
+    const args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
     checkAppInitialized();
-    ref1 = parseArgs.apply(null, args), window = ref1[0], options = ref1[1], callback = ref1[2];
-    if (options == null) {
-      options = {
-        type: 'none'
-      };
-    }
+
+    const parsedArgs = parseArgs.apply(null, args);
+    const window = parsedArgs[0];
+    const options = parsedArgs[1] != null ? parsedArgs[1] : { type: 'none' };
+    const callback = parsedArgs[2];
     if (options.type == null) {
       options.type = 'none';
     }
-    messageBoxType = messageBoxTypes.indexOf(options.type);
+    const messageBoxType = messageBoxTypes.indexOf(options.type);
     if (!(messageBoxType > -1)) {
       throw new TypeError('Invalid message box type');
     }
@@ -142,16 +137,16 @@ module.exports = {
     // Choose a default button to get selected when dialog is cancelled.
     if (options.cancelId == null) {
       options.cancelId = 0;
-      ref2 = options.buttons;
-      for (i = j = 0, len = ref2.length; j < len; i = ++j) {
-        text = ref2[i];
-        if ((ref3 = text.toLowerCase()) === 'cancel' || ref3 === 'no') {
+      for (let i = 0; i = options.buttons.length; i++) {
+        let text = options.buttons[i];
+        let lowerCaseText = text.toLowerCase();
+        if (lowerCaseText === 'cancel' || lowerCaseText === 'no') {
           options.cancelId = i;
           break;
         }
       }
     }
-    flags = options.noLink ? messageBoxOptions.noLink : 0;
+    const flags = options.noLink ? messageBoxOptions.noLink : 0;
     return binding.showMessageBox(messageBoxType, options.buttons, options.defaultId, options.cancelId, flags, options.title, options.message, options.detail, options.icon, window, callback);
   },
   showErrorBox: function() {
@@ -162,9 +157,6 @@ module.exports = {
 };
 
 // Mark standard asynchronous functions.
-var ref1 = ['showMessageBox', 'showOpenDialog', 'showSaveDialog'];
-var j, len, api;
-for (j = 0, len = ref1.length; j < len; j++) {
-  api = ref1[j];
+['showMessageBox', 'showOpenDialog', 'showSaveDialog'].forEach(function(api) {
   v8Util.setHiddenValue(module.exports[api], 'asynchronous', true);
-}
+});

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -27,16 +27,28 @@ MenuItem = (function() {
   MenuItem.types = ['normal', 'separator', 'submenu', 'checkbox', 'radio'];
 
   function MenuItem(options) {
-    var click, ref;
     const Menu = require('electron').Menu;
-    click = options.click, this.selector = options.selector, this.type = options.type, this.role = options.role, this.label = options.label, this.sublabel = options.sublabel, this.accelerator = options.accelerator, this.icon = options.icon, this.enabled = options.enabled, this.visible = options.visible, this.checked = options.checked, this.submenu = options.submenu;
+    const click = options.click;
+
+    this.selector = options.selector;
+    this.type = options.type;
+    this.role = options.role;
+    this.label = options.label;
+    this.sublabel = options.sublabel;
+    this.accelerator = options.accelerator;
+    this.icon = options.icon;
+    this.enabled = options.enabled;
+    this.visible = options.visible;
+    this.checked = options.checked;
+    this.submenu = options.submenu;
+
     if ((this.submenu != null) && this.submenu.constructor !== Menu) {
       this.submenu = Menu.buildFromTemplate(this.submenu);
     }
     if ((this.type == null) && (this.submenu != null)) {
       this.type = 'submenu';
     }
-    if (this.type === 'submenu' && ((ref = this.submenu) != null ? ref.constructor : void 0) !== Menu) {
+    if (this.type === 'submenu' && (this.submenu != null ? this.submenu.constructor : undefined) !== Menu) {
       throw new Error('Invalid submenu');
     }
     this.overrideReadOnlyProperty('type', 'normal');
@@ -55,16 +67,15 @@ MenuItem = (function() {
     this.commandId = ++nextCommandId;
     this.click = (focusedWindow) => {
       // Manually flip the checked flags when clicked.
-      var methodName, ref1, ref2;
-      if ((ref1 = this.type) === 'checkbox' || ref1 === 'radio') {
+      if (this.type === 'checkbox' || this.type === 'radio') {
         this.checked = !this.checked;
       }
       if (this.role && rolesMap[this.role] && process.platform !== 'darwin' && (focusedWindow != null)) {
-        methodName = rolesMap[this.role];
+        const methodName = rolesMap[this.role];
         if (methodInBrowserWindow[methodName]) {
           return focusedWindow[methodName]();
         } else {
-          return (ref2 = focusedWindow.webContents) != null ? ref2[methodName]() : void 0;
+          return focusedWindow.webContents != null ? focusedWindow.webContents[methodName]() : undefined;
         }
       } else if (typeof click === 'function') {
         return click(this, focusedWindow);

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -26,7 +26,7 @@ var generateGroupId = function(items, pos) {
     }
   } else if (pos < items.length) {
     let i = pos;
-    while (i < items.length)
+    while (i < items.length) {
       let item = items[i];
       if (item.type === 'radio') {
         return item.groupId;
@@ -59,9 +59,9 @@ var indexToInsertByPosition = function(items, position) {
   }
 
   const split = position.split('=');
-  const query = split[0]
+  const query = split[0];
   const id = split[1];
-  const insertIndex = indexOfItemById(items, id);
+  let insertIndex = indexOfItemById(items, id);
   if (insertIndex === -1 && query !== 'endof') {
     console.warn("Item with id '" + id + "' is not found");
     return items.length;
@@ -204,7 +204,7 @@ Menu.prototype.insert = function(pos, item) {
             if (otherItem !== item) {
               v8Util.setHiddenValue(otherItem, 'checked', false);
             }
-          }
+          });
           return v8Util.setHiddenValue(item, 'checked', true);
         }
       });

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -12,26 +12,29 @@ var nextGroupId = 0;
 // Search between separators to find a radio menu item and return its group id,
 // otherwise generate a group id.
 var generateGroupId = function(items, pos) {
-  var i, item, j, k, ref1, ref2, ref3;
   if (pos > 0) {
-    for (i = j = ref1 = pos - 1; ref1 <= 0 ? j <= 0 : j >= 0; i = ref1 <= 0 ? ++j : --j) {
-      item = items[i];
+    let i = pos - 1;
+    while (i >= 0) {
+      let item = items[i];
       if (item.type === 'radio') {
         return item.groupId;
       }
       if (item.type === 'separator') {
         break;
       }
+      i--;
     }
   } else if (pos < items.length) {
-    for (i = k = ref2 = pos, ref3 = items.length - 1; ref2 <= ref3 ? k <= ref3 : k >= ref3; i = ref2 <= ref3 ? ++k : --k) {
-      item = items[i];
+    let i = pos;
+    while (i < items.length)
+      let item = items[i];
       if (item.type === 'radio') {
         return item.groupId;
       }
       if (item.type === 'separator') {
         break;
       }
+      i++;
     }
   }
   return ++nextGroupId;
@@ -51,12 +54,14 @@ var indexOfItemById = function(items, id) {
 
 // Returns the index of where to insert the item according to |position|.
 var indexToInsertByPosition = function(items, position) {
-  var id, insertIndex, query, ref1;
   if (!position) {
     return items.length;
   }
-  ref1 = position.split('='), query = ref1[0], id = ref1[1];
-  insertIndex = indexOfItemById(items, id);
+
+  const split = position.split('=');
+  const query = split[0]
+  const id = split[1];
+  const insertIndex = indexOfItemById(items, id);
   if (insertIndex === -1 && query !== 'endof') {
     console.warn("Item with id '" + id + "' is not found");
     return items.length;
@@ -120,10 +125,9 @@ Menu.prototype._init = function() {
     },
     menuWillShow: () => {
       // Make sure radio groups have at least one menu item seleted.
-      var checked, group, id, j, len, radioItem, ref1;
-      ref1 = this.groupsMap;
-      for (id in ref1) {
-        group = ref1[id];
+      var checked, group, id, j, len, radioItem;
+      for (id in this.groupsMap) {
+        group = this.groupsMap[id];
         checked = false;
         for (j = 0, len = group.length; j < len; j++) {
           radioItem = group[j];
@@ -196,10 +200,7 @@ Menu.prototype.insert = function(pos, item) {
           return v8Util.getHiddenValue(item, 'checked');
         },
         set: () => {
-          var j, len, otherItem, ref1;
-          ref1 = this.groupsMap[item.groupId];
-          for (j = 0, len = ref1.length; j < len; j++) {
-            otherItem = ref1[j];
+          this.groupsMap[item.groupId].forEach(function(otherItem) {
             if (otherItem !== item) {
               v8Util.setHiddenValue(otherItem, 'checked', false);
             }

--- a/lib/browser/api/navigation-controller.js
+++ b/lib/browser/api/navigation-controller.js
@@ -6,15 +6,17 @@ var slice = [].slice;
 
 // The history operation in renderer is redirected to browser.
 ipcMain.on('ATOM_SHELL_NAVIGATION_CONTROLLER', function() {
-  var args, event, method, ref;
-  event = arguments[0], method = arguments[1], args = 3 <= arguments.length ? slice.call(arguments, 2) : [];
-  return (ref = event.sender)[method].apply(ref, args);
+  const event = arguments[0];
+  const method = arguments[1];
+  const args = 3 <= arguments.length ? slice.call(arguments, 2) : [];
+  return event.sender[method].apply(event.sender, args);
 });
 
 ipcMain.on('ATOM_SHELL_SYNC_NAVIGATION_CONTROLLER', function() {
-  var args, event, method, ref;
-  event = arguments[0], method = arguments[1], args = 3 <= arguments.length ? slice.call(arguments, 2) : [];
-  return event.returnValue = (ref = event.sender)[method].apply(ref, args);
+  const event = arguments[0];
+  const method = arguments[1];
+  const args = 3 <= arguments.length ? slice.call(arguments, 2) : [];
+  return event.returnValue = event.sender[method].apply(event.sender, args);
 });
 
 // JavaScript implementation of Chromium's NavigationController.

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -66,7 +66,7 @@ const webFrameMethods = [
 
 let wrapWebContents = function(webContents) {
   // webContents is an EventEmitter.
-  var controller, method, name, ref1;
+  var controller, method, name;
   webContents.__proto__ = EventEmitter.prototype;
 
   // Every remote callback from renderer process would add a listenter to the
@@ -85,9 +85,8 @@ let wrapWebContents = function(webContents) {
 
   // The navigation controller.
   controller = new NavigationController(webContents);
-  ref1 = NavigationController.prototype;
-  for (name in ref1) {
-    method = ref1[name];
+  for (name in NavigationController.prototype) {
+    method = NavigationController.prototype[name];
     if (method instanceof Function) {
       (function(name, method) {
         return webContents[name] = function() {

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -113,18 +113,18 @@ app.once('ready', function() {
     }
   });
   BrowserWindow.prototype._loadDevToolsExtensions = function(extensionInfoArray) {
-    var ref;
-    return (ref = this.devToolsWebContents) != null ? ref.executeJavaScript("DevToolsAPI.addExtensions(" + (JSON.stringify(extensionInfoArray)) + ");") : void 0;
+    const devToolsWebContents = this.devToolsWebContents;
+    if (devToolsWebContents != null) {
+      const code = "DevToolsAPI.addExtensions(" + JSON.stringify(extensionInfoArray) + ");";
+      devToolsWebContents.executeJavaScript(code);
+    }
   };
   BrowserWindow.addDevToolsExtension = function(srcDirectory) {
-    var extensionInfo, j, len1, ref, window;
-    extensionInfo = getExtensionInfoFromPath(srcDirectory);
+    const extensionInfo = getExtensionInfoFromPath(srcDirectory);
     if (extensionInfo) {
-      ref = BrowserWindow.getAllWindows();
-      for (j = 0, len1 = ref.length; j < len1; j++) {
-        window = ref[j];
+      BrowserWindow.getAllWindows().forEach(function(window) {
         window._loadDevToolsExtensions([extensionInfo]);
-      }
+      });
       return extensionInfo.name;
     }
   };

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -33,43 +33,35 @@ ipcMain.on('ATOM_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', function(event, captureW
 
 desktopCapturer.emit = function(event, name, sources) {
   // Receiving sources result from main process, now send them back to renderer.
-  var captureScreen, captureWindow, handledRequest, i, len, ref, ref1, ref2, request, result, source, thumbnailSize, unhandledRequestsQueue;
-  handledRequest = requestsQueue.shift(0);
-  result = (function() {
-    var i, len, results;
-    results = [];
-    for (i = 0, len = sources.length; i < len; i++) {
-      source = sources[i];
-      results.push({
-        id: source.id,
-        name: source.name,
-        thumbnail: source.thumbnail.toDataUrl()
-      });
-    }
-    return results;
-  })();
-  if ((ref = handledRequest.webContents) != null) {
-    ref.send("ATOM_RENDERER_DESKTOP_CAPTURER_RESULT_" + handledRequest.id, result);
+  const handledRequest = requestsQueue.shift(0);
+  const result = sources.map(function(source) {
+    return {
+      id: source.id,
+      name: source.name,
+      thumbnail: source.thumbnail.toDataUrl()
+    };
+  });
+
+  if (handledRequest.webContents != null) {
+    handledRequest.webContents.send("ATOM_RENDERER_DESKTOP_CAPTURER_RESULT_" + handledRequest.id, result);
   }
 
   // Check the queue to see whether there is other same request. If has, handle
-  // it for reducing redunplicated `desktopCaptuer.startHandling` calls.
-  unhandledRequestsQueue = [];
-  for (i = 0, len = requestsQueue.length; i < len; i++) {
-    request = requestsQueue[i];
+  // it for reducing reduplicated `desktopCaptuer.startHandling` calls.
+  requestQueue = requestsQueue.filter(function(request) {
     if (deepEqual(handledRequest.options, request.options)) {
-      if ((ref1 = request.webContents) != null) {
-        ref1.send("ATOM_RENDERER_DESKTOP_CAPTURER_RESULT_" + request.id, result);
+      if (request.webContents != null) {
+        requets.webContents.send("ATOM_RENDERER_DESKTOP_CAPTURER_RESULT_" + request.id, result);
       }
+      return false;
     } else {
-      unhandledRequestsQueue.push(request);
+      return true;
     }
-  }
-  requestsQueue = unhandledRequestsQueue;
+  });
 
   // If the requestsQueue is not empty, start a new request handling.
   if (requestsQueue.length > 0) {
-    ref2 = requestsQueue[0].options, captureWindow = ref2.captureWindow, captureScreen = ref2.captureScreen, thumbnailSize = ref2.thumbnailSize;
-    return desktopCapturer.startHandling(captureWindow, captureScreen, thumbnailSize);
+    const options = requestsQueue[0].options;
+    return desktopCapturer.startHandling(options.captureWindow, options.captureScreen, options.thumbnailSize);
   }
 };

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -9,8 +9,7 @@ var deepEqual = function(opt1, opt2) {
 var requestsQueue = [];
 
 ipcMain.on('ATOM_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', function(event, captureWindow, captureScreen, thumbnailSize, id) {
-  var request;
-  request = {
+  const request = {
     id: id,
     options: {
       captureWindow: captureWindow,
@@ -48,10 +47,10 @@ desktopCapturer.emit = function(event, name, sources) {
 
   // Check the queue to see whether there is other same request. If has, handle
   // it for reducing reduplicated `desktopCaptuer.startHandling` calls.
-  requestQueue = requestsQueue.filter(function(request) {
+  requestsQueue = requestsQueue.filter(function(request) {
     if (deepEqual(handledRequest.options, request.options)) {
       if (request.webContents != null) {
-        requets.webContents.send("ATOM_RENDERER_DESKTOP_CAPTURER_RESULT_" + request.id, result);
+        request.webContents.send("ATOM_RENDERER_DESKTOP_CAPTURER_RESULT_" + request.id, result);
       }
       return false;
     } else {

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const ipcMain = require('electron').ipcMain;
 const webContents = require('electron').webContents;
 
@@ -163,7 +165,7 @@ var createGuest = function(embedder, params) {
 
 // Attach the guest to an element of embedder.
 var attachGuest = function(embedder, elementInstanceId, guestInstanceId, params) {
-  var guest, key, oldGuestInstanceId, ref1, webPreferences;
+  var guest, key, oldGuestInstanceId, webPreferences;
   guest = guestInstances[guestInstanceId].guest;
 
   // Destroy the old guest when attaching.
@@ -182,7 +184,7 @@ var attachGuest = function(embedder, elementInstanceId, guestInstanceId, params)
   }
   webPreferences = {
     guestInstanceId: guestInstanceId,
-    nodeIntegration: (ref1 = params.nodeintegration) != null ? ref1 : false,
+    nodeIntegration: params.nodeintegration != null ? params.nodeintegration : false,
     plugins: params.plugins,
     webSecurity: !params.disablewebsecurity,
     blinkFeatures: params.blinkfeatures
@@ -222,18 +224,23 @@ ipcMain.on('ATOM_SHELL_GUEST_VIEW_MANAGER_DESTROY_GUEST', function(event, id) {
 });
 
 ipcMain.on('ATOM_SHELL_GUEST_VIEW_MANAGER_SET_SIZE', function(event, id, params) {
-  var ref1;
-  return (ref1 = guestInstances[id]) != null ? ref1.guest.setSize(params) : void 0;
+  const guestInstance = guestInstances[id];
+  return guestInstance != null ? guestInstance.guest.setSize(params) : undefined;
+});
+
+ipcMain.on('ATOM_SHELL_GUEST_VIEW_MANAGER_SET_ALLOW_TRANSPARENCY', function(event, id, allowtransparency) {
+  const guestInstance = guestInstances[id];
+  return guestInstance != null ? guestInstance.guest.setAllowTransparency(allowtransparency) : undefined;
 });
 
 // Returns WebContents from its guest id.
 exports.getGuest = function(id) {
-  var ref1;
-  return (ref1 = guestInstances[id]) != null ? ref1.guest : void 0;
+  const guestInstance = guestInstances[id];
+  return guestInstance != null ? guestInstance.guest : undefined;
 };
 
 // Returns the embedder of the guest.
 exports.getEmbedder = function(id) {
-  var ref1;
-  return (ref1 = guestInstances[id]) != null ? ref1.embedder : void 0;
+  const guestInstance = guestInstances[id];
+  return guestInstance != null ? guestInstance.embedder : undefined;
 };

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -228,11 +228,6 @@ ipcMain.on('ATOM_SHELL_GUEST_VIEW_MANAGER_SET_SIZE', function(event, id, params)
   return guestInstance != null ? guestInstance.guest.setSize(params) : undefined;
 });
 
-ipcMain.on('ATOM_SHELL_GUEST_VIEW_MANAGER_SET_ALLOW_TRANSPARENCY', function(event, id, allowtransparency) {
-  const guestInstance = guestInstances[id];
-  return guestInstance != null ? guestInstance.guest.setAllowTransparency(allowtransparency) : undefined;
-});
-
 // Returns WebContents from its guest id.
 exports.getGuest = function(id) {
   const guestInstance = guestInstances[id];

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -54,7 +54,7 @@ var createGuest = function(embedder, url, frameName, options) {
   if (options.webPreferences == null) {
     options.webPreferences = {};
   }
-  const embedderWindow = BrowserWindow.fromWebContents(embedder)
+  const embedderWindow = BrowserWindow.fromWebContents(embedder);
   options.webPreferences.openerId = embedderWindow != null ? embedderWindow.id : undefined;
   guest = new BrowserWindow(options);
   guest.loadURL(url);
@@ -130,6 +130,6 @@ ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', function() {
   const method = arguments[2];
   const args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
   const guestWindow = BrowserWindow.fromId(guestId);
-  const guestContents = guestWindow != null ? guestContents.webContents : null
+  const guestContents = guestWindow != null ? guestContents.webContents : null;
   return guestContents != null ? guestContents[method].apply(guestContents, args) : undefined;
 });

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const ipcMain = require('electron').ipcMain;
 const BrowserWindow = require('electron').BrowserWindow;
 
@@ -41,7 +43,7 @@ var mergeBrowserWindowOptions = function(embedder, options) {
 
 // Create a new guest created by |embedder| with |options|.
 var createGuest = function(embedder, url, frameName, options) {
-  var closedByEmbedder, closedByUser, guest, guestId, ref1;
+  var closedByEmbedder, closedByUser, guest, guestId;
   guest = frameToGuest[frameName];
   if (frameName && (guest != null)) {
     guest.loadURL(url);
@@ -52,7 +54,8 @@ var createGuest = function(embedder, url, frameName, options) {
   if (options.webPreferences == null) {
     options.webPreferences = {};
   }
-  options.webPreferences.openerId = (ref1 = BrowserWindow.fromWebContents(embedder)) != null ? ref1.id : void 0;
+  const embedderWindow = BrowserWindow.fromWebContents(embedder)
+  options.webPreferences.openerId = embedderWindow != null ? embedderWindow.id : undefined;
   guest = new BrowserWindow(options);
   guest.loadURL(url);
 
@@ -95,30 +98,38 @@ ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPEN', function() {
 });
 
 ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', function(event, guestId) {
-  var ref1;
-  return (ref1 = BrowserWindow.fromId(guestId)) != null ? ref1.destroy() : void 0;
+  const guestWindow = BrowserWindow.fromId(guestId);
+  return guestWindow != null ? guestWindow.destroy() : undefined;
 });
 
 ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', function() {
-  var args, guestId, method, ref1;
-  event = arguments[0], guestId = arguments[1], method = arguments[2], args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
-  return event.returnValue = (ref1 = BrowserWindow.fromId(guestId)) != null ? ref1[method].apply(ref1, args) : void 0;
+  const event = arguments[0];
+  const guestId = arguments[1];
+  const method = arguments[2];
+  const args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
+  const guestWindow = BrowserWindow.fromId(guestId);
+  return event.returnValue = guestWindow != null ? guestWindow[method].apply(guestWindow, args) : undefined;
 });
 
 ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', function(event, guestId, message, targetOrigin, sourceOrigin) {
-  var guestContents, ref1, ref2, sourceId;
-  sourceId = (ref1 = BrowserWindow.fromWebContents(event.sender)) != null ? ref1.id : void 0;
+  const senderWindow = BrowserWindow.fromWebContents(event.sender);
+  const sourceId = senderWindow != null ? senderWindow.id : undefined;
   if (sourceId == null) {
     return;
   }
-  guestContents = (ref2 = BrowserWindow.fromId(guestId)) != null ? ref2.webContents : void 0;
+
+  const guestWindow = BrowserWindow.fromId(guestId);
+  const guestContents = guestWindow != null ? guestWindow.webContents : undefined;
   if ((guestContents != null ? guestContents.getURL().indexOf(targetOrigin) : void 0) === 0 || targetOrigin === '*') {
     return guestContents != null ? guestContents.send('ATOM_SHELL_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin) : void 0;
   }
 });
 
 ipcMain.on('ATOM_SHELL_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', function() {
-  var args, guestId, method, ref1, ref2;
-  guestId = arguments[1], method = arguments[2], args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
-  return (ref1 = BrowserWindow.fromId(guestId)) != null ? (ref2 = ref1.webContents) != null ? ref2[method].apply(ref2, args) : void 0 : void 0;
+  const guestId = arguments[1];
+  const method = arguments[2];
+  const args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
+  const guestWindow = BrowserWindow.fromId(guestId);
+  const guestContents = guestWindow != null ? guestContents.webContents : null
+  return guestContents != null ? guestContents[method].apply(guestContents, args) : undefined;
 });

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
 const util = require('util');
@@ -57,18 +59,19 @@ if (process.platform === 'win32') {
 
 // Don't quit on fatal error.
 process.on('uncaughtException', function(error) {
-
   // Do nothing if the user has a custom uncaught exception handler.
-  var dialog, message, ref, stack;
   if (process.listeners('uncaughtException').length > 1) {
     return;
   }
 
   // Show error in GUI.
-  dialog = require('electron').dialog;
-  stack = (ref = error.stack) != null ? ref : error.name + ": " + error.message;
-  message = "Uncaught Exception:\n" + stack;
-  return dialog.showErrorBox('A JavaScript error occurred in the main process', message);
+  const dialog = require('electron').dialog;
+  let stack = error.stack;
+  if (stack == null) {
+    stack = error.name + ": " + error.message;
+  }
+  const message = "Uncaught Exception:\n" + stack;
+  dialog.showErrorBox('A JavaScript error occurred in the main process', message);
 });
 
 // Emit 'exit' event on quit.

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -147,7 +147,6 @@ var exceptionToMeta = function(error) {
 var unwrapArgs = function(sender, args) {
   var metaToValue;
   metaToValue = function(meta) {
-    var i, len, member, ref, returnValue;
     switch (meta.type) {
       case 'value':
         return meta.value;
@@ -166,16 +165,13 @@ var unwrapArgs = function(sender, args) {
       case 'object': {
         let ret = {};
         Object.defineProperty(ret.constructor, 'name', { value: meta.name });
-
-        ref = meta.members;
-        for (i = 0, len = ref.length; i < len; i++) {
-          member = ref[i];
+        meta.members.forEach(function(member) {
           ret[member.name] = metaToValue(member.value);
-        }
+        });
         return ret;
       }
       case 'function-with-return-value':
-        returnValue = metaToValue(meta.value);
+        const returnValue = metaToValue(meta.value);
         return function() {
           return returnValue;
         };
@@ -217,7 +213,7 @@ var unwrapArgs = function(sender, args) {
 // Call a function and send reply asynchronously if it's a an asynchronous
 // style function and the caller didn't pass a callback.
 var callFunction = function(event, func, caller, args) {
-  var funcMarkedAsync, funcName, funcPassedCallback, ref, ret;
+  var funcMarkedAsync, funcName, funcPassedCallback, ret;
   funcMarkedAsync = v8Util.getHiddenValue(func, 'asynchronous');
   funcPassedCallback = typeof args[args.length - 1] === 'function';
   try {
@@ -234,7 +230,10 @@ var callFunction = function(event, func, caller, args) {
     // Catch functions thrown further down in function invocation and wrap
     // them with the function name so it's easier to trace things like
     // `Error processing argument -1.`
-    funcName = (ref = func.name) != null ? ref : "anonymous";
+    funcName = func.name;
+    if (funcName == null) {
+      funcName = "anonymous";
+    }
     throw new Error("Could not call remote function `" + funcName + "`. Check that the function signature is correct. Underlying error: " + error.message);
   }
 };

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -170,11 +170,12 @@ var unwrapArgs = function(sender, args) {
         });
         return ret;
       }
-      case 'function-with-return-value':
+      case 'function-with-return-value': {
         const returnValue = metaToValue(meta.value);
         return function() {
           return returnValue;
         };
+      }
       case 'function': {
         // Cache the callbacks in renderer.
         let webContentsId = sender.getId();

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -214,9 +214,8 @@ var unwrapArgs = function(sender, args) {
 // Call a function and send reply asynchronously if it's a an asynchronous
 // style function and the caller didn't pass a callback.
 var callFunction = function(event, func, caller, args) {
-  var funcMarkedAsync, funcName, funcPassedCallback, ret;
-  funcMarkedAsync = v8Util.getHiddenValue(func, 'asynchronous');
-  funcPassedCallback = typeof args[args.length - 1] === 'function';
+  const funcMarkedAsync = v8Util.getHiddenValue(func, 'asynchronous');
+  const funcPassedCallback = typeof args[args.length - 1] === 'function';
   try {
     if (funcMarkedAsync && !funcPassedCallback) {
       args.push(function(ret) {
@@ -224,14 +223,14 @@ var callFunction = function(event, func, caller, args) {
       });
       return func.apply(caller, args);
     } else {
-      ret = func.apply(caller, args);
+      let ret = func.apply(caller, args);
       return event.returnValue = valueToMeta(event.sender, ret, true);
     }
   } catch (error) {
     // Catch functions thrown further down in function invocation and wrap
     // them with the function name so it's easier to trace things like
     // `Error processing argument -1.`
-    funcName = func.name;
+    let funcName = func.name;
     if (funcName == null) {
       funcName = "anonymous";
     }

--- a/lib/common/api/callbacks-registry.js
+++ b/lib/common/api/callbacks-registry.js
@@ -12,7 +12,7 @@ class CallbacksRegistry {
 
   add(callback) {
     // The callback is already added.
-    var filenameAndLine, id, location, match, ref, regexp, stackString;
+    var filenameAndLine, id, location, match, regexp, stackString;
     id = v8Util.getHiddenValue(callback, 'callbackId');
     if (id != null) {
       return id;
@@ -31,8 +31,7 @@ class CallbacksRegistry {
       if (location.indexOf('atom.asar') !== -1) {
         continue;
       }
-      ref = /([^\/^\)]*)\)?$/gi.exec(location);
-      filenameAndLine = ref[1];
+      filenameAndLine = /([^\/^\)]*)\)?$/gi.exec(location)[1];
       break;
     }
     this.callbacks[id] = callback;
@@ -42,20 +41,22 @@ class CallbacksRegistry {
   }
 
   get(id) {
-    var ref;
-    return (ref = this.callbacks[id]) != null ? ref : function() {};
+    const callback = this.callbacks[id];
+    return callback != null ? callback : function() {};
   }
 
   call() {
-    var args, id, ref;
-    id = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
-    return (ref = this.get(id)).call.apply(ref, [global].concat(slice.call(args)));
+    const id = arguments[0];
+    const args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
+    const callback = this.get(id);
+    return callback.call.apply(callback, [global].concat(slice.call(args)));
   }
 
   apply() {
-    var args, id, ref;
-    id = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
-    return (ref = this.get(id)).apply.apply(ref, [global].concat(slice.call(args)));
+    const id = arguments[0];
+    const args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
+    const callback = this.get(id);
+    return callback.apply.apply(callback, [global].concat(slice.call(args)));
   }
 
   remove(id) {

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -162,7 +162,7 @@
       if (!archive) {
         invalidArchiveError(asarPath);
       }
-      newPath = archive.copyFileOut(filePath);
+      const newPath = archive.copyFileOut(filePath);
       if (!newPath) {
         notFoundError(asarPath, filePath);
       }
@@ -289,7 +289,7 @@
     fs.statSyncNoException = function(p) {
       const split = splitPath(p);
       const isAsar = split[0];
-      const asarPath = split[1]
+      const asarPath = split[1];
       const filePath = split[2];
       if (!isAsar) {
         return statSyncNoException(p);
@@ -326,8 +326,8 @@
     realpath = fs.realpath;
     fs.realpath = function(p, cache, callback) {
       const split = splitPath(p);
-      const isAsar = split[0]
-      const asarPath = split[1]
+      const isAsar = split[0];
+      const asarPath = split[1];
       const filePath = split[2];
       if (!isAsar) {
         return realpath.apply(this, arguments);
@@ -438,7 +438,7 @@
     readFileSync = fs.readFileSync;
     fs.readFileSync = function(p, opts) {
       // this allows v8 to optimize this function
-      const options = opts;
+      var options = opts;
       const split = splitPath(p);
       const isAsar = split[0];
       const asarPath = split[1];
@@ -462,7 +462,7 @@
         }
       }
       if (info.unpacked) {
-        realPath = archive.copyFileOut(filePath);
+        const realPath = archive.copyFileOut(filePath);
         return fs.readFileSync(realPath, options);
       }
       if (!options) {
@@ -567,7 +567,7 @@
     };
     internalModuleStat = process.binding('fs').internalModuleStat;
     process.binding('fs').internalModuleStat = function(p) {
-      const split = splitPath(p)
+      const split = splitPath(p);
       const isAsar = split[0];
       const asarPath = split[1];
       const filePath = split[2];
@@ -605,8 +605,8 @@
         if (typeof mode === 'function') {
           callback = mode;
         }
-        const split = splitPath(p)
-        const isAsar = split[0]
+        const split = splitPath(p);
+        const isAsar = split[0];
         const filePath = split[2];
         if (isAsar && filePath.length) {
           return notDirError(callback);

--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -150,13 +150,15 @@
     }
     old = module[name];
     return module[name] = function() {
-      var archive, asarPath, filePath, isAsar, newPath, p, ref;
-      p = arguments[arg];
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const p = arguments[arg];
+      const split = splitPath(p);
+      const isAsar = split[0];
+      const asarPath = split[1];
+      const filePath = split[2];
       if (!isAsar) {
         return old.apply(this, arguments);
       }
-      archive = getOrCreateArchive(asarPath);
+      const archive = getOrCreateArchive(asarPath);
       if (!archive) {
         invalidArchiveError(asarPath);
       }
@@ -176,21 +178,23 @@
     }
     old = module[name];
     return module[name] = function() {
-      var archive, asarPath, callback, filePath, isAsar, newPath, p, ref;
-      p = arguments[arg];
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const p = arguments[arg];
+      const split = splitPath(p);
+      const isAsar = split[0];
+      const asarPath = split[1];
+      const filePath = split[2];
       if (!isAsar) {
         return old.apply(this, arguments);
       }
-      callback = arguments[arguments.length - 1];
+      const callback = arguments[arguments.length - 1];
       if (typeof callback !== 'function') {
         return overrideAPISync(module, name, arg);
       }
-      archive = getOrCreateArchive(asarPath);
+      const archive = getOrCreateArchive(asarPath);
       if (!archive) {
         return invalidArchiveError(asarPath, callback);
       }
-      newPath = archive.copyFileOut(filePath);
+      const newPath = archive.copyFileOut(filePath);
       if (!newPath) {
         return notFoundError(asarPath, filePath, callback);
       }
@@ -221,16 +225,18 @@
 
     lstatSync = fs.lstatSync;
     fs.lstatSync = function(p) {
-      var archive, asarPath, filePath, isAsar, ref, stats;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const split = splitPath(p);
+      const isAsar = split[0];
+      const asarPath = split[1];
+      const filePath = split[2];
       if (!isAsar) {
         return lstatSync(p);
       }
-      archive = getOrCreateArchive(asarPath);
+      const archive = getOrCreateArchive(asarPath);
       if (!archive) {
         invalidArchiveError(asarPath);
       }
-      stats = archive.stat(filePath);
+      const stats = archive.stat(filePath);
       if (!stats) {
         notFoundError(asarPath, filePath);
       }
@@ -238,16 +244,18 @@
     };
     lstat = fs.lstat;
     fs.lstat = function(p, callback) {
-      var archive, asarPath, filePath, isAsar, ref, stats;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const split = splitPath(p);
+      const isAsar = split[0];
+      const asarPath = split[1];
+      const filePath = split[2];
       if (!isAsar) {
         return lstat(p, callback);
       }
-      archive = getOrCreateArchive(asarPath);
+      const archive = getOrCreateArchive(asarPath);
       if (!archive) {
         return invalidArchiveError(asarPath, callback);
       }
-      stats = getOrCreateArchive(asarPath).stat(filePath);
+      const stats = getOrCreateArchive(asarPath).stat(filePath);
       if (!stats) {
         return notFoundError(asarPath, filePath, callback);
       }
@@ -279,16 +287,18 @@
     };
     statSyncNoException = fs.statSyncNoException;
     fs.statSyncNoException = function(p) {
-      var archive, asarPath, filePath, isAsar, ref, stats;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const split = splitPath(p);
+      const isAsar = split[0];
+      const asarPath = split[1]
+      const filePath = split[2];
       if (!isAsar) {
         return statSyncNoException(p);
       }
-      archive = getOrCreateArchive(asarPath);
+      const archive = getOrCreateArchive(asarPath);
       if (!archive) {
         return false;
       }
-      stats = archive.stat(filePath);
+      const stats = archive.stat(filePath);
       if (!stats) {
         return false;
       }
@@ -296,16 +306,18 @@
     };
     realpathSync = fs.realpathSync;
     fs.realpathSync = function(p) {
-      var archive, asarPath, filePath, isAsar, real, ref;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const split = splitPath(p);
+      const isAsar = split[0];
+      const asarPath = split[1];
+      const filePath = split[2];
       if (!isAsar) {
         return realpathSync.apply(this, arguments);
       }
-      archive = getOrCreateArchive(asarPath);
+      const archive = getOrCreateArchive(asarPath);
       if (!archive) {
         invalidArchiveError(asarPath);
       }
-      real = archive.realpath(filePath);
+      const real = archive.realpath(filePath);
       if (real === false) {
         notFoundError(asarPath, filePath);
       }
@@ -313,8 +325,10 @@
     };
     realpath = fs.realpath;
     fs.realpath = function(p, cache, callback) {
-      var archive, asarPath, filePath, isAsar, real, ref;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const split = splitPath(p);
+      const isAsar = split[0]
+      const asarPath = split[1]
+      const filePath = split[2];
       if (!isAsar) {
         return realpath.apply(this, arguments);
       }
@@ -322,11 +336,11 @@
         callback = cache;
         cache = void 0;
       }
-      archive = getOrCreateArchive(asarPath);
+      const archive = getOrCreateArchive(asarPath);
       if (!archive) {
         return invalidArchiveError(asarPath, callback);
       }
-      real = archive.realpath(filePath);
+      const real = archive.realpath(filePath);
       if (real === false) {
         return notFoundError(asarPath, filePath, callback);
       }
@@ -339,12 +353,14 @@
     };
     exists = fs.exists;
     fs.exists = function(p, callback) {
-      var archive, asarPath, filePath, isAsar, ref;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const split = splitPath(p);
+      const isAsar = split[0];
+      const asarPath = split[1];
+      const filePath = split[2];
       if (!isAsar) {
         return exists(p, callback);
       }
-      archive = getOrCreateArchive(asarPath);
+      const archive = getOrCreateArchive(asarPath);
       if (!archive) {
         return invalidArchiveError(asarPath, callback);
       }
@@ -354,12 +370,14 @@
     };
     existsSync = fs.existsSync;
     fs.existsSync = function(p) {
-      var archive, asarPath, filePath, isAsar, ref;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const split = splitPath(p);
+      const isAsar = split[0];
+      const asarPath = split[1];
+      const filePath = split[2];
       if (!isAsar) {
         return existsSync(p);
       }
-      archive = getOrCreateArchive(asarPath);
+      const archive = getOrCreateArchive(asarPath);
       if (!archive) {
         return false;
       }
@@ -367,20 +385,22 @@
     };
     readFile = fs.readFile;
     fs.readFile = function(p, options, callback) {
-      var archive, asarPath, buffer, encoding, fd, filePath, info, isAsar, realPath, ref;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const split = splitPath(p);
+      const isAsar = split[0];
+      const asarPath = split[1];
+      const filePath = split[2];
       if (!isAsar) {
         return readFile.apply(this, arguments);
       }
       if (typeof options === 'function') {
         callback = options;
-        options = void 0;
+        options = undefined;
       }
-      archive = getOrCreateArchive(asarPath);
+      const archive = getOrCreateArchive(asarPath);
       if (!archive) {
         return invalidArchiveError(asarPath, callback);
       }
-      info = archive.getFileInfo(filePath);
+      const info = archive.getFileInfo(filePath);
       if (!info) {
         return notFoundError(asarPath, filePath, callback);
       }
@@ -390,7 +410,7 @@
         });
       }
       if (info.unpacked) {
-        realPath = archive.copyFileOut(filePath);
+        const realPath = archive.copyFileOut(filePath);
         return fs.readFile(realPath, options, callback);
       }
       if (!options) {
@@ -404,9 +424,9 @@
       } else if (!util.isObject(options)) {
         throw new TypeError('Bad arguments');
       }
-      encoding = options.encoding;
-      buffer = new Buffer(info.size);
-      fd = archive.getFd();
+      const encoding = options.encoding;
+      const buffer = new Buffer(info.size);
+      const fd = archive.getFd();
       if (!(fd >= 0)) {
         return notFoundError(asarPath, filePath, callback);
       }
@@ -418,17 +438,19 @@
     readFileSync = fs.readFileSync;
     fs.readFileSync = function(p, opts) {
       // this allows v8 to optimize this function
-      var archive, asarPath, buffer, encoding, fd, filePath, info, isAsar, options, realPath, ref;
-      options = opts;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const options = opts;
+      const split = splitPath(p);
+      const isAsar = split[0];
+      const asarPath = split[1];
+      const filePath = split[2];
       if (!isAsar) {
         return readFileSync.apply(this, arguments);
       }
-      archive = getOrCreateArchive(asarPath);
+      const archive = getOrCreateArchive(asarPath);
       if (!archive) {
         invalidArchiveError(asarPath);
       }
-      info = archive.getFileInfo(filePath);
+      const info = archive.getFileInfo(filePath);
       if (!info) {
         notFoundError(asarPath, filePath);
       }
@@ -454,9 +476,9 @@
       } else if (!util.isObject(options)) {
         throw new TypeError('Bad arguments');
       }
-      encoding = options.encoding;
-      buffer = new Buffer(info.size);
-      fd = archive.getFd();
+      const encoding = options.encoding;
+      const buffer = new Buffer(info.size);
+      const fd = archive.getFd();
       if (!(fd >= 0)) {
         notFoundError(asarPath, filePath);
       }
@@ -470,16 +492,18 @@
     };
     readdir = fs.readdir;
     fs.readdir = function(p, callback) {
-      var archive, asarPath, filePath, files, isAsar, ref;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const split = splitPath(p);
+      const isAsar = split[0];
+      const asarPath = split[1];
+      const filePath = split[2];
       if (!isAsar) {
         return readdir.apply(this, arguments);
       }
-      archive = getOrCreateArchive(asarPath);
+      const archive = getOrCreateArchive(asarPath);
       if (!archive) {
         return invalidArchiveError(asarPath, callback);
       }
-      files = archive.readdir(filePath);
+      const files = archive.readdir(filePath);
       if (!files) {
         return notFoundError(asarPath, filePath, callback);
       }
@@ -489,16 +513,18 @@
     };
     readdirSync = fs.readdirSync;
     fs.readdirSync = function(p) {
-      var archive, asarPath, filePath, files, isAsar, ref;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const split = splitPath(p);
+      const isAsar = split[0];
+      const asarPath = split[1];
+      const filePath = split[2];
       if (!isAsar) {
         return readdirSync.apply(this, arguments);
       }
-      archive = getOrCreateArchive(asarPath);
+      const archive = getOrCreateArchive(asarPath);
       if (!archive) {
         invalidArchiveError(asarPath);
       }
-      files = archive.readdir(filePath);
+      const files = archive.readdir(filePath);
       if (!files) {
         notFoundError(asarPath, filePath);
       }
@@ -506,32 +532,34 @@
     };
     internalModuleReadFile = process.binding('fs').internalModuleReadFile;
     process.binding('fs').internalModuleReadFile = function(p) {
-      var archive, asarPath, buffer, fd, filePath, info, isAsar, realPath, ref;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const split = splitPath(p);
+      const isAsar = split[0];
+      const asarPath = split[1];
+      const filePath = split[2];
       if (!isAsar) {
         return internalModuleReadFile(p);
       }
-      archive = getOrCreateArchive(asarPath);
+      const archive = getOrCreateArchive(asarPath);
       if (!archive) {
-        return void 0;
+        return;
       }
-      info = archive.getFileInfo(filePath);
+      const info = archive.getFileInfo(filePath);
       if (!info) {
-        return void 0;
+        return;
       }
       if (info.size === 0) {
         return '';
       }
       if (info.unpacked) {
-        realPath = archive.copyFileOut(filePath);
+        const realPath = archive.copyFileOut(filePath);
         return fs.readFileSync(realPath, {
           encoding: 'utf8'
         });
       }
-      buffer = new Buffer(info.size);
-      fd = archive.getFd();
+      const buffer = new Buffer(info.size);
+      const fd = archive.getFd();
       if (!(fd >= 0)) {
-        return void 0;
+        return;
       }
       logASARAccess(asarPath, filePath, info.offset);
       fs.readSync(fd, buffer, 0, info.size, info.offset);
@@ -539,23 +567,27 @@
     };
     internalModuleStat = process.binding('fs').internalModuleStat;
     process.binding('fs').internalModuleStat = function(p) {
-      var archive, asarPath, filePath, isAsar, ref, stats;
-      ref = splitPath(p), isAsar = ref[0], asarPath = ref[1], filePath = ref[2];
+      const split = splitPath(p)
+      const isAsar = split[0];
+      const asarPath = split[1];
+      const filePath = split[2];
+
       if (!isAsar) {
         return internalModuleStat(p);
       }
-      archive = getOrCreateArchive(asarPath);
 
+      const archive = getOrCreateArchive(asarPath);
       // -ENOENT
       if (!archive) {
         return -34;
       }
-      stats = archive.stat(filePath);
 
+      const stats = archive.stat(filePath);
       // -ENOENT
       if (!stats) {
         return -34;
       }
+
       if (stats.isDirectory) {
         return 1;
       } else {
@@ -570,11 +602,12 @@
     if (process.platform === 'win32') {
       mkdir = fs.mkdir;
       fs.mkdir = function(p, mode, callback) {
-        var filePath, isAsar, ref;
         if (typeof mode === 'function') {
           callback = mode;
         }
-        ref = splitPath(p), isAsar = ref[0], filePath = ref[2];
+        const split = splitPath(p)
+        const isAsar = split[0]
+        const filePath = split[2];
         if (isAsar && filePath.length) {
           return notDirError(callback);
         }
@@ -582,8 +615,9 @@
       };
       mkdirSync = fs.mkdirSync;
       fs.mkdirSync = function(p, mode) {
-        var filePath, isAsar, ref;
-        ref = splitPath(p), isAsar = ref[0], filePath = ref[2];
+        const split = splitPath(p);
+        const isAsar = split[0];
+        const filePath = split[2];
         if (isAsar && filePath.length) {
           notDirError();
         }

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -144,18 +144,13 @@ let setObjectPrototype = function(object, metaId, descriptor) {
 
 // Convert meta data from browser into real value.
 let metaToValue = function(meta) {
-  var el, i, len, ref1, results, ret;
   switch (meta.type) {
     case 'value':
       return meta.value;
     case 'array':
-      ref1 = meta.members;
-      results = [];
-      for (i = 0, len = ref1.length; i < len; i++) {
-        el = ref1[i];
-        results.push(metaToValue(el));
-      }
-      return results;
+      return meta.members.map(function (el) {
+        return metaToValue(el);
+      });
     case 'buffer':
       return new Buffer(meta.value);
     case 'promise':
@@ -172,6 +167,7 @@ let metaToValue = function(meta) {
       if (remoteObjectCache.has(meta.id))
         return remoteObjectCache.get(meta.id);
 
+      let ret;
       if (meta.type === 'function') {
         // A shadow class to represent the remote function object.
         let remoteFunction = function() {
@@ -216,20 +212,10 @@ let metaToValue = function(meta) {
 
 // Construct a plain object from the meta.
 var metaToPlainObject = function(meta) {
-  var i, len, name, obj, ref1, ref2, value;
-  obj = (function() {
-    switch (meta.type) {
-      case 'error':
-        return new Error;
-      default:
-        return {};
-    }
-  })();
-  ref1 = meta.members;
-  for (i = 0, len = ref1.length; i < len; i++) {
-    ref2 = ref1[i], name = ref2.name, value = ref2.value;
-    obj[name] = value;
-  }
+  const obj = meta.type === 'error' ? new Error : {};
+  meta.members.forEach(function (member) {
+    obj[member.name] = member.value;
+  });
   return obj;
 };
 

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -163,7 +163,7 @@ let metaToValue = function(meta) {
       return new Date(meta.value);
     case 'exception':
       throw new Error(meta.message + "\n" + meta.stack);
-    default:
+    default: {
       if (remoteObjectCache.has(meta.id))
         return remoteObjectCache.get(meta.id);
 
@@ -207,6 +207,7 @@ let metaToValue = function(meta) {
       v8Util.setHiddenValue(ret, 'atomId', meta.id);
       remoteObjectCache.set(meta.id, ret);
       return ret;
+    }
   }
 };
 

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -48,10 +48,7 @@ electron.ipcRenderer.on('ELECTRON_INTERNAL_RENDERER_ASYNC_WEB_FRAME_METHOD', (ev
 var nodeIntegration = 'false';
 var preloadScript = null;
 
-var ref = process.argv;
-var i, len, arg;
-for (i = 0, len = ref.length; i < len; i++) {
-  arg = ref[i];
+process.argv.forEach(function(arg) {
   if (arg.indexOf('--guest-instance-id=') === 0) {
     // This is a guest web view.
     process.guestInstanceId = parseInt(arg.substr(arg.indexOf('=') + 1));
@@ -63,7 +60,7 @@ for (i = 0, len = ref.length; i < len; i++) {
   } else if (arg.indexOf('--preload=') === 0) {
     preloadScript = arg.substr(arg.indexOf('=') + 1);
   }
-}
+});
 
 if (location.protocol === 'chrome-devtools:') {
   // Override some inspector APIs.

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -92,7 +92,7 @@ if (process.guestInstanceId == null) {
 
 // Make the browser window or guest view emit "new-window" event.
 window.open = function(url, frameName, features) {
-  var feature, guestId, i, ints, j, len, len1, name, options, ref1, ref2, value;
+  var feature, guestId, i, ints, j, len, len1, name, options, value;
   if (frameName == null) {
     frameName = '';
   }
@@ -103,14 +103,12 @@ window.open = function(url, frameName, features) {
   ints = ['x', 'y', 'width', 'height', 'min-width', 'max-width', 'min-height', 'max-height', 'zoom-factor'];
 
   // Make sure to get rid of excessive whitespace in the property name
-  ref1 = features.split(/,\s*/);
-  for (i = 0, len = ref1.length; i < len; i++) {
-    feature = ref1[i];
-    ref2 = feature.split(/\s*=/);
-    name = ref2[0];
-    value = ref2[1];
+  features.split(/,\s*/).forEach(function(feature) {
+    const segments = feature.split(/\s*=/);
+    name = segments[0];
+    value = segments[1];
     options[name] = value === 'yes' || value === '1' ? true : value === 'no' || value === '0' ? false : value;
-  }
+  })
   if (options.left) {
     if (options.x == null) {
       options.x = options.left;

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -92,23 +92,22 @@ if (process.guestInstanceId == null) {
 
 // Make the browser window or guest view emit "new-window" event.
 window.open = function(url, frameName, features) {
-  var feature, guestId, i, ints, j, len, len1, name, options, value;
   if (frameName == null) {
     frameName = '';
   }
   if (features == null) {
     features = '';
   }
-  options = {};
-  ints = ['x', 'y', 'width', 'height', 'min-width', 'max-width', 'min-height', 'max-height', 'zoom-factor'];
+  const options = {};
+  const ints = ['x', 'y', 'width', 'height', 'min-width', 'max-width', 'min-height', 'max-height', 'zoom-factor'];
 
   // Make sure to get rid of excessive whitespace in the property name
   features.split(/,\s*/).forEach(function(feature) {
     const segments = feature.split(/\s*=/);
-    name = segments[0];
-    value = segments[1];
+    const name = segments[0];
+    const value = segments[1];
     options[name] = value === 'yes' || value === '1' ? true : value === 'no' || value === '0' ? false : value;
-  })
+  });
   if (options.left) {
     if (options.x == null) {
       options.x = options.left;
@@ -131,13 +130,12 @@ window.open = function(url, frameName, features) {
 
   // Resolve relative urls.
   url = resolveURL(url);
-  for (j = 0, len1 = ints.length; j < len1; j++) {
-    name = ints[j];
+  ints.forEach(function(name) {
     if (options[name] != null) {
       options[name] = parseInt(options[name], 10);
     }
-  }
-  guestId = ipcRenderer.sendSync('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPEN', url, frameName, options);
+  });
+  const guestId = ipcRenderer.sendSync('ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPEN', url, frameName, options);
   if (guestId) {
     return BrowserWindowProxy.getOrCreate(guestId);
   } else {

--- a/lib/renderer/web-view/guest-view-internal.js
+++ b/lib/renderer/web-view/guest-view-internal.js
@@ -44,12 +44,14 @@ var DEPRECATED_EVENTS = {
 };
 
 var dispatchEvent = function() {
-  var args, domEvent, eventKey, eventName, f, i, j, len, webView;
-  webView = arguments[0], eventName = arguments[1], eventKey = arguments[2], args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
+  const webView = arguments[0];
+  const eventName = arguments[1];
+  const eventKey = arguments[2];
+  const args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
   if (DEPRECATED_EVENTS[eventName] != null) {
     dispatchEvent.apply(null, [webView, DEPRECATED_EVENTS[eventName], eventKey].concat(slice.call(args)));
   }
-  domEvent = new Event(eventName);
+  const domEvent = new Event(eventName);
   WEB_VIEW_EVENTS[eventKey].forEach(function(field, index) {
     domEvent[field] = args[index];
   });

--- a/lib/renderer/web-view/guest-view-internal.js
+++ b/lib/renderer/web-view/guest-view-internal.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const ipcRenderer = require('electron').ipcRenderer;
 const webFrame = require('electron').webFrame;
 
@@ -42,17 +44,15 @@ var DEPRECATED_EVENTS = {
 };
 
 var dispatchEvent = function() {
-  var args, domEvent, eventKey, eventName, f, i, j, len, ref1, webView;
+  var args, domEvent, eventKey, eventName, f, i, j, len, webView;
   webView = arguments[0], eventName = arguments[1], eventKey = arguments[2], args = 4 <= arguments.length ? slice.call(arguments, 3) : [];
   if (DEPRECATED_EVENTS[eventName] != null) {
     dispatchEvent.apply(null, [webView, DEPRECATED_EVENTS[eventName], eventKey].concat(slice.call(args)));
   }
   domEvent = new Event(eventName);
-  ref1 = WEB_VIEW_EVENTS[eventKey];
-  for (i = j = 0, len = ref1.length; j < len; i = ++j) {
-    f = ref1[i];
-    domEvent[f] = args[i];
-  }
+  WEB_VIEW_EVENTS[eventKey].forEach(function(field, index) {
+    domEvent[field] = args[index];
+  });
   webView.dispatchEvent(domEvent);
   if (eventName === 'load-commit') {
     return webView.onLoadCommit(domEvent);
@@ -75,14 +75,11 @@ module.exports = {
       return webView.dispatchEvent(domEvent);
     });
     return ipcRenderer.on("ATOM_SHELL_GUEST_VIEW_INTERNAL_SIZE_CHANGED-" + viewInstanceId, function() {
-      var args, domEvent, f, i, j, len, ref1;
-      args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
-      domEvent = new Event('size-changed');
-      ref1 = ['oldWidth', 'oldHeight', 'newWidth', 'newHeight'];
-      for (i = j = 0, len = ref1.length; j < len; i = ++j) {
-        f = ref1[i];
-        domEvent[f] = args[i];
-      }
+      const args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
+      const domEvent = new Event('size-changed');
+      ['oldWidth', 'oldHeight', 'newWidth', 'newHeight'].forEach(function (field, index) {
+        domEvent[field] = args[index];
+      });
       return webView.onSizeChanged(domEvent);
     });
   },

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -225,15 +225,15 @@ var WebViewImpl = (function() {
   };
 
   WebViewImpl.prototype.buildParams = function() {
-    var attribute, attributeName, css, elementRect, params, ref1;
-    params = {
+    const params = {
       instanceId: this.viewInstanceId,
       userAgentOverride: this.userAgentOverride
     };
-    ref1 = this.attributes;
-    for (attributeName in ref1) {
-      if (!hasProp.call(ref1, attributeName)) continue;
-      attribute = ref1[attributeName];
+
+    const attributes = this.attributes;
+    for (let attributeName in attributes) {
+      if (!hasProp.call(attributes, attributeName)) continue;
+      const attribute = attributes[attributeName];
       params[attributeName] = attribute.getValue();
     }
 
@@ -242,8 +242,8 @@ var WebViewImpl = (function() {
     // However, in the case where the WebView has a fixed size we can
     // use that value to initially size the guest so as to avoid a relayout of
     // the on display:block.
-    css = window.getComputedStyle(this.webviewNode, null);
-    elementRect = this.webviewNode.getBoundingClientRect();
+    const css = window.getComputedStyle(this.webviewNode, null);
+    const elementRect = this.webviewNode.getBoundingClientRect();
     params.elementWidth = parseInt(elementRect.width) || parseInt(css.getPropertyValue('width'));
     params.elementHeight = parseInt(elementRect.height) || parseInt(css.getPropertyValue('height'));
     return params;


### PR DESCRIPTION
* Cleans up the `ref`, `ref1`, `ref2`, etc. variables left over from the CoffeeScript migration.
* Migrates to using `const` and `let` over long `var` lines at the top of several functions.
* Migrates to using `forEach`, `find`, `filter`, `map` over `for` loops in several places.

### Before

```js
BrowserWindow.fromWebContents = function(webContents) {
  var i, len, ref1, window, windows;
  windows = BrowserWindow.getAllWindows();
  for (i = 0, len = windows.length; i < len; i++) {
     window = windows[i];
     if ((ref1 = window.webContents) != null ? ref1.equal(webContents) : void 0) {
       return window;
     }
   }
};
```

### After

```js
BrowserWindow.fromWebContents = function(webContents) {
  return BrowserWindow.getAllWindows().find(function(window) {
    const contents = window.webContents;
    return contents != null && contents.equal(webContents);
  });
};
```

Refs #4065 