### PR TITLE
OSX: Expose 3-finger swipe events in browser-window

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -243,6 +243,22 @@ void Window::OnWindowScrollTouchEnd() {
   Emit("scroll-touch-end");
 }
 
+void Window::OnWindowSwipeUp() {
+  Emit("swipe-up");
+}
+
+void Window::OnWindowSwipeRight() {
+  Emit("swipe-right");
+}
+
+void Window::OnWindowSwipeDown() {
+  Emit("swipe-down");
+}
+
+void Window::OnWindowSwipeLeft() {
+  Emit("swipe-left");
+}
+
 void Window::OnWindowEnterHtmlFullScreen() {
   Emit("enter-html-full-screen");
 }

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -243,20 +243,8 @@ void Window::OnWindowScrollTouchEnd() {
   Emit("scroll-touch-end");
 }
 
-void Window::OnWindowSwipeUp() {
-  Emit("swipe-up");
-}
-
-void Window::OnWindowSwipeRight() {
-  Emit("swipe-right");
-}
-
-void Window::OnWindowSwipeDown() {
-  Emit("swipe-down");
-}
-
-void Window::OnWindowSwipeLeft() {
-  Emit("swipe-left");
+void Window::OnWindowSwipe(const std::string& direction) {
+  Emit("swipe", direction);
 }
 
 void Window::OnWindowEnterHtmlFullScreen() {

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -69,6 +69,10 @@ class Window : public mate::TrackableObject<Window>,
   void OnWindowMoved() override;
   void OnWindowScrollTouchBegin() override;
   void OnWindowScrollTouchEnd() override;
+  void OnWindowSwipeUp() override;
+  void OnWindowSwipeRight() override;
+  void OnWindowSwipeDown() override;
+  void OnWindowSwipeLeft() override;
   void OnWindowEnterFullScreen() override;
   void OnWindowLeaveFullScreen() override;
   void OnWindowEnterHtmlFullScreen() override;

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -69,10 +69,7 @@ class Window : public mate::TrackableObject<Window>,
   void OnWindowMoved() override;
   void OnWindowScrollTouchBegin() override;
   void OnWindowScrollTouchEnd() override;
-  void OnWindowSwipeUp() override;
-  void OnWindowSwipeRight() override;
-  void OnWindowSwipeDown() override;
-  void OnWindowSwipeLeft() override;
+  void OnWindowSwipe(const std::string& direction) override;
   void OnWindowEnterFullScreen() override;
   void OnWindowLeaveFullScreen() override;
   void OnWindowEnterHtmlFullScreen() override;

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -480,24 +480,9 @@ void NativeWindow::NotifyWindowScrollTouchEnd() {
                     OnWindowScrollTouchEnd());
 }
 
-void NativeWindow::NotifyWindowSwipeUp() {
+void NativeWindow::NotifyWindowSwipe(const std::string& direction) {
   FOR_EACH_OBSERVER(NativeWindowObserver, observers_,
-                    OnWindowSwipeUp());
-}
-
-void NativeWindow::NotifyWindowSwipeRight() {
-  FOR_EACH_OBSERVER(NativeWindowObserver, observers_,
-                    OnWindowSwipeRight());
-}
-
-void NativeWindow::NotifyWindowSwipeDown() {
-  FOR_EACH_OBSERVER(NativeWindowObserver, observers_,
-                    OnWindowSwipeDown());
-}
-
-void NativeWindow::NotifyWindowSwipeLeft() {
-  FOR_EACH_OBSERVER(NativeWindowObserver, observers_,
-                    OnWindowSwipeLeft());
+                    OnWindowSwipe(direction));
 }
 
 void NativeWindow::NotifyWindowLeaveFullScreen() {

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -480,6 +480,26 @@ void NativeWindow::NotifyWindowScrollTouchEnd() {
                     OnWindowScrollTouchEnd());
 }
 
+void NativeWindow::NotifyWindowSwipeUp() {
+  FOR_EACH_OBSERVER(NativeWindowObserver, observers_,
+                    OnWindowSwipeUp());
+}
+
+void NativeWindow::NotifyWindowSwipeRight() {
+  FOR_EACH_OBSERVER(NativeWindowObserver, observers_,
+                    OnWindowSwipeRight());
+}
+
+void NativeWindow::NotifyWindowSwipeDown() {
+  FOR_EACH_OBSERVER(NativeWindowObserver, observers_,
+                    OnWindowSwipeDown());
+}
+
+void NativeWindow::NotifyWindowSwipeLeft() {
+  FOR_EACH_OBSERVER(NativeWindowObserver, observers_,
+                    OnWindowSwipeLeft());
+}
+
 void NativeWindow::NotifyWindowLeaveFullScreen() {
   FOR_EACH_OBSERVER(NativeWindowObserver, observers_,
                     OnWindowLeaveFullScreen());

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -221,10 +221,7 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowMoved();
   void NotifyWindowScrollTouchBegin();
   void NotifyWindowScrollTouchEnd();
-  void NotifyWindowSwipeUp();
-  void NotifyWindowSwipeRight();
-  void NotifyWindowSwipeDown();
-  void NotifyWindowSwipeLeft();
+  void NotifyWindowSwipe(const std::string& direction);
   void NotifyWindowEnterFullScreen();
   void NotifyWindowLeaveFullScreen();
   void NotifyWindowEnterHtmlFullScreen();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -221,6 +221,10 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowMoved();
   void NotifyWindowScrollTouchBegin();
   void NotifyWindowScrollTouchEnd();
+  void NotifyWindowSwipeUp();
+  void NotifyWindowSwipeRight();
+  void NotifyWindowSwipeDown();
+  void NotifyWindowSwipeLeft();
   void NotifyWindowEnterFullScreen();
   void NotifyWindowLeaveFullScreen();
   void NotifyWindowEnterHtmlFullScreen();

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -267,6 +267,18 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 // NSWindow overrides.
 
+- (void)swipeWithEvent:(NSEvent *)event {
+    if (event.deltaY == 1.0) {
+        shell_->NotifyWindowSwipeUp();
+    } else if (event.deltaX == -1.0) {
+        shell_->NotifyWindowSwipeRight();
+    } else if (event.deltaY == -1.0) {
+        shell_->NotifyWindowSwipeDown();
+    } else if (event.deltaX == 1.0) {
+        shell_->NotifyWindowSwipeLeft();
+    }
+}
+
 - (NSRect)constrainFrameRect:(NSRect)frameRect toScreen:(NSScreen*)screen {
   // Resizing is disabled.
   if (ScopedDisableResize::IsResizeDisabled())

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -268,15 +268,15 @@ bool ScopedDisableResize::disable_resize_ = false;
 // NSWindow overrides.
 
 - (void)swipeWithEvent:(NSEvent *)event {
-    if (event.deltaY == 1.0) {
-        shell_->NotifyWindowSwipeUp();
-    } else if (event.deltaX == -1.0) {
-        shell_->NotifyWindowSwipeRight();
-    } else if (event.deltaY == -1.0) {
-        shell_->NotifyWindowSwipeDown();
-    } else if (event.deltaX == 1.0) {
-        shell_->NotifyWindowSwipeLeft();
-    }
+  if (event.deltaY == 1.0) {
+    shell_->NotifyWindowSwipe("up");
+  } else if (event.deltaX == -1.0) {
+    shell_->NotifyWindowSwipe("right");
+  } else if (event.deltaY == -1.0) {
+    shell_->NotifyWindowSwipe("down");
+  } else if (event.deltaX == 1.0) {
+    shell_->NotifyWindowSwipe("left");
+  }
 }
 
 - (NSRect)constrainFrameRect:(NSRect)frameRect toScreen:(NSScreen*)screen {

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -58,10 +58,7 @@ class NativeWindowObserver {
   virtual void OnWindowMoved() {}
   virtual void OnWindowScrollTouchBegin() {}
   virtual void OnWindowScrollTouchEnd() {}
-  virtual void OnWindowSwipeUp() {}
-  virtual void OnWindowSwipeRight() {}
-  virtual void OnWindowSwipeDown() {}
-  virtual void OnWindowSwipeLeft() {}
+  virtual void OnWindowSwipe(const std::string& direction) {}
   virtual void OnWindowEnterFullScreen() {}
   virtual void OnWindowLeaveFullScreen() {}
   virtual void OnWindowEnterHtmlFullScreen() {}

--- a/atom/browser/native_window_observer.h
+++ b/atom/browser/native_window_observer.h
@@ -58,6 +58,10 @@ class NativeWindowObserver {
   virtual void OnWindowMoved() {}
   virtual void OnWindowScrollTouchBegin() {}
   virtual void OnWindowScrollTouchEnd() {}
+  virtual void OnWindowSwipeUp() {}
+  virtual void OnWindowSwipeRight() {}
+  virtual void OnWindowSwipeDown() {}
+  virtual void OnWindowSwipeLeft() {}
   virtual void OnWindowEnterFullScreen() {}
   virtual void OnWindowLeaveFullScreen() {}
   virtual void OnWindowEnterHtmlFullScreen() {}

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -322,6 +322,22 @@ Emitted when scroll wheel event phase has begun.
 
 Emitted when scroll wheel event phase has ended.
 
+### Event: 'swipe-up' _OS X_
+
+Emitted on 3-finger swipe up.
+
+### Event: 'swipe-right' _OS X_
+
+Emitted on 3-finger swipe right.
+
+### Event: 'swipe-down' _OS X_
+
+Emitted on 3-finger swipe down.
+
+### Event: 'swipe-left' _OS X_
+
+Emitted on 3-finger swipe left.
+
 ## Methods
 
 The `BrowserWindow` object has the following methods:

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -322,21 +322,14 @@ Emitted when scroll wheel event phase has begun.
 
 Emitted when scroll wheel event phase has ended.
 
-### Event: 'swipe-up' _OS X_
+### Event: 'swipe' _OS X_
 
-Emitted on 3-finger swipe up.
+Returns:
 
-### Event: 'swipe-right' _OS X_
+* `event` Event
+* `direction` String
 
-Emitted on 3-finger swipe right.
-
-### Event: 'swipe-down' _OS X_
-
-Emitted on 3-finger swipe down.
-
-### Event: 'swipe-left' _OS X_
-
-Emitted on 3-finger swipe left.
+Emitted on 3-finger swipe. Possible directions are `up`, `right`, `down`, `left`.
 
 ## Methods
 


### PR DESCRIPTION
This adds a new `swipe` event to `browser-window` for 3-finger trackpad swipes on OS X.

#4181 added support for 2-finger scroll events on OS X, which allow apps to handle some forms of back/forward navigation. However, OS X also exposes a `swipeWithEvent` method on `NSResponder` for 3-finger swipes, and it's possible to set these as the "Swipe between pages" gesture. These swipes are only directional, with no velocity, so are easily exposed as one-off events. They will only fire if the option is set in System Preferences to **Swipe with two or three fingers** or **Swipe with three fingers**

![image](https://cloud.githubusercontent.com/assets/49224/13882592/013f5680-ed1e-11e5-968d-a03eeee779fc.png)