### PR TITLE
Fix alert()

### DIFF
--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -161,11 +161,14 @@ window.open = function(url, frameName, features) {
 // Use the dialog API to implement alert().
 window.alert = function(message, title) {
   var buttons;
+  if (message === undefined) {
+    message = '';
+  }
   if (title == null) {
     title = '';
   }
   buttons = ['OK'];
-  message = message.toString();
+  message = String(message);
   remote.dialog.showMessageBox(remote.getCurrentWindow(), {
     message: message,
     title: title,

--- a/lib/renderer/override.js
+++ b/lib/renderer/override.js
@@ -161,7 +161,7 @@ window.open = function(url, frameName, features) {
 // Use the dialog API to implement alert().
 window.alert = function(message, title) {
   var buttons;
-  if (message === undefined) {
+  if (arguments.length == 0) {
     message = '';
   }
   if (title == null) {


### PR DESCRIPTION
Stop `alert()` from throwing an error when passing no parameters or when passing null or undefined as the message. For example if you run `alert()` in a browser it will display a blank dialog box, but in Electron it will throw a error because there is no `.toString()` method on `undefined`. Changing `alert()` like this will also make it more consistent with the major browsers implementations.