### PR TITLE
Add repl option in default app

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -305,8 +305,9 @@ if (option.file && !option.webdriver) {
   helpMessage    += "  - .html/.htm file.\n";
   helpMessage    += "  - http://, https://, or file:// URL.\n";
   helpMessage    += "\nOptions:\n";
-  helpMessage    += "  -r, --require         Module to preload (option can be repeated)\n";
   helpMessage    += "  -h, --help            Print this usage message.\n";
+  helpMessage    += "  -i, --interactive     Open a REPL to the main process.\n";
+  helpMessage    += "  -r, --require         Module to preload (option can be repeated)\n";
   helpMessage    += "  -v, --version         Print the version.";
   console.log(helpMessage);
   process.exit(0);

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -9,12 +9,6 @@ const path = require('path');
 const repl = require('repl');
 const url = require('url');
 
-// Quit when all windows are closed and no other one is listening to this.
-app.on('window-all-closed', function() {
-  if (app.listeners('window-all-closed').length == 1)
-    app.quit();
-});
-
 // Parse command line options.
 var argv = process.argv.slice(1);
 var option = { file: null, help: null, version: null, webdriver: null, modules: [] };
@@ -42,6 +36,12 @@ for (var i = 0; i < argv.length; i++) {
     break;
   }
 }
+
+// Quit when all windows are closed and no other one is listening to this.
+app.on('window-all-closed', function() {
+  if (app.listeners('window-all-closed').length == 1 && !option.interactive)
+    app.quit();
+});
 
 // Create default menu.
 app.once('ready', function() {

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -6,6 +6,7 @@ const Menu     = electron.Menu;
 
 const fs = require('fs');
 const path = require('path');
+const repl = require('repl');
 const url = require('url');
 
 // Quit when all windows are closed and no other one is listening to this.
@@ -27,6 +28,8 @@ for (var i = 0; i < argv.length; i++) {
   } else if (argv[i] == '--help' || argv[i] == '-h') {
     option.help = true;
     break;
+  } else if (argv[i] == '--interactive' || argv[i] == '-i') {
+    option.interactive = true;
   } else if (argv[i] == '--test-type=webdriver') {
     option.webdriver = true;
   } else if (argv[i] == '--require' || argv[i] == '-r') {
@@ -307,6 +310,8 @@ if (option.file && !option.webdriver) {
   helpMessage    += "  -v, --version         Print the version.";
   console.log(helpMessage);
   process.exit(0);
+} else if (option.interactive) {
+  repl.start('> ');
 } else {
   loadApplicationByUrl('file://' + __dirname + '/index.html');
 }

--- a/default_app/main.js
+++ b/default_app/main.js
@@ -278,6 +278,12 @@ function loadApplicationByUrl(appUrl) {
   require('./default_app').load(appUrl);
 }
 
+function startRepl() {
+  repl.start('> ').on('exit', function() {
+    process.exit(0);
+  });
+}
+
 // Start the specified app if there is one specified in command line, otherwise
 // start the default app.
 if (option.file && !option.webdriver) {
@@ -312,7 +318,7 @@ if (option.file && !option.webdriver) {
   console.log(helpMessage);
   process.exit(0);
 } else if (option.interactive) {
-  repl.start('> ');
+  startRepl();
 } else {
   loadApplicationByUrl('file://' + __dirname + '/index.html');
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "python ./script/build.py -c D",
     "lint": "python ./script/eslint.py && python ./script/cpplint.py",
     "preinstall": "node -e 'process.exit(0)'",
+    "repl": "python ./script/start.py --interactive",
     "start": "python ./script/start.py",
     "test": "python ./script/test.py"
   }


### PR DESCRIPTION
This adds a `-i/--interactive` flag to the default app that starts a repl for the main process.

Can be used when developing locally via `npm run repl`.

```sh
> npm run repl

> electron@0.37.2 repl /Users/kevin/github/electron
> python ./script/start.py --interactive

> 1 + 1
2
> process.versions.electron
'0.37.2'
> process.versions.node
'5.1.1'
> const {BrowserWindow} = require('electron')
undefined
> BrowserWindow.getAllWindows()
[]
> .exit

```

/cc @zeke who was asking if this was possible in #4872 