### PR TITLE
Added electron-release-server link to the docs

### DIFF
--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -2,6 +2,8 @@
 
 This module provides an interface for the `Squirrel` auto-updater framework.
 
+You can quickly launch a multi-platform release server for distributing your application by forking [electron-release-server](https://github.com/ArekSredzki/electron-release-server).
+
 ## Platform notices
 
 Though `autoUpdater` provides a uniform API for different platforms, there are


### PR DESCRIPTION
By request from a couple users, I've added a link to the electron-release-server, that makes using the auto-updater much easier.