### PR TITLE
Improve error reporting when passing invalid argument types for dialog API methods

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -56,7 +56,7 @@ module.exports = {
       options.properties = ['openFile'];
     }
     if (!Array.isArray(options.properties)) {
-      throw new TypeError('Properties need to be array');
+      throw new TypeError('Properties must be an array');
     }
     properties = 0;
     for (prop in fileDialogProperties) {
@@ -68,12 +68,12 @@ module.exports = {
     if (options.title == null) {
       options.title = '';
     } else if (typeof options.title !== 'string') {
-      throw new TypeError('Title need to be string');
+      throw new TypeError('Title must be a string');
     }
     if (options.defaultPath == null) {
       options.defaultPath = '';
     } else if (typeof options.defaultPath !== 'string') {
-      throw new TypeError('Default path need to be string');
+      throw new TypeError('Default path must be a string');
     }
     if (options.filters == null) {
       options.filters = [];
@@ -96,12 +96,12 @@ module.exports = {
     if (options.title == null) {
       options.title = '';
     } else if (typeof options.title !== 'string') {
-      throw new TypeError('Title need to be string');
+      throw new TypeError('Title must be a string');
     }
     if (options.defaultPath == null) {
       options.defaultPath = '';
     } else if (typeof options.defaultPath !== 'string') {
-      throw new TypeError('Default path need to be string');
+      throw new TypeError('Default path must be a string');
     }
     if (options.filters == null) {
       options.filters = [];
@@ -129,22 +129,22 @@ module.exports = {
       throw new TypeError('Invalid message box type');
     }
     if (!Array.isArray(options.buttons)) {
-      throw new TypeError('Buttons need to be array');
+      throw new TypeError('Buttons must be an array');
     }
     if (options.title == null) {
       options.title = '';
     } else if (typeof options.title !== 'string') {
-      throw new TypeError('Title need to be string');
+      throw new TypeError('Title must be a string');
     }
     if (options.message == null) {
       options.message = '';
     } else if (typeof options.message !== 'string') {
-      throw new TypeError('Message need to be string');
+      throw new TypeError('Message must be a string');
     }
     if (options.detail == null) {
       options.detail = '';
     } else if (typeof options.detail !== 'string') {
-      throw new TypeError('Detail need to be string');
+      throw new TypeError('Detail must be a string');
     }
     if (options.icon == null) {
       options.icon = null;

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -67,9 +67,13 @@ module.exports = {
     }
     if (options.title == null) {
       options.title = '';
+    } else if (typeof options.title !== 'string') {
+      throw new TypeError('Title need to be string');
     }
     if (options.defaultPath == null) {
       options.defaultPath = '';
+    } else if (typeof options.defaultPath !== 'string') {
+      throw new TypeError('Default path need to be string');
     }
     if (options.filters == null) {
       options.filters = [];
@@ -91,9 +95,13 @@ module.exports = {
     }
     if (options.title == null) {
       options.title = '';
+    } else if (typeof options.title !== 'string') {
+      throw new TypeError('Title need to be string');
     }
     if (options.defaultPath == null) {
       options.defaultPath = '';
+    } else if (typeof options.defaultPath !== 'string') {
+      throw new TypeError('Default path need to be string');
     }
     if (options.filters == null) {
       options.filters = [];
@@ -125,12 +133,18 @@ module.exports = {
     }
     if (options.title == null) {
       options.title = '';
+    } else if (typeof options.title !== 'string') {
+      throw new TypeError('Title need to be string');
     }
     if (options.message == null) {
       options.message = '';
+    } else if (typeof options.message !== 'string') {
+      throw new TypeError('Message need to be string');
     }
     if (options.detail == null) {
       options.detail = '';
+    } else if (typeof options.detail !== 'string') {
+      throw new TypeError('Detail need to be string');
     }
     if (options.icon == null) {
       options.icon = null;


### PR DESCRIPTION
Currently next code:
```javascript
dialog.showMessageBox({
	type: 'warning',
	buttons: [ 'Cancel' ],
	message: 'Foo',
	detail: {}
});
```

Will produce this error, which does not make much sense:
```
Uncaught Error: Could not call remote function ``. Check that the function signature is correct. Underlying error: Error processing argument at index 7, conversion failure from ...
```

This PR adds type checks and better error reporting.
