### PR TITLE
common: use v8::private symbols as identifiers for object properties

### DIFF
--- a/atom/common/api/atom_api_v8_util.cc
+++ b/atom/common/api/atom_api_v8_util.cc
@@ -11,20 +11,40 @@
 
 namespace {
 
-v8::Local<v8::Value> GetHiddenValue(v8::Local<v8::Object> object,
+v8::Local<v8::Value> GetHiddenValue(v8::Isolate* isolate,
+                                    v8::Local<v8::Object> object,
                                     v8::Local<v8::String> key) {
-  return object->GetHiddenValue(key);
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  v8::Local<v8::Private> privateKey = v8::Private::ForApi(isolate, key);
+  v8::Local<v8::Value> value;
+  v8::Maybe<bool> result = object->HasPrivate(context, privateKey);
+  if (!(result.IsJust() && result.FromJust()))
+    return v8::Local<v8::Value>();
+  if (object->GetPrivate(context, privateKey).ToLocal(&value))
+    return value;
+  return v8::Local<v8::Value>();
 }
 
-void SetHiddenValue(v8::Local<v8::Object> object,
+void SetHiddenValue(v8::Isolate* isolate,
+                    v8::Local<v8::Object> object,
                     v8::Local<v8::String> key,
                     v8::Local<v8::Value> value) {
-  object->SetHiddenValue(key, value);
+  if (value.IsEmpty())
+    return;
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  v8::Local<v8::Private> privateKey = v8::Private::ForApi(isolate, key);
+  object->SetPrivate(context, privateKey, value);
 }
 
-void DeleteHiddenValue(v8::Local<v8::Object> object,
+void DeleteHiddenValue(v8::Isolate* isolate,
+                       v8::Local<v8::Object> object,
                        v8::Local<v8::String> key) {
-  object->DeleteHiddenValue(key);
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  v8::Local<v8::Private> privateKey = v8::Private::ForApi(isolate, key);
+  // Actually deleting the value would make force the object into
+  // dictionary mode which is unnecessarily slow. Instead, we replace
+  // the hidden value with "undefined".
+  object->SetPrivate(context, privateKey, v8::Undefined(isolate));
 }
 
 int32_t GetObjectHash(v8::Local<v8::Object> object) {

--- a/atom/renderer/atom_render_view_observer.cc
+++ b/atom/renderer/atom_render_view_observer.cc
@@ -39,7 +39,11 @@ bool GetIPCObject(v8::Isolate* isolate,
                   v8::Local<v8::Context> context,
                   v8::Local<v8::Object>* ipc) {
   v8::Local<v8::String> key = mate::StringToV8(isolate, "ipc");
-  v8::Local<v8::Value> value = context->Global()->GetHiddenValue(key);
+  v8::Local<v8::Private> privateKey = v8::Private::ForApi(isolate, key);
+  v8::Local<v8::Object> global_object = context->Global();
+  v8::Local<v8::Value> value;
+  if (!global_object->GetPrivate(context, privateKey).ToLocal(&value))
+    return false;
   if (value.IsEmpty() || !value->IsObject())
     return false;
   *ipc = value->ToObject();


### PR DESCRIPTION
Fixes #4802 
Fixes #4870 


Depends on https://github.com/zcbenz/native-mate/pull/4

For more context https://github.com/atom/electron/issues/4802#issuecomment-199588369