### PR TITLE
Disable node on child window when disabled on parent

### DIFF
--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -84,6 +84,9 @@ than the minimum values or greater than the maximum.
 If "on", the guest page in `webview` will have node integration and can use node
 APIs like `require` and `process` to access low level system resources.
 
+**Note:** Node integration will always be disabled in the `webview` if it is
+disabled on the parent window.
+
 ### `plugins`
 
 ```html

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -23,6 +23,9 @@ Creates a new window and returns an instance of `BrowserWindowProxy` class.
 The `features` string follows the format of standard browser, but each feature
 has to be a field of `BrowserWindow`'s options.
 
+**Note:** Node integration will always be disabled in the opened `window` if it
+is disabled on the parent window.
+
 ### `window.opener.postMessage(message, targetOrigin)`
 
 * `message` String

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -30,7 +30,7 @@ var mergeBrowserWindowOptions = function (embedder, options) {
     mergeOptions(options, embedder.browserWindowOptions)
 
     // Disable node integration on child window if disabled on parent window
-    if (!embedder.getWebPreferences().nodeIntegration) {
+    if (embedder.getWebPreferences().nodeIntegration === false) {
       options.webPreferences.nodeIntegration = false
     }
   } else {

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -30,7 +30,7 @@ var mergeBrowserWindowOptions = function (embedder, options) {
     mergeOptions(options, embedder.browserWindowOptions)
 
     // Disable node integration on child window if disabled on parent window
-    if (!embedder.browserWindowOptions.webPreferences.nodeIntegration) {
+    if (!embedder.getWebPreferences().nodeIntegration) {
       options.webPreferences.nodeIntegration = false
     }
   } else {

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -28,11 +28,6 @@ var mergeBrowserWindowOptions = function (embedder, options) {
   if (embedder.browserWindowOptions != null) {
     // Inherit the original options if it is a BrowserWindow.
     mergeOptions(options, embedder.browserWindowOptions)
-
-    // Disable node integration on child window if disabled on parent window
-    if (embedder.getWebPreferences().nodeIntegration === false) {
-      options.webPreferences.nodeIntegration = false
-    }
   } else {
     // Or only inherit web-preferences if it is a webview.
     if (options.webPreferences == null) {
@@ -40,6 +35,12 @@ var mergeBrowserWindowOptions = function (embedder, options) {
     }
     mergeOptions(options.webPreferences, embedder.getWebPreferences())
   }
+
+  // Disable node integration on child window if disabled on parent window
+  if (embedder.getWebPreferences().nodeIntegration === false) {
+    options.webPreferences.nodeIntegration = false
+  }
+
   return options
 }
 

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -28,6 +28,11 @@ var mergeBrowserWindowOptions = function (embedder, options) {
   if (embedder.browserWindowOptions != null) {
     // Inherit the original options if it is a BrowserWindow.
     mergeOptions(options, embedder.browserWindowOptions)
+
+    // Disable node integration on child window if disabled on parent window
+    if (!embedder.browserWindowOptions.webPreferences.nodeIntegration) {
+      options.webPreferences.nodeIntegration = false
+    }
   } else {
     // Or only inherit web-preferences if it is a webview.
     if (options.webPreferences == null) {

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -199,7 +199,7 @@ describe('chromium feature', function () {
         },
         slashes: true
       })
-      b = window.open(windowUrl, 'nodeIntegration=no,show=no')
+      b = window.open(windowUrl, '', 'nodeIntegration=no,show=no')
     })
 
     it('does not override child options', function (done) {

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -192,10 +192,10 @@ describe('chromium feature', function () {
       window.addEventListener('message', listener)
 
       var windowUrl = require('url').format({
-        pathname: fixtures + "/pages/window-opener-no-node-integration.html",
+        pathname: `${fixtures}/pages/window-opener-no-node-integration.html`,
         protocol: 'file',
         query: {
-          p: fixtures + "/pages/window-opener-node.html"
+          p: `${fixtures}/pages/window-opener-node.html`
         },
         slashes: true
       })

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -199,7 +199,6 @@ describe('chromium feature', function () {
         },
         slashes: true
       })
-      console.log(windowUrl)
       b = window.open(windowUrl, 'nodeIntegration=no,show=no')
     })
 

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -160,7 +160,7 @@ describe('chromium feature', function () {
     it('accepts "nodeIntegration" as feature', function (done) {
       var b
       listener = function (event) {
-        assert.equal(event.data, 'undefined')
+        assert.equal(event.data.isProcessGlobalUndefined, true)
         b.close()
         done()
       }
@@ -185,7 +185,7 @@ describe('chromium feature', function () {
     it('disables node integration when it is disabled on the parent window', function (done) {
       var b
       listener = function (event) {
-        assert.equal(event.data, 'undefined')
+        assert.equal(event.data.isProcessGlobalUndefined, true)
         b.close()
         done()
       }

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -182,6 +182,27 @@ describe('chromium feature', function () {
       b = window.open('file://' + fixtures + '/pages/window-open-size.html', '', 'show=no')
     })
 
+    it('disables node integration when it is disabled on the parent window', function (done) {
+      var b
+      listener = function (event) {
+        assert.equal(event.data, 'undefined')
+        b.close()
+        done()
+      }
+      window.addEventListener('message', listener)
+
+      var windowUrl = require('url').format({
+        pathname: fixtures + "/pages/window-opener-no-node-integration.html",
+        protocol: 'file',
+        query: {
+          p: fixtures + "/pages/window-opener-node.html"
+        },
+        slashes: true
+      })
+      console.log(windowUrl)
+      b = window.open(windowUrl, 'nodeIntegration=no,show=no')
+    })
+
     it('does not override child options', function (done) {
       var b, size
       size = {

--- a/spec/fixtures/pages/webview-opener-no-node-integration.html
+++ b/spec/fixtures/pages/webview-opener-no-node-integration.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  var windowUrl = decodeURIComponent(window.location.search.substring(3))
+  window.open('file://' + windowUrl, '', 'nodeIntegration=yes,show=no')
+  console.log('window opened')
+</script>
+</body>
+</html>

--- a/spec/fixtures/pages/webview-opener-no-node-integration.html
+++ b/spec/fixtures/pages/webview-opener-no-node-integration.html
@@ -3,7 +3,6 @@
 <script type="text/javascript" charset="utf-8">
   var windowUrl = decodeURIComponent(window.location.search.substring(3))
   window.open('file://' + windowUrl, '', 'nodeIntegration=yes,show=no')
-  console.log('window opened')
 </script>
 </body>
 </html>

--- a/spec/fixtures/pages/window-opener-no-node-integration.html
+++ b/spec/fixtures/pages/window-opener-no-node-integration.html
@@ -1,0 +1,15 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  var windowUrl = decodeURIComponent(window.location.search.substring(3))
+  var opened = window.open('file://' + windowUrl, '', 'nodeIntegration=yes,show=no')
+  window.addEventListener('message', function (event) {
+    try {
+      opened.close();
+    } finally {
+      window.opener.postMessage(event.data, '*');
+    }
+  });
+</script>
+</body>
+</html>

--- a/spec/fixtures/pages/window-opener-no-node-integration.html
+++ b/spec/fixtures/pages/window-opener-no-node-integration.html
@@ -5,11 +5,11 @@
   var opened = window.open('file://' + windowUrl, '', 'nodeIntegration=yes,show=no')
   window.addEventListener('message', function (event) {
     try {
-      opened.close();
+      opened.close()
     } finally {
-      window.opener.postMessage(event.data, '*');
+      window.opener.postMessage(event.data, '*')
     }
-  });
+  })
 </script>
 </body>
 </html>

--- a/spec/fixtures/pages/window-opener-node.html
+++ b/spec/fixtures/pages/window-opener-node.html
@@ -1,7 +1,7 @@
 <html>
 <body>
 <script type="text/javascript" charset="utf-8">
-  window.opener.postMessage(typeof process, '*')
+  window.opener.postMessage({isProcessGlobalUndefined: typeof process === 'undefined'}, '*')
 </script>
 </body>
 </html>

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -2,9 +2,7 @@ const assert = require('assert')
 const path = require('path')
 const http = require('http')
 const url = require('url')
-
-const {remote} = require('electron')
-const {app} = remote
+const {app, session} = require('electron')
 
 describe('<webview> tag', function () {
   this.timeout(10000)
@@ -704,7 +702,6 @@ describe('<webview> tag', function () {
 
   describe('permission-request event', function () {
     function setUpRequestHandler (webview, requested_permission) {
-      const session = require('electron').remote.session
       var listener = function (webContents, permission, callback) {
         if (webContents.getId() === webview.getId()) {
           assert.equal(permission, requested_permission)

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -3,6 +3,9 @@ const path = require('path')
 const http = require('http')
 const url = require('url')
 
+const {remote} = require('electron')
+const {BrowserWindow} = remote
+
 describe('<webview> tag', function () {
   this.timeout(10000)
 
@@ -71,6 +74,32 @@ describe('<webview> tag', function () {
       })
       webview.setAttribute('nodeintegration', 'on')
       webview.src = 'file://' + fixtures + '/pages/post.html'
+      document.body.appendChild(webview)
+    })
+
+
+    it('disables node integration on child windows when it is disabled on the webview', function (done) {
+      webview.addEventListener('console-message', function (e) {
+        assert.equal(e.message, 'window opened')
+        const sourceId = remote.getCurrentWindow().id
+        const windows = BrowserWindow.getAllWindows().filter(function (window) {
+          return window.id !== sourceId
+        })
+        assert.equal(windows.length, 1)
+        assert.equal(windows[0].webContents.getWebPreferences().nodeIntegration, false)
+        done()
+      })
+
+      webview.setAttribute('allowpopups', 'on')
+
+      webview.src = require('url').format({
+        pathname: `${fixtures}/pages/webview-opener-no-node-integration.html`,
+        protocol: 'file',
+        query: {
+          p: `${fixtures}/pages/window-opener-node.html`
+        },
+        slashes: true
+      })
       document.body.appendChild(webview)
     })
 

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -84,7 +84,7 @@ describe('<webview> tag', function () {
 
       webview.setAttribute('allowpopups', 'on')
 
-      webview.src = require('url').format({
+      webview.src = url.format({
         pathname: `${fixtures}/pages/webview-opener-no-node-integration.html`,
         protocol: 'file',
         query: {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -2,7 +2,7 @@ const assert = require('assert')
 const path = require('path')
 const http = require('http')
 const url = require('url')
-const {app, session} = require('electron')
+const {app, session} = require('electron').remote
 
 describe('<webview> tag', function () {
   this.timeout(10000)

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -4,7 +4,7 @@ const http = require('http')
 const url = require('url')
 
 const {remote} = require('electron')
-const {BrowserWindow} = remote
+const {app} = remote
 
 describe('<webview> tag', function () {
   this.timeout(10000)
@@ -79,14 +79,8 @@ describe('<webview> tag', function () {
 
 
     it('disables node integration on child windows when it is disabled on the webview', function (done) {
-      webview.addEventListener('console-message', function (e) {
-        assert.equal(e.message, 'window opened')
-        const sourceId = remote.getCurrentWindow().id
-        const windows = BrowserWindow.getAllWindows().filter(function (window) {
-          return window.id !== sourceId
-        })
-        assert.equal(windows.length, 1)
-        assert.equal(windows[0].webContents.getWebPreferences().nodeIntegration, false)
+      app.once('browser-window-created', function (event, window) {
+        assert.equal(window.webContents.getWebPreferences().nodeIntegration, false)
         done()
       })
 


### PR DESCRIPTION
If `nodeIntegration` is disabled on the parent window then disable it on all child windows opened via `window.open` or in `<webview>` tags.

This prevents windows without node integration from opening new windows with node integration enabled.

This seems to be an intuitive behavior for this option, if you disable node on a window/webview then all downstream windows will also have node integration disabled preventing content run in those windows from "breaking out" and getting access to node integration via calls to `window.open`.

Fixes #3943
Fixes #4026 

/cc @zeke :pear: