### PR TITLE
Update source tree docs for new layout

### DIFF
--- a/docs/development/source-code-directory-structure.md
+++ b/docs/development/source-code-directory-structure.md
@@ -11,35 +11,36 @@ to understand the source code better.
 
 ```
 Electron
-├──atom - Source code of Electron.
-|  ├── app - System entry code.
-|  ├── browser - The frontend including the main window, UI, and all of the
-|  |   main process things. This talks to the renderer to manage web pages.
-|  |   ├── lib - Javascript part of the main process initialization code.
-|  |   ├── ui - Implementation of UI stuff for different platforms.
-|  |   |   ├── cocoa - Cocoa specific source code.
-|  |   |   ├── gtk - GTK+ specific source code.
-|  |   |   └── win - Windows GUI specific source code.
-|  |   ├── default_app - The default page to show when Electron is started
-|  |   |   without providing an app.
-|  |   ├── api - The implementation of the main process APIs.
-|  |   |   └── lib - Javascript part of the API implementation.
-|  |   ├── net - Network related code.
-|  |   ├── mac - Mac specific Objective-C source code.
-|  |   └── resources - Icons, platform-dependent files, etc.
-|  ├── renderer - Code that runs in renderer process.
-|  |   ├── lib - Javascript part of renderer initialization code.
-|  |   └── api - The implementation of renderer process APIs.
-|  |       └── lib - Javascript part of the API implementation.
-|  └── common - Code that used by both the main and renderer processes,
-|      including some utility functions and code to integrate node's message
-|      loop into Chromium's message loop.
-|      ├── lib - Common Javascript initialization code.
-|      └── api - The implementation of common APIs, and foundations of
-|          Electron's built-in modules.
-|          └── lib - Javascript part of the API implementation.
+├── atom - C++ source code.
+|   ├── app - System entry code.
+|   ├── browser - The frontend including the main window, UI, and all of the
+|   |   main process things. This talks to the renderer to manage web pages.
+|   |   ├── ui - Implementation of UI stuff for different platforms.
+|   |   |   ├── cocoa - Cocoa specific source code.
+|   |   |   ├── gtk - GTK+ specific source code.
+|   |   |   └── win - Windows GUI specific source code.
+|   |   ├── api - The implementation of the main process APIs.
+|   |   ├── net - Network related code.
+|   |   ├── mac - Mac specific Objective-C source code.
+|   |   └── resources - Icons, platform-dependent files, etc.
+|   ├── renderer - Code that runs in renderer process.
+|   |   └── api - The implementation of renderer process APIs.
+|   └── common - Code that used by both the main and renderer processes,
+|       including some utility functions and code to integrate node's message
+|       loop into Chromium's message loop.
+|       └── api - The implementation of common APIs, and foundations of
+|           Electron's built-in modules.
 ├── chromium_src - Source code that copied from Chromium.
+├── default_app - The default page to show when Electron is started without
+|   providing an app.
 ├── docs - Documentations.
+├── lib  - JavaScript source code.
+|   ├── browser - Javascript main process initialization code.
+|   |   └── api - Javascript API implementation.
+|   ├── common - JavaScript used by both the main and renderer processes
+|   |   └── api - Javascript API implementation.
+|   └── renderer - Javascript renderer process initialization code.
+|       └── api - Javascript API implementation.
 ├── spec - Automatic tests.
 ├── atom.gyp - Building rules of Electron.
 └── common.gypi - Compiler specific settings and building rules for other


### PR DESCRIPTION
Update the `source-code-directory-structure.md` doc based on the changes in #4722

Main adjustments:

- All JavaScript moved to root `lib/` folder
- `default_app/` folder moved to root