### PR TITLE
Put link on same line as name

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -387,5 +387,4 @@ Menu:
 ```
 
 [AboutInformationPropertyListFiles]: https://developer.apple.com/library/ios/documentation/general/Reference/InfoPlistKeyReference/Articles/AboutInformationPropertyListFiles.html
-[setMenu]:
-https://github.com/atom/electron/blob/master/docs/api/browser-window.md#winsetmenumenu-linux-windows
+[setMenu]: https://github.com/atom/electron/blob/master/docs/api/browser-window.md#winsetmenumenu-linux-windows


### PR DESCRIPTION
Noticed a link wasn't rendering right on the docs page because of the newline after the `:`

http://electron.atom.io/docs/v0.37.2/api/menu/

<img width="452" alt="screen shot 2016-03-24 at 3 18 19 pm" src="https://cloud.githubusercontent.com/assets/671378/14033077/a56689d0-f1d4-11e5-8f62-131197882914.png">
