### PR TITLE
Remove path for nodeIntegration value of 'disable'

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -97,11 +97,6 @@ void WebContentsPreferences::AppendExtraCommandLineSwitches(
   // Check if we have node integration specified.
   bool node_integration = true;
   web_preferences.GetBoolean(options::kNodeIntegration, &node_integration);
-  // Be compatible with old API of "node-integration" option.
-  std::string old_token;
-  if (web_preferences.GetString(options::kNodeIntegration, &old_token) &&
-      old_token != "disable")
-    node_integration = true;
   command_line->AppendSwitchASCII(switches::kNodeIntegration,
                                   node_integration ? "true" : "false");
 

--- a/lib/renderer/init.js
+++ b/lib/renderer/init.js
@@ -84,7 +84,7 @@ if (location.protocol === 'chrome-devtools:') {
   }
 }
 
-if (nodeIntegration === 'true' || nodeIntegration === 'all' || nodeIntegration === 'except-iframe' || nodeIntegration === 'manual-enable-iframe') {
+if (nodeIntegration === 'true') {
   // Export node bindings to global.
   global.require = require;
   global.module = module;


### PR DESCRIPTION
This looked to be a no-op since `node_integration` already defaulted to `true` and this check was setting it to `true` based on the value not equaling `"disable"`.

/cc @zcbenz 