### PR TITLE
Store default_app in .asar archive

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -29,6 +29,7 @@
       'type': 'executable',
       'dependencies': [
         'js2asar',
+        'app2asar',
         '<(project_name)_lib',
       ],
       'sources': [
@@ -64,12 +65,6 @@
               'files': [
                 '<(PRODUCT_DIR)/<(product_name) Helper.app',
                 '<(PRODUCT_DIR)/<(product_name) Framework.framework',
-              ],
-            },
-            {
-              'destination': '<(PRODUCT_DIR)/<(product_name).app/Contents/Resources',
-              'files': [
-                'default_app',
               ],
             },
           ],
@@ -167,12 +162,6 @@
                 'external_binaries/vccorlib120.dll',
               ],
             },
-            {
-              'destination': '<(PRODUCT_DIR)/resources',
-              'files': [
-                'default_app',
-              ]
-            },
           ],
         }, {
           'dependencies': [
@@ -207,12 +196,6 @@
                 '<(libchromiumcontent_dir)/natives_blob.bin',
                 '<(libchromiumcontent_dir)/snapshot_blob.bin',
               ],
-            },
-            {
-              'destination': '<(PRODUCT_DIR)/resources',
-              'files': [
-                'default_app',
-              ]
             },
           ],
         }],  # OS=="linux"
@@ -376,11 +359,43 @@
             'python',
             'tools/js2asar.py',
             '<@(_outputs)',
+            'lib',
             '<@(_inputs)',
           ],
         }
       ],
     },  # target js2asar
+    {
+      'target_name': 'app2asar',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'app2asar',
+          'variables': {
+            'conditions': [
+              ['OS=="mac"', {
+                'resources_path': '<(PRODUCT_DIR)/<(product_name).app/Contents/Resources',
+              },{
+                'resources_path': '<(PRODUCT_DIR)/resources',
+              }],
+            ],
+          },
+          'inputs': [
+            '<@(default_app_sources)',
+          ],
+          'outputs': [
+            '<(resources_path)/default_app.asar',
+          ],
+          'action': [
+            'python',
+            'tools/js2asar.py',
+            '<@(_outputs)',
+            'default_app',
+            '<@(_inputs)',
+          ],
+        }
+      ],
+    },  # target app2asar
     {
       'target_name': 'atom_js2c',
       'type': 'none',

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -67,6 +67,12 @@
       'lib/common/asar.js',
       'lib/common/asar_init.js',
     ],
+    'default_app_sources': [
+      'default_app/default_app.js',
+      'default_app/index.html',
+      'default_app/main.js',
+      'default_app/package.json',
+    ],
     'lib_sources': [
       'atom/app/atom_content_client.cc',
       'atom/app/atom_content_client.h',

--- a/lib/browser/init.js
+++ b/lib/browser/init.js
@@ -117,7 +117,7 @@ require('./guest-window-manager')
 
 // Now we try to load app's package.json.
 var packageJson = null
-var searchPaths = ['app', 'app.asar', 'default_app']
+var searchPaths = ['app', 'app.asar', 'default_app.asar']
 var i, len, packagePath
 for (i = 0, len = searchPaths.length; i < len; i++) {
   packagePath = searchPaths[i]

--- a/tools/js2asar.py
+++ b/tools/js2asar.py
@@ -29,7 +29,6 @@ def copy_files(source_files, output_dir):
 
 
 def call_asar(archive, output_dir):
-  print(output_dir)
   asar = os.path.join(SOURCE_ROOT, 'node_modules', 'asar', 'bin', 'asar')
   subprocess.check_call([find_node(), asar, 'pack', output_dir, archive])
 

--- a/tools/js2asar.py
+++ b/tools/js2asar.py
@@ -12,26 +12,26 @@ SOURCE_ROOT = os.path.dirname(os.path.dirname(__file__))
 
 def main():
   archive = sys.argv[1]
-  js_source_files = sys.argv[2:]
+  folder_name = sys.argv[2]
+  source_files = sys.argv[3:]
 
   output_dir = tempfile.mkdtemp()
-  copy_js(js_source_files, output_dir)
-  call_asar(archive, output_dir)
+  copy_files(source_files, output_dir)
+  call_asar(archive, os.path.join(output_dir, folder_name))
   shutil.rmtree(output_dir)
 
 
-def copy_js(js_source_files, output_dir):
-  for source_file in js_source_files:
-    output_filename = os.path.splitext(source_file)[0] + '.js'
-    output_path = os.path.join(output_dir, output_filename)
+def copy_files(source_files, output_dir):
+  for source_file in source_files:
+    output_path = os.path.join(output_dir, source_file)
     safe_mkdir(os.path.dirname(output_path))
     shutil.copy2(source_file, output_path)
 
 
 def call_asar(archive, output_dir):
-  js_dir = os.path.join(output_dir, 'lib')
+  print(output_dir)
   asar = os.path.join(SOURCE_ROOT, 'node_modules', 'asar', 'bin', 'asar')
-  subprocess.check_call([find_node(), asar, 'pack', js_dir, archive])
+  subprocess.check_call([find_node(), asar, 'pack', output_dir, archive])
 
 
 def find_node():


### PR DESCRIPTION
This pull request stores the `default_app` in a `.asar` archive when built instead of in a folder.

Couple (minor) advantages to this:

- Smaller size
- Fewer files in `Electron.app`
- Changes to `default_app` are now picked up when running a local build
- Easier to remove (just one file vs. a folder)

/cc @zcbenz @zeke @jlord thoughts?