### PR TITLE
Add dialog callback fallback

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -20,18 +20,25 @@ var messageBoxOptions = {
   noLink: 1 << 0
 }
 
-var parseArgs = function (window, options, callback) {
+var parseArgs = function (window, options, callback, ...args) {
   if (!(window === null || (window != null ? window.constructor : void 0) === BrowserWindow)) {
     // Shift.
     callback = options
     options = window
     window = null
   }
+
   if ((callback == null) && typeof options === 'function') {
     // Shift.
     callback = options
     options = null
   }
+
+  // Fallback to using very last argument as the callback function
+  if ((callback == null) && typeof args[args.length - 1] === 'function') {
+    callback = args[args.length - 1]
+  }
+
   return [window, options, callback]
 }
 


### PR DESCRIPTION
Currently the app will hang if a dialog API is called with a `null` or `undefined` callback parameter since the callback added by the `rpc-server.js` for asynchronous APIs will then be at the 4th argument position and `parseArgs` in `dialog.js` will be looking for it at the third position.

This pull request adds a fallback that uses the last argument as the callback so that the `rpc-server` callback wrapper argument will always be used when specified.

Closes #4936