### PR TITLE
Remote object should be referenced by its members

### DIFF
--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -91,8 +91,9 @@ var wrapArgs = function (args, visited) {
 }
 
 // Populate object's members from descriptors.
+// The |ref| will be kept referenced by |members|.
 // This matches |getObjectMemebers| in rpc-server.
-let setObjectMembers = function (object, metaId, members) {
+let setObjectMembers = function (ref, object, metaId, members) {
   for (let member of members) {
     if (object.hasOwnProperty(member.name)) continue
 
@@ -110,7 +111,7 @@ let setObjectMembers = function (object, metaId, members) {
         }
       }
       descriptor.get = function () {
-        remoteMemberFunction.ref = object  // The member should reference its object.
+        remoteMemberFunction.ref = ref  // The member should reference its object.
         return remoteMemberFunction
       }
       // Enable monkey-patch the method
@@ -139,11 +140,11 @@ let setObjectMembers = function (object, metaId, members) {
 
 // Populate object's prototype from descriptor.
 // This matches |getObjectPrototype| in rpc-server.
-let setObjectPrototype = function (object, metaId, descriptor) {
+let setObjectPrototype = function (ref, object, metaId, descriptor) {
   if (descriptor === null) return
   let proto = {}
-  setObjectMembers(proto, metaId, descriptor.members)
-  setObjectPrototype(proto, metaId, descriptor.proto)
+  setObjectMembers(ref, proto, metaId, descriptor.members)
+  setObjectPrototype(ref, proto, metaId, descriptor.proto)
   Object.setPrototypeOf(object, proto)
 }
 
@@ -198,9 +199,9 @@ let metaToValue = function (meta) {
       }
 
       // Populate delegate members.
-      setObjectMembers(ret, meta.id, meta.members)
+      setObjectMembers(ret, ret, meta.id, meta.members)
       // Populate delegate prototype.
-      setObjectPrototype(ret, meta.id, meta.proto)
+      setObjectPrototype(ret, ret, meta.id, meta.proto)
 
       // Set constructor.name to object's name.
       Object.defineProperty(ret.constructor, 'name', { value: meta.name })

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -109,9 +109,16 @@ let setObjectMembers = function (object, metaId, members) {
           return metaToValue(ret)
         }
       }
-      descriptor.writable = true
+      descriptor.get = function () {
+        remoteMemberFunction.ref = object  // The member should reference its object.
+        return remoteMemberFunction
+      }
+      // Enable monkey-patch the method
+      descriptor.set = function (value) {
+        remoteMemberFunction = value
+        return value
+      }
       descriptor.configurable = true
-      descriptor.value = remoteMemberFunction
     } else if (member.type === 'get') {
       descriptor.get = function () {
         return metaToValue(ipcRenderer.sendSync('ATOM_BROWSER_MEMBER_GET', metaId, member.name))

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -149,6 +149,13 @@ describe('ipc module', function () {
       assert(!proto.hasOwnProperty('method'))
       assert(Object.getPrototypeOf(proto).hasOwnProperty('method'))
     })
+
+    it('is referenced by methods in prototype chain', function () {
+      let method = derived.method
+      derived = null
+      gc()
+      assert.equal(method(), 'method')
+    });
   })
 
   describe('ipc.sender.send', function () {

--- a/spec/api-ipc-spec.js
+++ b/spec/api-ipc-spec.js
@@ -73,6 +73,12 @@ describe('ipc module', function () {
 
       assert.equal(delete remoteFunctions.aFunction, true)
     })
+
+    it('is referenced by its members', function () {
+      let stringify = remote.getGlobal('JSON').stringify
+      gc();
+      stringify({})
+    });
   })
 
   describe('remote value in browser', function () {


### PR DESCRIPTION
This fixes another case that would cause the exception in #4733. In JS when you store a method of an object, the object will not be referenced, so in the following case calling `stringify` would throw exception because the `remote.getGlobal('JSON')` gets garbage collected.

```js
let stringify = remote.getGlobal('JSON').stringify
stringify({})
```

In normal JS this is not a problem because the methods are objects themselves and rely on `this` pointer when being called. However in Electron the problem is the member methods of remote objects are not real functions, they just only records the object and the method's name, and send them to the main process when being called.

This PR works around it by referencing the remote object in its remote member methods, so as long as the methods are stored by user the remote object would never be garbage collected.

A real solution should be treating member methods as real functions, and get the remote object from the `this` pointer. But let's try it in another PR.

Close #4733.