### PR TITLE
use example accelerators that align with best practices

### DIFF
--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -5,8 +5,8 @@ multiple modifiers and key codes, combined by the `+` character.
 
 Examples:
 
-* `Command+A`
-* `Ctrl+Shift+Z`
+* `CommandOrControl+A`
+* `CommandOrControl+Shift+Z`
 
 ## Platform notice
 

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -14,9 +14,9 @@ const app = electron.app;
 const globalShortcut = electron.globalShortcut;
 
 app.on('ready', function() {
-  // Register a 'ctrl+x' shortcut listener.
-  var ret = globalShortcut.register('ctrl+x', function() {
-    console.log('ctrl+x is pressed');
+  // Register a 'CommandOrControl+X' shortcut listener.
+  var ret = globalShortcut.register('CommandOrControl+X', function() {
+    console.log('CommandOrControl+X is pressed');
   });
 
   if (!ret) {
@@ -24,12 +24,12 @@ app.on('ready', function() {
   }
 
   // Check whether a shortcut is registered.
-  console.log(globalShortcut.isRegistered('ctrl+x'));
+  console.log(globalShortcut.isRegistered('CommandOrControl+X'));
 });
 
 app.on('will-quit', function() {
   // Unregister a shortcut.
-  globalShortcut.unregister('ctrl+x');
+  globalShortcut.unregister('CommandOrControl+X');
 
   // Unregister all shortcuts.
   globalShortcut.unregisterAll();


### PR DESCRIPTION
The existing examples are platform specific. This updates them to set a better precedent for readers.