### PR TITLE
Upgrade Node to v5.10.0

### DIFF
--- a/atom/common/api/atom_bindings.cc
+++ b/atom/common/api/atom_bindings.cc
@@ -98,8 +98,17 @@ void AtomBindings::OnCallNextTick(uv_async_t* handle) {
            self->pending_next_ticks_.begin();
        it != self->pending_next_ticks_.end(); ++it) {
     node::Environment* env = *it;
+    // KickNextTick, copied from node.cc:
     node::Environment::AsyncCallbackScope callback_scope(env);
-    env->KickNextTick(&callback_scope);
+    if (callback_scope.in_makecallback())
+      continue;
+    node::Environment::TickInfo* tick_info = env->tick_info();
+    if (tick_info->length() == 0)
+      env->isolate()->RunMicrotasks();
+    v8::Local<v8::Object> process = env->process_object();
+    if (tick_info->length() == 0)
+      tick_info->set_index(0);
+    env->tick_callback_function()->Call(process, 0, nullptr).IsEmpty();
   }
 
   self->pending_next_ticks_.clear();

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -175,6 +175,9 @@ node::Environment* NodeBindings::CreateEnvironment(
   mate::Dictionary process(context->GetIsolate(), env->process_object());
   process.Set("type", process_type);
   process.Set("resourcesPath", resources_path);
+  // Do not set DOM globals for renderer process.
+  if (!is_browser_)
+    process.Set("_noBrowserGlobals", resources_path);
   // The path to helper app.
   base::FilePath helper_exec_path;
   PathService::Get(content::CHILD_PROCESS_EXE, &helper_exec_path);


### PR DESCRIPTION
To use the new `node_no_browser_globals` flag introduce by https://github.com/nodejs/node/pull/5853.